### PR TITLE
WIP: Expose builtin for trace.

### DIFF
--- a/src/compiler/codegen/builtins.cc
+++ b/src/compiler/codegen/builtins.cc
@@ -36,6 +36,8 @@ namespace verona::compiler
       builtin_create_sleeping_cown();
     else if (name == "fulfill_sleeping_cown")
       builtin_fulfill_sleeping_cown();
+    else if (name == "trace")
+      builtin_trace_region();
     else
       throw std::logic_error("Invalid builtin");
   }
@@ -77,6 +79,16 @@ namespace verona::compiler
 
     gen_.opcode(Opcode::NewSleepingCown);
     gen_.reg(Register(0));
+    gen_.opcode(Opcode::Return);
+  }
+
+  void BuiltinGenerator::builtin_trace_region()
+  {
+    assert(abi_.arguments == 2);
+    assert(abi_.returns == 1);
+
+    gen_.opcode(Opcode::TraceRegion);
+    gen_.reg(Register(1));
     gen_.opcode(Opcode::Return);
   }
 

--- a/src/compiler/codegen/builtins.h
+++ b/src/compiler/codegen/builtins.h
@@ -21,6 +21,7 @@ namespace verona::compiler
   private:
     void builtin_print();
     void builtin_create_sleeping_cown();
+    void builtin_trace_region();
     void builtin_fulfill_sleeping_cown();
     void builtin_binop(bytecode::BinaryOperator op);
   };

--- a/src/interpreter/bytecode.h
+++ b/src/interpreter/bytecode.h
@@ -161,6 +161,7 @@ namespace verona::bytecode
     Print, // format(u8), argc(u8), args(u8)...
     Return,
     Store, // dst(u8), base(u8), selector(u32), src(u8)
+    TraceRegion, // region(u8)
     Unreachable,
     When, // codepointer(u32), cown count(u8), capture count(u8)
 
@@ -348,6 +349,13 @@ namespace verona::bytecode
   {
     using Operands = OpcodeOperands<Register, std::string_view>;
     constexpr static std::string_view format = "STRING {}, \"{}\"";
+  };
+
+  template<>
+  struct OpcodeSpec<Opcode::TraceRegion>
+  {
+    using Operands = OpcodeOperands<Register>;
+    constexpr static std::string_view format = "TRACE REGION {}";
   };
 
   template<>

--- a/src/interpreter/vm.cc
+++ b/src/interpreter/vm.cc
@@ -415,6 +415,15 @@ namespace verona::interpreter
     write(dst, std::move(a));
   }
 
+  void VM::opcode_trace_region(const Value& object)
+  {
+    check_type(object, {Value::Tag::ISO, Value::Tag::MUT});
+
+    VMObject* region = object->object->region();
+
+    rt::RegionTrace::gc(alloc_, region);
+  }
+
   void VM::opcode_print(const Value& src, uint8_t argc)
   {
     check_type(src, Value::Tag::STRING);
@@ -624,6 +633,7 @@ namespace verona::interpreter
       OP(Return, opcode_return);
       OP(Store, opcode_store);
       OP(String, opcode_string);
+      OP(TraceRegion, opcode_trace_region);
       OP(When, opcode_when);
       OP(Unreachable, opcode_unreachable);
 

--- a/src/interpreter/vm.h
+++ b/src/interpreter/vm.h
@@ -83,6 +83,7 @@ namespace verona::interpreter
     void opcode_store(
       Register dst, const Value& base, SelectorIdx selector, Value src);
     void opcode_string(Register dst, std::string_view imm);
+    void opcode_trace_region(const Value& region);
     void
     opcode_when(CodePtr selector, uint8_t cown_count, uint8_t capture_count);
     void opcode_unreachable();

--- a/src/stdlib/builtin.verona
+++ b/src/stdlib/builtin.verona
@@ -22,6 +22,11 @@ class Builtin {
   // Temporary API to implement promises
   create_sleeping_cown[T](): cown[T] { Builtin.create_sleeping_cown() }
   fulfill_sleeping_cown[T](x: cown[T], v: T) { Builtin.fulfill_sleeping_cown(x, v) }
+
+  // This exposes trace on a trable region
+  // TODO: invalidate other references into this region
+  // TODO: needs expanding as we add other region allocation strategies
+  trace(x : mut) { }
 }
 
 class None {

--- a/testsuite/demo/run-pass/library/queue.verona
+++ b/testsuite/demo/run-pass/library/queue.verona
@@ -5,20 +5,31 @@ class Node[Value]
 {
     value: (iso & Value) | (None & imm);
     next: (Node[Value] & mut) | (None & imm);
+
+    final(self: mut)
+    {
+      Builtin.print("Finalise node\n");
+    }
 }
 
 class Queue[Value]
 {
+  id: U64;
   hd: Node[Value] & mut;
   tl: Node[Value] & mut;
   none: None & imm;  // Fix when we have singletons
+  length: U64;
+  freed: U64;
 
-  create(): Queue[Value] & iso
+  create(i: U64): Queue[Value] & iso
   {
     var q = new Queue;
     var n = new Node in q;
     q.hd = n;
     q.tl = n;
+    q.id = i;
+    q.length = 0;
+    q.freed = 0;
     q.none = freeze (new None);
     n.next = q.none;
     n.value = q.none;
@@ -35,11 +46,28 @@ class Queue[Value]
     old_tl.value = v;
     old_tl.next = n_tail;
     self.tl = n_tail;
+
+    self.length = self.length + 1;
   }
 
   remove(self: mut): (iso & Value) | (None & imm)
   {
     var h = self.hd;
+
+    // Data structure level GC heuristic:
+    var boundary = self.length + self.length + 4;
+    var value = self.freed > boundary;
+    
+    if (value)
+    {
+      Builtin.print1("Should reclaim some memory! Queue {}\n", self.id);
+      
+      // This needs to ensure other references are removed in the type system.
+      Builtin.trace(self);
+      
+      self.freed = 0;
+    };
+
     match (h.value = self.none)
     {
       var a: None => a,
@@ -51,6 +79,8 @@ class Queue[Value]
           var n: Node[Value] =>
           {
             self.hd = n;
+            self.length = self.length - 1;
+            self.freed = self.freed + 1;
             v
           }
         }

--- a/testsuite/demo/run-pass/queue_harness.verona
+++ b/testsuite/demo/run-pass/queue_harness.verona
@@ -10,33 +10,62 @@ class Main
 {
   refine(a: Queue[U64Obj]) {}
 
-  main()
+  run(q: Queue[U64Obj] & mut)
   {
-    var q = mut-view (Queue.create());
-
-    // Type inference is choosing Queue[U64Obj & iso], which we can't codegen yet.
-    Main.refine(q);
-
     q.add(U64Obj.create(1));
     q.add(U64Obj.create(2));
 
     var a1 = q.remove();
-    Main.print(a1);
-    // CHECK-L: Queue elem: 1
+    Main.print(q.id, a1);
     var a2 = q.remove();
-    Main.print(a2);
-    // CHECK-L: Queue elem: 2
+    Main.print(q.id, a2);
     var a3 = q.remove();
-    Main.print(a3);
-    // CHECK-L: Queue empty
+    Main.print(q.id, a3);
   }
 
-  print(a: (U64Obj & iso) | (None & imm))
+  main()
+  {
+    var q = mut-view (Queue.create(1));
+    var q2 = mut-view (Queue.create(2));
+
+    // Type inference is choosing Queue[U64Obj & iso], which we can't codegen yet.
+    Main.refine(q);
+
+    Main.run(q);
+    // CHECK-L: Queue 1 elem: 1
+    // CHECK-L: Queue 1 elem: 2
+
+    Main.run(q2);
+    Main.run(q);
+    Main.run(q2);
+    Main.run(q2);
+    Main.run(q);
+    Main.run(q2);
+    Main.run(q2);
+    Main.run(q);
+    Main.run(q);
+    Main.run(q2);
+    Main.run(q);
+    Main.run(q2);
+    Main.run(q2);
+    Main.run(q);
+    Main.run(q);
+    Main.run(q2);
+    Main.run(q);
+    Main.run(q);
+    Main.run(q2);
+    Main.run(q);
+    Main.run(q);
+
+    Builtin.print("Finished\n");
+  }
+
+  print(id: U64, a: (U64Obj & iso) | (None & imm))
   {
     match (a)
     {
-      var vv: U64Obj => Builtin.print1("Queue elem: {}\n", (mut-view vv).v),
-      var n: None   => Builtin.print("Queue empty\n"),
+      var vv: U64Obj => Builtin.print2("Queue {} elem: {}\n", id, (mut-view vv).v),
+      var n: None   => Builtin.print1("Queue {} empty\n", id),
     }
   }
 }

--- a/testsuite/demo/run-pass/scheduler.verona
+++ b/testsuite/demo/run-pass/scheduler.verona
@@ -45,7 +45,7 @@ class Scheduler
   create(): cown[Scheduler]
   {
     var s = new Scheduler;
-    var q = Queue.create();
+    var q = Queue.create(0);
     Scheduler.refine(mut-view(q));
     s.queues = q;
     cown(s)
@@ -64,7 +64,7 @@ class Scheduler
           {
             var n: None => 
             {
-              var jq = Queue.create();
+              var jq = Queue.create(0);
               (mut-view jq).add(j);
               s.queues = jq;
             }
@@ -91,7 +91,7 @@ class Scheduler
           {
             var n: None => 
             {
-              var wq = Queue.create();
+              var wq = Queue.create(0);
               (mut-view wq).add(w);
               s.queues = wq;
             }


### PR DESCRIPTION
This exposes the trace region functionality.

It is does not correctly impose constraints on callers that they cannot keep references into this region.  Thus it can lead to dangling pointers.

Type system work required to fix this API.

The example illustrates how we might use trace on a per-data-structure level.