### PR TITLE
Remove snmalloc up to date check.

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -116,12 +116,6 @@ phases:
       grep -L "Copyright (c) Microsoft Corporation"  `git ls-files -- '*.cpp' '*.cc' '*.h' '*.hh' '*.verona'| xargs`
     displayName: 'Check Copyright'
 
-  - script: |
-      cd src/rt/external/snmalloc
-      git diff origin/master --quiet
-
-    displayName: 'Check snmalloc up-to-date'
-
 - phase: Lang_Linux
   queue:
     name: 'Hosted Ubuntu 1604'


### PR DESCRIPTION
Internally, we kept snmalloc and verona highly synchronised.  With both project moving into the open this is going to be harder to achieve, and an alternative mechanism should be found for keeping up to date, than simply failing CI.