### PR TITLE
Remove parser requirement for an else branch

### DIFF
--- a/src/compiler/ast.h
+++ b/src/compiler/ast.h
@@ -419,11 +419,16 @@ namespace verona::compiler
     ASTPtr<Expression> body;
   };
 
+  struct ElseExpr : public Expression
+  {
+    ASTPtr<Expression> body;
+  };
+
   struct IfExpr : public Expression
   {
     ASTPtr<Expression> condition;
     ASTPtr<Expression> then_block;
-    ASTPtr<Expression> else_block;
+    ASTPtr<ElseExpr, /* optional */ true> else_block;
   };
 
   struct BlockExpr : public Expression

--- a/src/compiler/ir/builder.cc
+++ b/src/compiler/ir/builder.cc
@@ -683,8 +683,18 @@ namespace verona::compiler
     // Result of each branch is owned by the Phi node.
     BuilderResult then_value =
       push_scope(*expr.then_block, phi_input_kind(kind), then_bb);
-    BuilderResult else_value =
-      push_scope(*expr.else_block, phi_input_kind(kind), else_bb);
+
+    BuilderResult<IRInput> else_value = BuilderResult<IRInput>::Invalid();
+
+    if (expr.else_block)
+    {
+      else_value =
+        push_scope(*expr.else_block->body, phi_input_kind(kind), else_bb);
+    }
+    else
+    {
+      else_value = unit(expr.source_range, phi_input_kind(kind), else_bb);
+    }
 
     BasicBlock* exit_bb = function_ir_->add_block(bb);
     set_terminator(then_bb, BranchTerminator{exit_bb});

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -84,7 +84,8 @@ namespace verona::compiler
     Rule keyword = term(
       "while"_E | "if" | "class" | "interface" | "var" | "unit" | "match" |
       "U64" | "String" | "iso" | "mut" | "imm" | "mut-view" | "freeze" | "in" |
-      "cown" | "static_assert" | "not" | "subtype" | "when" | "from" | "where");
+      "cown" | "static_assert" | "not" | "subtype" | "when" | "from" | "where" |
+      "else");
 
     Rule self = term("self");
     Rule self_def = self;
@@ -113,7 +114,7 @@ namespace verona::compiler
     Rule local_def = def_ident;
 
     Rule symbol_expr = ref_ident;
-    Rule define_local = "var" >> local_def >> -("=" >> expr2);
+    Rule define_local = trace("var", "var" >> local_def >> -("=" >> expr2));
     Rule assign_local = ref_ident >> "=" >> expr2;
 
     Rule field_expr = expr4 >> "." >> ref_ident;
@@ -125,7 +126,8 @@ namespace verona::compiler
 
     Rule empty_expr = trace("Empty", ""_E);
     Rule while_loop = trace("While", "while" >> expr3 >> block);
-    Rule if_expr = trace("If", "if" >> expr3 >> block >> "else" >> block);
+    Rule else_expr = "else" >> block;
+    Rule if_expr = trace("If", "if" >> expr3 >> block >> -else_expr);
     Rule block_expr = block;
 
     Rule match_arm = "var" >> local_def >> ":" >> type >> "=>" >>
@@ -211,13 +213,14 @@ namespace verona::compiler
     Rule method = def_ident >> fn_signature >> (fn_body | ";");
 
     Rule field = def_ident >> ":" >> type >> ";";
-    Rule member = method | field;
+    Rule member = trace("member", method | field);
 
     Rule class_kind = "class"_E;
     Rule interface_kind = "interface"_E;
     Rule entity_kind = class_kind | interface_kind;
 
-    Rule entity = entity_kind >> def_ident >> generics >> braces(*member);
+    Rule entity =
+      trace("entity", entity_kind >> def_ident >> generics >> braces(*member));
 
     Rule assertion_kind_subtype = "subtype"_E;
     Rule assertion_kind_not_subtype = "not"_E >> "subtype"_E;
@@ -273,6 +276,7 @@ namespace verona::compiler
     BindAST<WhileExpr> while_loop = g.while_loop;
     BindAST<WhenExpr> when_clause = g.when_clause;
     BindAST<IfExpr> if_expr = g.if_expr;
+    BindAST<ElseExpr> else_expr = g.else_expr;
     BindAST<BlockExpr> block_expr = g.block_expr;
     BindAST<EmptyExpr> empty_expr = g.empty_expr;
 

--- a/src/compiler/printing.cc
+++ b/src/compiler/printing.cc
@@ -104,7 +104,14 @@ namespace verona::compiler
 
     void visit_if(IfExpr& e) final
     {
-      print("(if {} {} {})", *e.condition, *e.then_block, *e.else_block);
+      if (e.else_block)
+      {
+        print("(if {} {} {}", *e.condition, *e.then_block, *e.else_block->body);
+      }
+      else
+      {
+        print("(if {} {})", *e.condition, *e.then_block);
+      }
     }
 
     void visit_block(BlockExpr& e) final

--- a/src/compiler/recursive_visitor.h
+++ b/src/compiler/recursive_visitor.h
@@ -59,7 +59,10 @@ namespace verona::compiler
     {
       this->visit_expr(*expr.condition, args...);
       this->visit_expr(*expr.then_block, args...);
-      this->visit_expr(*expr.else_block, args...);
+      if (expr.else_block)
+      {
+        this->visit_expr(*expr.else_block->body, args...);
+      }
     }
     void visit_block(BlockExpr& expr, Args... args) override
     {

--- a/src/compiler/resolution.cc
+++ b/src/compiler/resolution.cc
@@ -417,7 +417,8 @@ namespace verona::compiler
     {
       visit_expr(*expr.condition);
       push_scope([&]() { visit_expr(*expr.then_block); });
-      push_scope([&]() { visit_expr(*expr.else_block); });
+      if (expr.else_block)
+        push_scope([&]() { visit_expr(*expr.else_block->body); });
     }
 
     void visit_while(WhileExpr& expr) final


### PR DESCRIPTION
The parser already assumes both the then and else parts of an if are surrounded in braces, this PR allows the if to be one-sided.  Makes a few examples nicer to write.