### PR TITLE
Change Pony language link to official website

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -30,7 +30,7 @@ Project Verona is a research language that is inspired by ideas from other langu
 
 * [Rust](https://www.rust-lang.org)
 * [Cyclone](http://cyclone.thelanguage.org/)
-* [Pony](https://github.com/ponylang/)
+* [Pony](https://www.ponylang.io/)
 
 Many of the ideas we built on have been popularised by Rust, such as borrowing
 and linearity, and Pony, such as reference capabilities.


### PR DESCRIPTION
Pony language has an official website. To make documentation more consistent (looking at Rust and Cyclone examples) I propose to use the official website link instead of the GitHub account link in the current version of FAQ.