### PR TITLE
Add GH action that checks if snmalloc is up to date.

### DIFF
--- a/.github/workflows/update-snmalloc.yaml
+++ b/.github/workflows/update-snmalloc.yaml
@@ -9,8 +9,8 @@
 name: Check for snmalloc updates
 
 # The environment variables below should be the only configuration that ever
-# needs changing. In particular if the submodule is moved then SUBMODULE_PATH
-# needs to be updated.
+# needs changing. In particular if the submodule is moved then SUBMODULE_KEY
+# may need to be updated.
 env:
   # This is the key used for this submodule in .gitmodules
   # Most of the time it will match the path


### PR DESCRIPTION
GitHub workflow which checks for updates in the snmalloc submodule. If it is out-of-date and no issue exists yet, it creates one.
This triggers periodically (every 6 hours), when pushing to master, or when creating a PR.

The latter case never creates an issue, and only serves as a way to check that we are still able to retrieve the submodule revision (eg. in case the PR moved the submodule). PRs are *not* blocked by an outdated snmalloc.

Fixes #7 
