### PR TITLE
Add primitive types

### DIFF
--- a/src/compiler/analysis.cc
+++ b/src/compiler/analysis.cc
@@ -105,9 +105,7 @@ namespace verona::compiler
 
       FnAnalysis& analysis = results_->functions[method];
 
-      const Entity* builtin = program_.find_entity("Builtin");
-      analysis.ir =
-        IRBuilder::build(*method->signature, *method->body, builtin);
+      analysis.ir = IRBuilder::build(*method->signature, *method->body);
       IRPrinter(*context_.dump(path, "ir")).print("IR", *method, *analysis.ir);
 
       analysis.liveness = compute_liveness(*analysis.ir);

--- a/src/compiler/analysis.cc
+++ b/src/compiler/analysis.cc
@@ -17,12 +17,8 @@ namespace verona::compiler
   {
   public:
     AnalysisVisitor(
-      Context& context,
-      const Entity* builtin_definition,
-      AnalysisResults* results)
-    : context_(context),
-      builtin_definition_(builtin_definition),
-      results_(results)
+      Context& context, const Program& program, AnalysisResults* results)
+    : context_(context), program_(program), results_(results)
     {}
 
     void visit_program(Program* program)
@@ -109,8 +105,9 @@ namespace verona::compiler
 
       FnAnalysis& analysis = results_->functions[method];
 
-      analysis.ir = IRBuilder::build(
-        *method->signature, *method->body, builtin_definition_);
+      const Entity* builtin = program_.find_entity("Builtin");
+      analysis.ir =
+        IRBuilder::build(*method->signature, *method->body, builtin);
       IRPrinter(*context_.dump(path, "ir")).print("IR", *method, *analysis.ir);
 
       analysis.liveness = compute_liveness(*analysis.ir);
@@ -119,7 +116,7 @@ namespace verona::compiler
         .print("Liveness Analysis", *method, *analysis.ir);
 
       analysis.inference =
-        infer(context_, *method, *analysis.ir, *analysis.liveness);
+        infer(context_, program_, *method, *analysis.ir, *analysis.liveness);
 
       analysis.typecheck = typecheck(context_, method, *analysis.inference);
       if (!analysis.typecheck)
@@ -151,7 +148,7 @@ namespace verona::compiler
     }
 
     Context& context_;
-    const Entity* builtin_definition_;
+    const Program& program_;
     AnalysisResults* results_;
   };
 
@@ -212,8 +209,7 @@ namespace verona::compiler
     auto results = std::make_unique<AnalysisResults>();
     results->ok = true;
 
-    AnalysisVisitor visitor(
-      context, program->find_entity("Builtin"), results.get());
+    AnalysisVisitor visitor(context, *program, results.get());
     visitor.visit_program(program);
 
     return results;

--- a/src/compiler/ast.cc
+++ b/src/compiler/ast.cc
@@ -101,25 +101,25 @@ namespace verona::compiler
     switch (op)
     {
       case BinaryOperator::Add:
-        return "u64_add";
+        return "add";
       case BinaryOperator::Sub:
-        return "u64_sub";
+        return "sub";
       case BinaryOperator::Lt:
-        return "u64_lt";
+        return "lt";
       case BinaryOperator::Le:
-        return "u64_le";
+        return "le";
       case BinaryOperator::Gt:
-        return "u64_gt";
+        return "gt";
       case BinaryOperator::Ge:
-        return "u64_ge";
+        return "ge";
       case BinaryOperator::Eq:
-        return "u64_eq";
+        return "eq";
       case BinaryOperator::Ne:
-        return "u64_ne";
+        return "ne";
       case BinaryOperator::And:
-        return "u64_and";
+        return "and";
       case BinaryOperator::Or:
-        return "u64_or";
+        return "or";
 
         EXHAUSTIVE_SWITCH
     }

--- a/src/compiler/ast.cc
+++ b/src/compiler/ast.cc
@@ -68,7 +68,7 @@ namespace verona::compiler
     if (parent == nullptr)
       throw std::logic_error("path called before resolution");
 
-    return parent->path() + "." + name;
+    return parent->path() + "." + get_name();
   }
 
   std::string

--- a/src/compiler/ast.h
+++ b/src/compiler/ast.h
@@ -445,11 +445,6 @@ namespace verona::compiler
     const Entity* definition = nullptr;
   };
 
-  struct NewCownExpr : public Expression
-  {
-    ASTPtr<Expression> contents;
-  };
-
   struct Argument : public ASTContainer
   {
     ASTPtr<Expression> inner;
@@ -597,11 +592,6 @@ namespace verona::compiler
 
     // Added during resolution
     Symbol symbol = ErrorSymbol();
-  };
-
-  struct CownTypeExpr final : public TypeExpression
-  {
-    ASTPtr<TypeExpression> contents;
   };
 
   struct UnionTypeExpr final : public TypeExpression

--- a/src/compiler/ast.h
+++ b/src/compiler/ast.h
@@ -288,9 +288,11 @@ namespace verona::compiler
     {
       Class,
       Interface,
+      Primitive,
     };
     static constexpr Kind Class = Kind::Class;
     static constexpr Kind Interface = Kind::Interface;
+    static constexpr Kind Primitive = Kind::Primitive;
 
     ASTPtr<ASTConstant<Kind>> kind;
     ASTChild<Name> name;

--- a/src/compiler/ast.h
+++ b/src/compiler/ast.h
@@ -329,6 +329,7 @@ namespace verona::compiler
     {
       return name;
     }
+
     Kind kind() const
     {
       if (kind_)

--- a/src/compiler/ast.h
+++ b/src/compiler/ast.h
@@ -555,11 +555,6 @@ namespace verona::compiler
     ASTPtr<Expression> expr;
   };
 
-  struct FreezeExpr : public Expression
-  {
-    ASTPtr<Expression> expr;
-  };
-
   enum class BinaryOperator
   {
     Add,

--- a/src/compiler/ast.h
+++ b/src/compiler/ast.h
@@ -592,9 +592,6 @@ namespace verona::compiler
   struct TypeExpression : public SourceLocatableMixin<ASTContainer>
   {};
 
-  struct IntegerTypeExpr final : public TypeExpression
-  {};
-
   struct StringTypeExpr final : public TypeExpression
   {};
 

--- a/src/compiler/codegen/builtins.cc
+++ b/src/compiler/codegen/builtins.cc
@@ -33,25 +33,28 @@ namespace verona::compiler
         return builtin_fulfill_sleeping_cown();
       else if (method == "trace")
         return builtin_trace_region();
-      else if (method == "u64_add")
+    }
+    else if (entity == "U64")
+    {
+      if (method == "add")
         return builtin_binop(bytecode::BinaryOperator::Add);
-      else if (method == "u64_sub")
+      else if (method == "sub")
         return builtin_binop(bytecode::BinaryOperator::Sub);
-      else if (method == "u64_lt")
+      else if (method == "lt")
         return builtin_binop(bytecode::BinaryOperator::Lt);
-      else if (method == "u64_gt")
+      else if (method == "gt")
         return builtin_binop(bytecode::BinaryOperator::Gt);
-      else if (method == "u64_le")
+      else if (method == "le")
         return builtin_binop(bytecode::BinaryOperator::Le);
-      else if (method == "u64_ge")
+      else if (method == "ge")
         return builtin_binop(bytecode::BinaryOperator::Ge);
-      else if (method == "u64_eq")
+      else if (method == "eq")
         return builtin_binop(bytecode::BinaryOperator::Eq);
-      else if (method == "u64_ne")
+      else if (method == "ne")
         return builtin_binop(bytecode::BinaryOperator::Ne);
-      else if (method == "u64_and")
+      else if (method == "and")
         return builtin_binop(bytecode::BinaryOperator::And);
-      else if (method == "u64_or")
+      else if (method == "or")
         return builtin_binop(bytecode::BinaryOperator::Or);
     }
     throw std::logic_error("Invalid builtin");
@@ -126,18 +129,16 @@ namespace verona::compiler
 
   void BuiltinGenerator::builtin_binop(bytecode::BinaryOperator op)
   {
-    assert(abi_.arguments == 3);
+    assert(abi_.arguments == 2);
     assert(abi_.returns == 1);
 
     gen_.opcode(Opcode::BinOp);
     gen_.reg(Register(0));
     gen_.u8(static_cast<uint8_t>(op));
-    gen_.reg(Register(1));
-    gen_.reg(Register(2));
-    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(0));
     gen_.reg(Register(1));
     gen_.opcode(Opcode::Clear);
-    gen_.reg(Register(2));
+    gen_.reg(Register(1));
     gen_.opcode(Opcode::Return);
   }
 }

--- a/src/compiler/codegen/builtins.cc
+++ b/src/compiler/codegen/builtins.cc
@@ -8,38 +8,53 @@ namespace verona::compiler
 {
   using bytecode::Opcode;
 
-  void BuiltinGenerator::generate_builtin(std::string_view name)
+  /* static */
+  void BuiltinGenerator::generate(
+    Context& context, Generator& gen, const CodegenItem<Method>& method)
   {
-    if (name.rfind("print", 0) == 0)
-      builtin_print();
-    else if (name == "u64_add")
-      builtin_binop(bytecode::BinaryOperator::Add);
-    else if (name == "u64_sub")
-      builtin_binop(bytecode::BinaryOperator::Sub);
-    else if (name == "u64_lt")
-      builtin_binop(bytecode::BinaryOperator::Lt);
-    else if (name == "u64_gt")
-      builtin_binop(bytecode::BinaryOperator::Gt);
-    else if (name == "u64_le")
-      builtin_binop(bytecode::BinaryOperator::Le);
-    else if (name == "u64_ge")
-      builtin_binop(bytecode::BinaryOperator::Ge);
-    else if (name == "u64_eq")
-      builtin_binop(bytecode::BinaryOperator::Eq);
-    else if (name == "u64_ne")
-      builtin_binop(bytecode::BinaryOperator::Ne);
-    else if (name == "u64_and")
-      builtin_binop(bytecode::BinaryOperator::And);
-    else if (name == "u64_or")
-      builtin_binop(bytecode::BinaryOperator::Or);
-    else if (name == "create_sleeping_cown")
-      builtin_create_sleeping_cown();
-    else if (name == "fulfill_sleeping_cown")
-      builtin_fulfill_sleeping_cown();
-    else if (name == "trace")
-      builtin_trace_region();
-    else
-      throw std::logic_error("Invalid builtin");
+    FunctionABI abi(*method.definition->signature);
+    BuiltinGenerator v(context, gen, abi);
+    v.generate_header(method.instantiated_path());
+    v.generate_builtin(
+      method.definition->parent->name, method.definition->name);
+    v.finish();
+  }
+
+  void BuiltinGenerator::generate_builtin(
+    std::string_view entity, std::string_view method)
+  {
+    if (entity == "Builtin")
+    {
+      if (method.rfind("print", 0) == 0)
+        return builtin_print();
+      else if (method == "create_sleeping_cown")
+        return builtin_create_sleeping_cown();
+      else if (method == "fulfill_sleeping_cown")
+        return builtin_fulfill_sleeping_cown();
+      else if (method == "trace")
+        return builtin_trace_region();
+      else if (method == "u64_add")
+        return builtin_binop(bytecode::BinaryOperator::Add);
+      else if (method == "u64_sub")
+        return builtin_binop(bytecode::BinaryOperator::Sub);
+      else if (method == "u64_lt")
+        return builtin_binop(bytecode::BinaryOperator::Lt);
+      else if (method == "u64_gt")
+        return builtin_binop(bytecode::BinaryOperator::Gt);
+      else if (method == "u64_le")
+        return builtin_binop(bytecode::BinaryOperator::Le);
+      else if (method == "u64_ge")
+        return builtin_binop(bytecode::BinaryOperator::Ge);
+      else if (method == "u64_eq")
+        return builtin_binop(bytecode::BinaryOperator::Eq);
+      else if (method == "u64_ne")
+        return builtin_binop(bytecode::BinaryOperator::Ne);
+      else if (method == "u64_and")
+        return builtin_binop(bytecode::BinaryOperator::And);
+      else if (method == "u64_or")
+        return builtin_binop(bytecode::BinaryOperator::Or);
+    }
+    throw std::logic_error("Invalid builtin");
   }
 
   void BuiltinGenerator::builtin_print()

--- a/src/compiler/codegen/builtins.cc
+++ b/src/compiler/codegen/builtins.cc
@@ -27,10 +27,6 @@ namespace verona::compiler
     {
       if (method.rfind("print", 0) == 0)
         return builtin_print();
-      else if (method == "create_sleeping_cown")
-        return builtin_create_sleeping_cown();
-      else if (method == "fulfill_sleeping_cown")
-        return builtin_fulfill_sleeping_cown();
       else if (method == "freeze")
         return builtin_freeze();
       else if (method == "trace")
@@ -58,6 +54,15 @@ namespace verona::compiler
         return builtin_binop(bytecode::BinaryOperator::And);
       else if (method == "or")
         return builtin_binop(bytecode::BinaryOperator::Or);
+    }
+    else if (entity == "cown")
+    {
+      if (method == "create")
+        return builtin_cown_create();
+      else if (method == "_create_sleeping")
+        return builtin_cown_create_sleeping();
+      else if (method == "_fulfill_sleeping")
+        return builtin_cown_fulfill_sleeping();
     }
     fmt::print(stderr, "Invalid builtin {}.{}\n", entity, method);
     abort();
@@ -93,13 +98,16 @@ namespace verona::compiler
     gen_.opcode(Opcode::Return);
   }
 
-  void BuiltinGenerator::builtin_create_sleeping_cown()
+  void BuiltinGenerator::builtin_freeze()
   {
-    assert(abi_.arguments == 1);
+    assert(abi_.arguments == 2);
     assert(abi_.returns == 1);
 
-    gen_.opcode(Opcode::NewSleepingCown);
+    gen_.opcode(Opcode::Freeze);
     gen_.reg(Register(0));
+    gen_.reg(Register(1));
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(1));
     gen_.opcode(Opcode::Return);
   }
 
@@ -117,36 +125,6 @@ namespace verona::compiler
     gen_.opcode(Opcode::Return);
   }
 
-  void BuiltinGenerator::builtin_freeze()
-  {
-    assert(abi_.arguments == 2);
-    assert(abi_.returns == 1);
-
-    gen_.opcode(Opcode::Freeze);
-    gen_.reg(Register(0));
-    gen_.reg(Register(1));
-    gen_.opcode(Opcode::Clear);
-    gen_.reg(Register(1));
-    gen_.opcode(Opcode::Return);
-  }
-
-  void BuiltinGenerator::builtin_fulfill_sleeping_cown()
-  {
-    assert(abi_.arguments == 3);
-    assert(abi_.returns == 1);
-
-    gen_.opcode(Opcode::FulfillSleepingCown);
-    gen_.reg(Register(1));
-    gen_.reg(Register(2));
-    gen_.opcode(Opcode::Clear);
-    gen_.reg(Register(0));
-    gen_.opcode(Opcode::Clear);
-    gen_.reg(Register(1));
-    gen_.opcode(Opcode::Clear);
-    gen_.reg(Register(2));
-    gen_.opcode(Opcode::Return);
-  }
-
   void BuiltinGenerator::builtin_binop(bytecode::BinaryOperator op)
   {
     assert(abi_.arguments == 2);
@@ -157,6 +135,51 @@ namespace verona::compiler
     gen_.u8(static_cast<uint8_t>(op));
     gen_.reg(Register(0));
     gen_.reg(Register(1));
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(1));
+    gen_.opcode(Opcode::Return);
+  }
+
+  void BuiltinGenerator::builtin_cown_create()
+  {
+    assert(abi_.arguments == 2);
+    assert(abi_.returns == 1);
+
+    // This is a static method, therefore register 0 contains the descriptor for
+    // cown[T]. We use that to initialize the cown.
+    gen_.opcode(Opcode::NewCown);
+    gen_.reg(Register(0));
+    gen_.reg(Register(0));
+    gen_.reg(Register(1));
+
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(1));
+    gen_.opcode(Opcode::Return);
+  }
+
+  void BuiltinGenerator::builtin_cown_create_sleeping()
+  {
+    assert(abi_.arguments == 1);
+    assert(abi_.returns == 1);
+
+    // This is a static method, therefore register 0 contains the descriptor for
+    // cown[T]. We use that to initialize the cown.
+    gen_.opcode(Opcode::NewSleepingCown);
+    gen_.reg(Register(0));
+    gen_.reg(Register(0));
+    gen_.opcode(Opcode::Return);
+  }
+
+  void BuiltinGenerator::builtin_cown_fulfill_sleeping()
+  {
+    assert(abi_.arguments == 2);
+    assert(abi_.returns == 1);
+
+    gen_.opcode(Opcode::FulfillSleepingCown);
+    gen_.reg(Register(0));
+    gen_.reg(Register(1));
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(0));
     gen_.opcode(Opcode::Clear);
     gen_.reg(Register(1));
     gen_.opcode(Opcode::Return);

--- a/src/compiler/codegen/builtins.cc
+++ b/src/compiler/codegen/builtins.cc
@@ -31,6 +31,8 @@ namespace verona::compiler
         return builtin_create_sleeping_cown();
       else if (method == "fulfill_sleeping_cown")
         return builtin_fulfill_sleeping_cown();
+      else if (method == "freeze")
+        return builtin_freeze();
       else if (method == "trace")
         return builtin_trace_region();
     }
@@ -57,7 +59,8 @@ namespace verona::compiler
       else if (method == "or")
         return builtin_binop(bytecode::BinaryOperator::Or);
     }
-    throw std::logic_error("Invalid builtin");
+    fmt::print(stderr, "Invalid builtin {}.{}\n", entity, method);
+    abort();
   }
 
   void BuiltinGenerator::builtin_print()
@@ -106,6 +109,23 @@ namespace verona::compiler
     assert(abi_.returns == 1);
 
     gen_.opcode(Opcode::TraceRegion);
+    gen_.reg(Register(1));
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(0));
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(1));
+    gen_.opcode(Opcode::Return);
+  }
+
+  void BuiltinGenerator::builtin_freeze()
+  {
+    assert(abi_.arguments == 2);
+    assert(abi_.returns == 1);
+
+    gen_.opcode(Opcode::Freeze);
+    gen_.reg(Register(0));
+    gen_.reg(Register(1));
+    gen_.opcode(Opcode::Clear);
     gen_.reg(Register(1));
     gen_.opcode(Opcode::Return);
   }

--- a/src/compiler/codegen/builtins.h
+++ b/src/compiler/codegen/builtins.h
@@ -23,9 +23,10 @@ namespace verona::compiler
     void generate_builtin(std::string_view entity, std::string_view method);
 
     void builtin_print();
-    void builtin_create_sleeping_cown();
-    void builtin_trace_region();
-    void builtin_fulfill_sleeping_cown();
     void builtin_binop(bytecode::BinaryOperator op);
+    void builtin_create_sleeping_cown();
+    void builtin_fulfill_sleeping_cown();
+    void builtin_freeze();
+    void builtin_trace_region();
   };
 }

--- a/src/compiler/codegen/builtins.h
+++ b/src/compiler/codegen/builtins.h
@@ -16,9 +16,12 @@ namespace verona::compiler
     using FunctionGenerator::FunctionGenerator;
 
   public:
-    void generate_builtin(std::string_view name);
+    static void generate(
+      Context& context, Generator& gen, const CodegenItem<Method>& method);
 
   private:
+    void generate_builtin(std::string_view entity, std::string_view method);
+
     void builtin_print();
     void builtin_create_sleeping_cown();
     void builtin_trace_region();

--- a/src/compiler/codegen/builtins.h
+++ b/src/compiler/codegen/builtins.h
@@ -23,10 +23,11 @@ namespace verona::compiler
     void generate_builtin(std::string_view entity, std::string_view method);
 
     void builtin_print();
-    void builtin_binop(bytecode::BinaryOperator op);
-    void builtin_create_sleeping_cown();
-    void builtin_fulfill_sleeping_cown();
     void builtin_freeze();
     void builtin_trace_region();
+    void builtin_binop(bytecode::BinaryOperator op);
+    void builtin_cown_create();
+    void builtin_cown_create_sleeping();
+    void builtin_cown_fulfill_sleeping();
   };
 }

--- a/src/compiler/codegen/codegen.cc
+++ b/src/compiler/codegen/codegen.cc
@@ -3,6 +3,7 @@
 #include "compiler/codegen/codegen.h"
 
 #include "compiler/ast.h"
+#include "compiler/codegen/builtins.h"
 #include "compiler/codegen/descriptor.h"
 #include "compiler/codegen/function.h"
 #include "compiler/codegen/generator.h"
@@ -125,15 +126,21 @@ namespace verona::compiler
     {
       for (const auto& [method, method_info] : entity_info.methods)
       {
-        if (method.definition->body == nullptr)
+        if (!method_info.label.has_value())
           continue;
 
         gen.define_label(method_info.label.value());
-
-        const FnAnalysis& fn_analysis =
-          analysis.functions.at(method.definition);
-        emit_function(
-          context, reachability, selectors, gen, method, fn_analysis);
+        if (method.definition->kind() == Method::Builtin)
+        {
+          BuiltinGenerator::generate(context, gen, method);
+        }
+        else
+        {
+          const FnAnalysis& fn_analysis =
+            analysis.functions.at(method.definition);
+          emit_function(
+            context, reachability, selectors, gen, method, fn_analysis);
+        }
       }
     }
   }

--- a/src/compiler/codegen/codegen.cc
+++ b/src/compiler/codegen/codegen.cc
@@ -155,8 +155,8 @@ namespace verona::compiler
     std::vector<uint8_t> code;
     Generator gen(code);
 
-    Reachability reachability =
-      compute_reachability(context, gen, entry->first, entry->second, analysis);
+    Reachability reachability = compute_reachability(
+      context, program, gen, entry->first, entry->second, analysis);
     SelectorTable selectors = SelectorTable::build(reachability);
 
     emit_program_header(reachability, selectors, gen, entry->first);

--- a/src/compiler/codegen/descriptor.cc
+++ b/src/compiler/codegen/descriptor.cc
@@ -8,7 +8,7 @@ namespace verona::compiler
 {
   using bytecode::SelectorIdx;
 
-  void emit_class_descriptor(
+  void emit_class_primitive_descriptor(
     const SelectorTable& selectors,
     Generator& gen,
     const CodegenItem<Entity>& entity,
@@ -83,7 +83,8 @@ namespace verona::compiler
     switch (entity.definition->kind->value())
     {
       case Entity::Class:
-        emit_class_descriptor(selectors, gen, entity, reachability);
+      case Entity::Primitive:
+        emit_class_primitive_descriptor(selectors, gen, entity, reachability);
         break;
 
       case Entity::Interface:

--- a/src/compiler/codegen/descriptor.cc
+++ b/src/compiler/codegen/descriptor.cc
@@ -8,90 +8,156 @@ namespace verona::compiler
 {
   using bytecode::SelectorIdx;
 
-  void emit_class_primitive_descriptor(
-    const SelectorTable& selectors,
-    Generator& gen,
-    const CodegenItem<Entity>& entity,
-    const EntityReachability& reachability)
+  class EmitProgramHeader
   {
-    Generator::Relocatable rel_method_slots = gen.create_relocatable();
-    Generator::Relocatable rel_field_slots = gen.create_relocatable();
-    Generator::Relocatable rel_field_count = gen.create_relocatable();
+  public:
+    EmitProgramHeader(
+      const Program& program,
+      const Reachability& reachability,
+      const SelectorTable& selectors,
+      Generator& gen)
+    : program(program),
+      reachability(reachability),
+      selectors(selectors),
+      gen(gen)
+    {}
 
-    gen.str(entity.instantiated_path());
-    gen.u32(rel_method_slots);
-    gen.u32(truncate<uint32_t>(reachability.methods.size()));
-    gen.u32(rel_field_slots);
-    gen.u32(rel_field_count);
-    // Output label for finaliser for this class, if it has one.
-    if (reachability.finaliser.label.has_value())
-      gen.u32(reachability.finaliser.label.value());
-    else
-      gen.u32(0);
-
-    uint32_t method_slots = 0;
-    for (const auto& [method, info] : reachability.methods)
+    void emit_descriptor_table()
     {
-      TypeList arguments;
-      for (const auto& param : method.definition->signature->generics->types)
-      {
-        arguments.push_back(method.instantiation.types().at(param->index));
-      }
+      // Number of descriptors
+      gen.u32(truncate<uint32_t>(reachability.entities.size()));
 
-      Selector selector = Selector::method(method.definition->name, arguments);
-      SelectorIdx index = selectors.get(selector);
-      gen.selector(index);
-      gen.u32(info.label.value());
-      method_slots = std::max((uint32_t)(index + 1), method_slots);
+      size_t index = 0;
+      for (const auto& [entity, info] : reachability.entities)
+      {
+        gen.define_relocatable(info.descriptor, index++);
+        emit_descriptor(entity, info);
+      }
     }
 
-    uint32_t field_count = 0;
-    uint32_t field_slots = 0;
-    for (const auto& member : entity.definition->members)
+    void emit_descriptor(
+      const CodegenItem<Entity>& entity, const EntityReachability& info)
     {
-      if (const Field* fld = member->get_as<Field>())
+      switch (entity.definition->kind->value())
       {
-        SelectorIdx index = selectors.get(Selector::field(fld->name));
+        case Entity::Class:
+        case Entity::Primitive:
+          emit_class_primitive_descriptor(entity, info);
+          break;
+
+        case Entity::Interface:
+          emit_interface_descriptor(entity);
+          break;
+
+          EXHAUSTIVE_SWITCH;
+      }
+    }
+
+    void emit_class_primitive_descriptor(
+      const CodegenItem<Entity>& entity, const EntityReachability& info)
+    {
+      Generator::Relocatable rel_method_slots = gen.create_relocatable();
+      Generator::Relocatable rel_field_slots = gen.create_relocatable();
+      Generator::Relocatable rel_field_count = gen.create_relocatable();
+
+      gen.str(entity.instantiated_path());
+      gen.u32(rel_method_slots);
+      gen.u32(truncate<uint32_t>(info.methods.size()));
+      gen.u32(rel_field_slots);
+      gen.u32(rel_field_count);
+
+      // Output label for finaliser for this class, if it has one.
+      if (info.finaliser.label.has_value())
+        gen.u32(info.finaliser.label.value());
+      else
+        gen.u32(0);
+
+      uint32_t method_slots = 0;
+      for (const auto& [method, info] : info.methods)
+      {
+        TypeList arguments;
+        for (const auto& param : method.definition->signature->generics->types)
+        {
+          arguments.push_back(method.instantiation.types().at(param->index));
+        }
+
+        Selector selector =
+          Selector::method(method.definition->name, arguments);
+        SelectorIdx index = selectors.get(selector);
         gen.selector(index);
-        field_slots = std::max((uint32_t)(index + 1), field_slots);
-        field_count++;
+        gen.u32(info.label.value());
+        method_slots = std::max((uint32_t)(index + 1), method_slots);
       }
+
+      uint32_t field_count = 0;
+      uint32_t field_slots = 0;
+      for (const auto& member : entity.definition->members)
+      {
+        if (const Field* fld = member->get_as<Field>())
+        {
+          SelectorIdx index = selectors.get(Selector::field(fld->name));
+          gen.selector(index);
+          field_slots = std::max((uint32_t)(index + 1), field_slots);
+          field_count++;
+        }
+      }
+
+      gen.define_relocatable(rel_method_slots, method_slots);
+      gen.define_relocatable(rel_field_slots, field_slots);
+      gen.define_relocatable(rel_field_count, field_count);
     }
 
-    gen.define_relocatable(rel_method_slots, method_slots);
-    gen.define_relocatable(rel_field_slots, field_slots);
-    gen.define_relocatable(rel_field_count, field_count);
-  }
+    void emit_interface_descriptor(const CodegenItem<Entity>& entity)
+    {
+      gen.str(entity.instantiated_path());
+      gen.u32(0);
+      gen.u32(0);
+      gen.u32(0);
+      gen.u32(0);
+      gen.u32(0);
+    }
 
-  void
-  emit_interface_descriptor(Generator& gen, const CodegenItem<Entity>& entity)
-  {
-    gen.str(entity.instantiated_path());
-    gen.u32(0);
-    gen.u32(0);
-    gen.u32(0);
-    gen.u32(0);
-    gen.u32(0);
-  }
+    void emit_optional_special_descriptor(const std::string& name)
+    {
+      const EntityReachability* entity_info = nullptr;
+      if (const Entity* entity = program.find_entity(name))
+      {
+        CodegenItem item(entity, Instantiation::empty());
+        entity_info = reachability.try_find_entity(item);
+      }
 
-  void emit_descriptor(
+      if (entity_info)
+        gen.u32(entity_info->descriptor);
+      else
+        gen.u32(bytecode::INVALID_DESCRIPTOR);
+    }
+
+    void emit_special_descriptors(const CodegenItem<Entity>& main_class)
+    {
+      // Index of the main descriptor
+      gen.u32(reachability.find_entity(main_class).descriptor);
+      // Index of the main selector
+      gen.u32(selectors.get(Selector::method("main", TypeList())));
+
+      emit_optional_special_descriptor("U64");
+    }
+
+  private:
+    const Program& program;
+    const Reachability& reachability;
+    const SelectorTable& selectors;
+    Generator& gen;
+  };
+
+  void emit_program_header(
+    const Program& program,
+    const Reachability& reachability,
     const SelectorTable& selectors,
     Generator& gen,
-    const CodegenItem<Entity>& entity,
-    const EntityReachability& reachability)
+    const CodegenItem<Entity>& main)
   {
-    switch (entity.definition->kind->value())
-    {
-      case Entity::Class:
-      case Entity::Primitive:
-        emit_class_primitive_descriptor(selectors, gen, entity, reachability);
-        break;
-
-      case Entity::Interface:
-        emit_interface_descriptor(gen, entity);
-        break;
-
-        EXHAUSTIVE_SWITCH;
-    }
+    EmitProgramHeader emit(program, reachability, selectors, gen);
+    emit.emit_descriptor_table();
+    emit.emit_special_descriptors(main);
   }
 };

--- a/src/compiler/codegen/descriptor.cc
+++ b/src/compiler/codegen/descriptor.cc
@@ -19,17 +19,17 @@ namespace verona::compiler
     Generator::Relocatable rel_field_count = gen.create_relocatable();
 
     gen.str(entity.instantiated_path());
-    gen.u16(rel_method_slots);
-    gen.u16(truncate<uint16_t>(reachability.methods.size()));
-    gen.u16(rel_field_slots);
-    gen.u16(rel_field_count);
+    gen.u32(rel_method_slots);
+    gen.u32(truncate<uint32_t>(reachability.methods.size()));
+    gen.u32(rel_field_slots);
+    gen.u32(rel_field_count);
     // Output label for finaliser for this class, if it has one.
     if (reachability.finaliser.label.has_value())
       gen.u32(reachability.finaliser.label.value());
     else
       gen.u32(0);
 
-    uint16_t method_slots = 0;
+    uint32_t method_slots = 0;
     for (const auto& [method, info] : reachability.methods)
     {
       TypeList arguments;
@@ -42,18 +42,18 @@ namespace verona::compiler
       SelectorIdx index = selectors.get(selector);
       gen.selector(index);
       gen.u32(info.label.value());
-      method_slots = std::max((uint16_t)(index + 1), method_slots);
+      method_slots = std::max((uint32_t)(index + 1), method_slots);
     }
 
-    uint16_t field_count = 0;
-    uint16_t field_slots = 0;
+    uint32_t field_count = 0;
+    uint32_t field_slots = 0;
     for (const auto& member : entity.definition->members)
     {
       if (const Field* fld = member->get_as<Field>())
       {
         SelectorIdx index = selectors.get(Selector::field(fld->name));
         gen.selector(index);
-        field_slots = std::max((uint16_t)(index + 1), field_slots);
+        field_slots = std::max((uint32_t)(index + 1), field_slots);
         field_count++;
       }
     }
@@ -67,10 +67,10 @@ namespace verona::compiler
   emit_interface_descriptor(Generator& gen, const CodegenItem<Entity>& entity)
   {
     gen.str(entity.instantiated_path());
-    gen.u16(0);
-    gen.u16(0);
-    gen.u16(0);
-    gen.u16(0);
+    gen.u32(0);
+    gen.u32(0);
+    gen.u32(0);
+    gen.u32(0);
     gen.u32(0);
   }
 

--- a/src/compiler/codegen/descriptor.h
+++ b/src/compiler/codegen/descriptor.h
@@ -7,9 +7,10 @@
 
 namespace verona::compiler
 {
-  void emit_descriptor(
+  void emit_program_header(
+    const Program& program,
+    const Reachability& reachability,
     const SelectorTable& selectors,
     Generator& gen,
-    const CodegenItem<Entity>& entity,
-    const EntityReachability& reachability);
+    const CodegenItem<Entity>& main);
 };

--- a/src/compiler/codegen/function.cc
+++ b/src/compiler/codegen/function.cc
@@ -140,4 +140,34 @@ namespace verona::compiler
       v.finish();
     }
   }
+
+  void emit_functions(
+    Context& context,
+    const AnalysisResults& analysis,
+    const Reachability& reachability,
+    const SelectorTable& selectors,
+    Generator& gen)
+  {
+    for (const auto& [entity, entity_info] : reachability.entities)
+    {
+      for (const auto& [method, method_info] : entity_info.methods)
+      {
+        if (!method_info.label.has_value())
+          continue;
+
+        gen.define_label(method_info.label.value());
+        if (method.definition->kind() == Method::Builtin)
+        {
+          BuiltinGenerator::generate(context, gen, method);
+        }
+        else
+        {
+          const FnAnalysis& fn_analysis =
+            analysis.functions.at(method.definition);
+          emit_function(
+            context, reachability, selectors, gen, method, fn_analysis);
+        }
+      }
+    }
+  }
 }

--- a/src/compiler/codegen/function.h
+++ b/src/compiler/codegen/function.h
@@ -24,6 +24,13 @@ namespace verona::compiler
     const CodegenItem<Method>& method,
     const FnAnalysis& analysis);
 
+  void emit_functions(
+    Context& context,
+    const AnalysisResults& analysis,
+    const Reachability& reachability,
+    const SelectorTable& selectors,
+    Generator& gen);
+
   struct FunctionABI
   {
     explicit FunctionABI(const FnSignature& sig)

--- a/src/compiler/codegen/ir.h
+++ b/src/compiler/codegen/ir.h
@@ -266,16 +266,6 @@ namespace verona::compiler
       gen_.reg(input);
     }
 
-    void visit_stmt(const FreezeStmt& stmt)
-    {
-      Register input = variable(stmt.input);
-      Register output = variable(stmt.output);
-
-      gen_.opcode(Opcode::Freeze);
-      gen_.reg(output);
-      gen_.reg(input);
-    }
-
     void visit_stmt(const UnitStmt& stmt)
     {
       Register output = variable(stmt.output);

--- a/src/compiler/codegen/ir.h
+++ b/src/compiler/codegen/ir.h
@@ -192,15 +192,6 @@ namespace verona::compiler
       }
     }
 
-    void visit_stmt(const NewCownStmt& stmt)
-    {
-      Register input = variable(stmt.input);
-      Register output = variable(stmt.output);
-      gen_.opcode(Opcode::NewCown);
-      gen_.reg(output);
-      gen_.reg(input);
-    }
-
     void visit_stmt(const MatchBindStmt& stmt)
     {
       Register input = variable(stmt.input);

--- a/src/compiler/codegen/reachability.cc
+++ b/src/compiler/codegen/reachability.cc
@@ -525,13 +525,6 @@ namespace verona::compiler
     {}
 
     void visit_stmt(
-      const FreezeStmt& stmt,
-      const Instantiation& instantiation,
-      const TypecheckResults& typecheck,
-      const TypeAssignment& assignment)
-    {}
-
-    void visit_stmt(
       const EndScopeStmt& stmt,
       const Instantiation& instantiation,
       const TypecheckResults& typecheck,

--- a/src/compiler/codegen/reachability.cc
+++ b/src/compiler/codegen/reachability.cc
@@ -23,8 +23,12 @@ namespace verona::compiler
   : private RecursiveTypeVisitor<const Instantiation&>
   {
     ReachabilityVisitor(
-      Context& context, Generator& gen, const AnalysisResults& analysis)
+      Context& context,
+      const Program& program,
+      Generator& gen,
+      const AnalysisResults& analysis)
     : context_(context),
+      program_(program),
       gen_(gen),
       analysis_(analysis),
       solver_out_(context_.dump("reachability-solver"))
@@ -495,7 +499,9 @@ namespace verona::compiler
       const Instantiation& instantiation,
       const TypecheckResults& typecheck,
       const TypeAssignment& assignment)
-    {}
+    {
+      push(CodegenItem(program_.find_entity("U64"), Instantiation::empty()));
+    }
 
     void visit_stmt(
       const StringLiteralStmt& stmt,
@@ -592,6 +598,7 @@ namespace verona::compiler
     }
 
     Context& context_;
+    const Program& program_;
     Generator& gen_;
     const AnalysisResults& analysis_;
     Reachability result_;
@@ -654,12 +661,13 @@ namespace verona::compiler
 
   Reachability compute_reachability(
     Context& context,
+    const Program& program,
     Generator& gen,
     CodegenItem<Entity> main_class,
     CodegenItem<Method> main_method,
     const AnalysisResults& analysis)
   {
-    ReachabilityVisitor v(context, gen, analysis);
+    ReachabilityVisitor v(context, program, gen, analysis);
     v.process(main_class, main_method);
 
     dump_reachability(context, v.result_);

--- a/src/compiler/codegen/reachability.cc
+++ b/src/compiler/codegen/reachability.cc
@@ -574,7 +574,9 @@ namespace verona::compiler
     add_method(EntityReachability& parent, const CodegenItem<Method>& method)
     {
       std::optional<Label> label;
-      if (method.definition->body != nullptr)
+      if (
+        method.definition->body != nullptr ||
+        method.definition->kind() == Method::Builtin)
       {
         label = gen_.create_label();
         if (method.definition->is_finaliser())

--- a/src/compiler/codegen/reachability.cc
+++ b/src/compiler/codegen/reachability.cc
@@ -608,24 +608,36 @@ namespace verona::compiler
     std::unique_ptr<std::ostream> solver_out_;
   };
 
-  EntityReachability&
-  Reachability::find_entity(const CodegenItem<Entity>& entity)
+  const CodegenItem<Entity>&
+  Reachability::normalize_equivalence(const CodegenItem<Entity>& entity) const
   {
     auto it = equivalent_entities.find(entity);
     if (it != equivalent_entities.end())
-      return entities.at(it->second);
+      return it->second;
     else
-      return entities.at(entity);
+      return entity;
+  }
+
+  EntityReachability&
+  Reachability::find_entity(const CodegenItem<Entity>& entity)
+  {
+    return entities.at(normalize_equivalence(entity));
   }
 
   const EntityReachability&
   Reachability::find_entity(const CodegenItem<Entity>& entity) const
   {
-    auto it = equivalent_entities.find(entity);
-    if (it != equivalent_entities.end())
-      return entities.at(it->second);
+    return entities.at(normalize_equivalence(entity));
+  }
+
+  const EntityReachability*
+  Reachability::try_find_entity(const CodegenItem<Entity>& entity) const
+  {
+    auto it = entities.find(normalize_equivalence(entity));
+    if (it != entities.end())
+      return &it->second;
     else
-      return entities.at(entity);
+      return nullptr;
   }
 
   void dump_reachability(Context& context, const Reachability& reachability)

--- a/src/compiler/codegen/reachability.cc
+++ b/src/compiler/codegen/reachability.cc
@@ -447,13 +447,6 @@ namespace verona::compiler
     }
 
     void visit_stmt(
-      const NewCownStmt& stmt,
-      const Instantiation& instantiation,
-      const TypecheckResults& typecheck,
-      const TypeAssignment& assignment)
-    {}
-
-    void visit_stmt(
       const MatchBindStmt& stmt,
       const Instantiation& instantiation,
       const TypecheckResults& typecheck,

--- a/src/compiler/codegen/reachability.cc
+++ b/src/compiler/codegen/reachability.cc
@@ -610,7 +610,7 @@ namespace verona::compiler
   }
 
   const EntityReachability&
-  Reachability::find_entity(CodegenItem<Entity>& entity) const
+  Reachability::find_entity(const CodegenItem<Entity>& entity) const
   {
     auto it = equivalent_entities.find(entity);
     if (it != equivalent_entities.end())

--- a/src/compiler/codegen/reachability.h
+++ b/src/compiler/codegen/reachability.h
@@ -90,11 +90,24 @@ namespace verona::compiler
     std::map<CodegenItem<Entity>, CodegenItem<Entity>> equivalent_entities;
 
     /**
+     * Find the canonical item that is equivalent to `entity`.
+     */
+    const CodegenItem<Entity>&
+    normalize_equivalence(const CodegenItem<Entity>& entity) const;
+
+    /**
      * Find the information related to this entity or an equivalent one.
      */
     EntityReachability& find_entity(const CodegenItem<Entity>& entity);
     const EntityReachability&
     find_entity(const CodegenItem<Entity>& entity) const;
+
+    /**
+     * Find the information related to this entity or an equivalent one,
+     * returns nullptr if the item is not reachable.
+     */
+    const EntityReachability*
+    try_find_entity(const CodegenItem<Entity>& entity) const;
   };
 
   Reachability compute_reachability(

--- a/src/compiler/codegen/reachability.h
+++ b/src/compiler/codegen/reachability.h
@@ -99,6 +99,7 @@ namespace verona::compiler
 
   Reachability compute_reachability(
     Context& context,
+    const Program& program,
     Generator& gen,
     CodegenItem<Entity> main_class,
     CodegenItem<Method> main_method,

--- a/src/compiler/codegen/reachability.h
+++ b/src/compiler/codegen/reachability.h
@@ -93,7 +93,8 @@ namespace verona::compiler
      * Find the information related to this entity or an equivalent one.
      */
     EntityReachability& find_entity(const CodegenItem<Entity>& entity);
-    const EntityReachability& find_entity(CodegenItem<Entity>& entity) const;
+    const EntityReachability&
+    find_entity(const CodegenItem<Entity>& entity) const;
   };
 
   Reachability compute_reachability(

--- a/src/compiler/dataflow/use_def.h
+++ b/src/compiler/dataflow/use_def.h
@@ -103,12 +103,6 @@ namespace verona::compiler
       use_variable(stmt.input);
     }
 
-    void visit_inner_stmt(const FreezeStmt& stmt)
-    {
-      define_variable(stmt.output);
-      use_variable(stmt.input);
-    }
-
     void visit_inner_stmt(const CopyStmt& stmt)
     {
       define_variable(stmt.output);

--- a/src/compiler/dataflow/use_def.h
+++ b/src/compiler/dataflow/use_def.h
@@ -72,12 +72,6 @@ namespace verona::compiler
       define_variable(stmt.output);
     }
 
-    void visit_inner_stmt(const NewCownStmt& stmt)
-    {
-      define_variable(stmt.output);
-      use_variable(stmt.input);
-    }
-
     void visit_inner_stmt(const MatchBindStmt& stmt)
     {
       define_variable(stmt.output);

--- a/src/compiler/freevars.h
+++ b/src/compiler/freevars.h
@@ -149,11 +149,6 @@ namespace verona::compiler
       return combine(ty->lower, ty->upper);
     }
 
-    FreeVariables visit_cown_type(const CownTypePtr& ty) final
-    {
-      return free_variables(ty->contents).without_inferrable_regions();
-    }
-
     FreeVariables visit_viewpoint_type(const ViewpointTypePtr& ty) final
     {
       return free_variables(ty->right);

--- a/src/compiler/freevars.h
+++ b/src/compiler/freevars.h
@@ -201,11 +201,6 @@ namespace verona::compiler
       return FreeVariables();
     }
 
-    FreeVariables visit_integer_type(const IntegerTypePtr& ty) final
-    {
-      return FreeVariables();
-    }
-
     FreeVariables visit_string_type(const StringTypePtr& ty) final
     {
       return FreeVariables();

--- a/src/compiler/intern.cc
+++ b/src/compiler/intern.cc
@@ -315,9 +315,8 @@ namespace verona::compiler
       type->dyncast<DelayedFieldViewType>() || type->dyncast<EntityOfType>() ||
       type->dyncast<EntityType>() || type->dyncast<HasAppliedMethodType>() ||
       type->dyncast<HasFieldType>() || type->dyncast<HasMethodType>() ||
-      type->dyncast<IntegerType>() || type->dyncast<StringType>() ||
-      type->dyncast<IsEntityType>() || type->dyncast<CownType>() ||
-      type->dyncast<UnitType>())
+      type->dyncast<StringType>() || type->dyncast<IsEntityType>() ||
+      type->dyncast<CownType>() || type->dyncast<UnitType>())
       return type;
 
     if (type->dyncast<TypeParameter>() || type->dyncast<InferType>())
@@ -398,9 +397,8 @@ namespace verona::compiler
       type->dyncast<DelayedFieldViewType>() || type->dyncast<EntityOfType>() ||
       type->dyncast<EntityType>() || type->dyncast<HasAppliedMethodType>() ||
       type->dyncast<HasFieldType>() || type->dyncast<HasMethodType>() ||
-      type->dyncast<IntegerType>() || type->dyncast<StringType>() ||
-      type->dyncast<IsEntityType>() || type->dyncast<CownType>() ||
-      type->dyncast<UnitType>())
+      type->dyncast<StringType>() || type->dyncast<IsEntityType>() ||
+      type->dyncast<CownType>() || type->dyncast<UnitType>())
       return type;
 
     // TODO: We never actually create UnapplyRegionType anymore, so we could
@@ -419,8 +417,8 @@ namespace verona::compiler
       return mk_top();
 
     if (
-      right->dyncast<EntityType>() || right->dyncast<IntegerType>() ||
-      right->dyncast<StringType>() || right->dyncast<CownType>())
+      right->dyncast<EntityType>() || right->dyncast<StringType>() ||
+      right->dyncast<CownType>())
       return right;
 
     if (auto isect = left->dyncast<IntersectionType>())
@@ -679,11 +677,6 @@ namespace verona::compiler
     return intern(IsEntityType());
   }
 
-  IntegerTypePtr TypeInterner::mk_integer_type()
-  {
-    return intern(IntegerType());
-  }
-
   StringTypePtr TypeInterner::mk_string_type()
   {
     return intern(StringType());
@@ -763,10 +756,9 @@ namespace verona::compiler
 
     // These are all entity-like types already.
     if (
-      inner->dyncast<EntityType>() || inner->dyncast<IntegerType>() ||
-      inner->dyncast<StringType>() || inner->dyncast<UnitType>() ||
-      inner->dyncast<EntityOfType>() || inner->dyncast<HasFieldType>() ||
-      inner->dyncast<HasMethodType>() ||
+      inner->dyncast<EntityType>() || inner->dyncast<StringType>() ||
+      inner->dyncast<UnitType>() || inner->dyncast<EntityOfType>() ||
+      inner->dyncast<HasFieldType>() || inner->dyncast<HasMethodType>() ||
       inner->dyncast<HasAppliedMethodType>() ||
       inner->dyncast<DelayedFieldViewType>())
       return inner;
@@ -862,10 +854,9 @@ namespace verona::compiler
       type->dyncast<DelayedFieldViewType>() || type->dyncast<EntityOfType>() ||
       type->dyncast<EntityType>() || type->dyncast<HasAppliedMethodType>() ||
       type->dyncast<HasFieldType>() || type->dyncast<HasMethodType>() ||
-      type->dyncast<IntegerType>() || type->dyncast<StringType>() ||
-      type->dyncast<IsEntityType>() || type->dyncast<CownType>() ||
-      type->dyncast<StaticType>() || type->dyncast<UnitType>() ||
-      type->dyncast<TypeParameter>())
+      type->dyncast<StringType>() || type->dyncast<IsEntityType>() ||
+      type->dyncast<CownType>() || type->dyncast<StaticType>() ||
+      type->dyncast<UnitType>() || type->dyncast<TypeParameter>())
       return type;
 
     if (
@@ -966,10 +957,9 @@ namespace verona::compiler
       type->dyncast<DelayedFieldViewType>() || type->dyncast<EntityOfType>() ||
       type->dyncast<EntityType>() || type->dyncast<HasAppliedMethodType>() ||
       type->dyncast<HasFieldType>() || type->dyncast<HasMethodType>() ||
-      type->dyncast<IntegerType>() || type->dyncast<StringType>() ||
-      type->dyncast<IsEntityType>() || type->dyncast<CownType>() ||
-      type->dyncast<StaticType>() || type->dyncast<UnitType>() ||
-      type->dyncast<TypeParameter>())
+      type->dyncast<StringType>() || type->dyncast<IsEntityType>() ||
+      type->dyncast<CownType>() || type->dyncast<StaticType>() ||
+      type->dyncast<UnitType>() || type->dyncast<TypeParameter>())
       return type;
 
     if (
@@ -1160,7 +1150,6 @@ namespace verona::compiler
     DISPATCH(HasMethodType);
     DISPATCH(IndirectType);
     DISPATCH(InferType);
-    DISPATCH(IntegerType);
     DISPATCH(IntersectionType);
     DISPATCH(IsEntityType);
     DISPATCH(NotChildOfType);

--- a/src/compiler/intern.cc
+++ b/src/compiler/intern.cc
@@ -316,7 +316,7 @@ namespace verona::compiler
       type->dyncast<EntityType>() || type->dyncast<HasAppliedMethodType>() ||
       type->dyncast<HasFieldType>() || type->dyncast<HasMethodType>() ||
       type->dyncast<StringType>() || type->dyncast<IsEntityType>() ||
-      type->dyncast<CownType>() || type->dyncast<UnitType>())
+      type->dyncast<UnitType>())
       return type;
 
     if (type->dyncast<TypeParameter>() || type->dyncast<InferType>())
@@ -398,7 +398,7 @@ namespace verona::compiler
       type->dyncast<EntityType>() || type->dyncast<HasAppliedMethodType>() ||
       type->dyncast<HasFieldType>() || type->dyncast<HasMethodType>() ||
       type->dyncast<StringType>() || type->dyncast<IsEntityType>() ||
-      type->dyncast<CownType>() || type->dyncast<UnitType>())
+      type->dyncast<UnitType>())
       return type;
 
     // TODO: We never actually create UnapplyRegionType anymore, so we could
@@ -416,9 +416,7 @@ namespace verona::compiler
     if (left->dyncast<EntityType>() || left->dyncast<EntityOfType>())
       return mk_top();
 
-    if (
-      right->dyncast<EntityType>() || right->dyncast<StringType>() ||
-      right->dyncast<CownType>())
+    if (right->dyncast<EntityType>() || right->dyncast<StringType>())
       return right;
 
     if (auto isect = left->dyncast<IntersectionType>())
@@ -544,13 +542,6 @@ namespace verona::compiler
     std::cerr << "Bad Viewpoint(" << *left << ", " << *right << ")"
               << std::endl;
     abort();
-  }
-
-  TypePtr TypeInterner::mk_cown(TypePtr contents)
-  {
-    assert(is_interned(contents));
-
-    return intern(CownType(contents));
   }
 
   template<typename T>
@@ -855,8 +846,8 @@ namespace verona::compiler
       type->dyncast<EntityType>() || type->dyncast<HasAppliedMethodType>() ||
       type->dyncast<HasFieldType>() || type->dyncast<HasMethodType>() ||
       type->dyncast<StringType>() || type->dyncast<IsEntityType>() ||
-      type->dyncast<CownType>() || type->dyncast<StaticType>() ||
-      type->dyncast<UnitType>() || type->dyncast<TypeParameter>())
+      type->dyncast<StaticType>() || type->dyncast<UnitType>() ||
+      type->dyncast<TypeParameter>())
       return type;
 
     if (
@@ -958,8 +949,8 @@ namespace verona::compiler
       type->dyncast<EntityType>() || type->dyncast<HasAppliedMethodType>() ||
       type->dyncast<HasFieldType>() || type->dyncast<HasMethodType>() ||
       type->dyncast<StringType>() || type->dyncast<IsEntityType>() ||
-      type->dyncast<CownType>() || type->dyncast<StaticType>() ||
-      type->dyncast<UnitType>() || type->dyncast<TypeParameter>())
+      type->dyncast<StaticType>() || type->dyncast<UnitType>() ||
+      type->dyncast<TypeParameter>())
       return type;
 
     if (
@@ -1155,7 +1146,6 @@ namespace verona::compiler
     DISPATCH(NotChildOfType);
     DISPATCH(PathCompressionType);
     DISPATCH(RangeType);
-    DISPATCH(CownType);
     DISPATCH(StaticType);
     DISPATCH(StringType);
     DISPATCH(TypeParameter);

--- a/src/compiler/intern.h
+++ b/src/compiler/intern.h
@@ -67,8 +67,6 @@ namespace verona::compiler
 
     TypePtr mk_viewpoint(TypePtr left, TypePtr right);
 
-    TypePtr mk_cown(TypePtr contents);
-
     template<typename T>
     TypePtr mk_viewpoint(
       std::optional<CapabilityKind> capability,

--- a/src/compiler/intern.h
+++ b/src/compiler/intern.h
@@ -94,7 +94,6 @@ namespace verona::compiler
     IsEntityTypePtr mk_is_entity();
 
     UnitTypePtr mk_unit();
-    IntegerTypePtr mk_integer_type();
     StringTypePtr mk_string_type();
 
     FixpointTypePtr mk_fixpoint(TypePtr inner);

--- a/src/compiler/ir/builder.cc
+++ b/src/compiler/ir/builder.cc
@@ -513,15 +513,6 @@ namespace verona::compiler
   }
 
   BuilderResult<IRInput>
-  IRBuilder::visit_new_cown(NewCownExpr& expr, ValueKind kind, BasicBlock*& bb)
-  {
-    NewCownStmt stmt(expr.source_range);
-    stmt.input = visit_input(*expr.contents, bb);
-    stmt.output = fresh_variable(kind);
-    return add_statement(bb, std::move(stmt));
-  }
-
-  BuilderResult<IRInput>
   IRBuilder::visit_match_expr(MatchExpr& expr, ValueKind kind, BasicBlock*& bb)
   {
     IRInput input = visit_input(*expr.expr, bb);

--- a/src/compiler/ir/builder.cc
+++ b/src/compiler/ir/builder.cc
@@ -728,15 +728,6 @@ namespace verona::compiler
     return add_statement(bb, std::move(stmt));
   }
 
-  BuilderResult<IRInput> IRBuilder::visit_freeze_expr(
-    FreezeExpr& expr, ValueKind kind, BasicBlock*& bb)
-  {
-    FreezeStmt stmt(expr.source_range);
-    stmt.input = visit_input(*expr.expr, bb);
-    stmt.output = fresh_variable(kind);
-    return add_statement(bb, std::move(stmt));
-  }
-
   BuilderResult<IRInput> IRBuilder::visit_binary_operator_expr(
     BinaryOperatorExpr& expr, ValueKind kind, BasicBlock*& bb)
   {

--- a/src/compiler/ir/builder.h
+++ b/src/compiler/ir/builder.h
@@ -357,9 +357,6 @@ namespace verona::compiler
     BuilderResult<IRInput>
     visit_view_expr(ViewExpr& expr, ValueKind kind, BasicBlock*& bb) final;
 
-    BuilderResult<IRInput>
-    visit_freeze_expr(FreezeExpr& expr, ValueKind kind, BasicBlock*& bb) final;
-
     BuilderResult<IRInput> visit_binary_operator_expr(
       BinaryOperatorExpr& expr, ValueKind kind, BasicBlock*& bb) final;
 

--- a/src/compiler/ir/builder.h
+++ b/src/compiler/ir/builder.h
@@ -331,9 +331,6 @@ namespace verona::compiler
     visit_new_expr(NewExpr& expr, ValueKind kind, BasicBlock*& bb) final;
 
     BuilderResult<IRInput>
-    visit_new_cown(NewCownExpr& expr, ValueKind kind, BasicBlock*& bb) final;
-
-    BuilderResult<IRInput>
     visit_empty(EmptyExpr& expr, ValueKind kind, BasicBlock*& bb) final;
 
     BuilderResult<IRInput> visit_integer_literal_expr(

--- a/src/compiler/ir/builder.h
+++ b/src/compiler/ir/builder.h
@@ -167,11 +167,10 @@ namespace verona::compiler
   {
   public:
     static std::unique_ptr<MethodIR>
-    build(const FnSignature& sig, const FnBody& body, const Entity* builtin);
+    build(const FnSignature& sig, const FnBody& body);
 
   private:
-    IRBuilder(MethodIR* ir, const Entity* builtin)
-    : method_ir_(ir), builtin_definition_(builtin)
+    IRBuilder(MethodIR* ir) : method_ir_(ir)
     {
       scopes_.push_back(std::make_unique<ScopeData>());
     }
@@ -373,9 +372,6 @@ namespace verona::compiler
     BuilderResult<IRInput> unit(
       SourceManager::SourceRange source_range, ValueKind kind, BasicBlock* bb);
 
-    IRInput find_builtin(
-      SourceManager::SourceRange source_range, ValueKind kind, BasicBlock* bb);
-
     /**
      * For each basic block `term` jumps to, add `pred` as a predecessor.
      */
@@ -475,11 +471,5 @@ namespace verona::compiler
      * This contains a cache of symbols that are (re)defined by each expression.
      */
     ExprAssignsSymbol assigns_sym_;
-
-    /**
-     * Pointer to the Builtin entity. This is used to desugar certain
-     * expressions into method calls on that module.
-     */
-    const Entity* builtin_definition_;
   };
 }

--- a/src/compiler/ir/ir.h
+++ b/src/compiler/ir/ir.h
@@ -257,14 +257,6 @@ namespace verona::compiler
     IRInput input;
   };
 
-  struct FreezeStmt : public BaseStatement
-  {
-    using BaseStatement::BaseStatement;
-
-    Variable output;
-    IRInput input;
-  };
-
   /**
    * Generated at the end of a source-language scope.
    * Contains the list of local variables that go out of scope here. The
@@ -307,7 +299,6 @@ namespace verona::compiler
     CopyStmt,
     MatchBindStmt,
     ViewStmt,
-    FreezeStmt,
     EndScopeStmt,
     OverwriteStmt,
     UnitStmt>

--- a/src/compiler/ir/ir.h
+++ b/src/compiler/ir/ir.h
@@ -161,14 +161,6 @@ namespace verona::compiler
     TypeArgumentsId type_arguments;
   };
 
-  struct NewCownStmt : public BaseStatement
-  {
-    using BaseStatement::BaseStatement;
-
-    Variable output;
-    IRInput input;
-  };
-
   struct CallStmt : public BaseStatement
   {
     using BaseStatement::BaseStatement;
@@ -288,7 +280,6 @@ namespace verona::compiler
 
   typedef std::variant<
     NewStmt,
-    NewCownStmt,
     StaticTypeStmt,
     CallStmt,
     WhenStmt,

--- a/src/compiler/ir/print.cc
+++ b/src/compiler/ir/print.cc
@@ -162,17 +162,6 @@ namespace verona::compiler
   }
 
   void IRPrinter::print_inner_statement(
-    const TypeAssignment* assignment, const NewCownStmt& stmt) const
-  {
-    fmt::print(
-      out_,
-      "{} <- cown {}{}",
-      stmt.output,
-      stmt.input,
-      type_of(assignment, stmt.output));
-  }
-
-  void IRPrinter::print_inner_statement(
     const TypeAssignment* assignment, const CallStmt& stmt) const
   {
     fmt::print(

--- a/src/compiler/ir/print.cc
+++ b/src/compiler/ir/print.cc
@@ -259,17 +259,6 @@ namespace verona::compiler
   }
 
   void IRPrinter::print_inner_statement(
-    const TypeAssignment* assignment, const FreezeStmt& stmt) const
-  {
-    fmt::print(
-      out_,
-      "{} <- freeze({}){}",
-      stmt.output,
-      stmt.input,
-      type_of(assignment, stmt.output));
-  }
-
-  void IRPrinter::print_inner_statement(
     const TypeAssignment* assignment, const CopyStmt& stmt) const
   {
     fmt::print(

--- a/src/compiler/ir/print.h
+++ b/src/compiler/ir/print.h
@@ -58,8 +58,6 @@ namespace verona::compiler
     void print_inner_statement(
       const TypeAssignment* assignment, const NewStmt& stmt) const;
     void print_inner_statement(
-      const TypeAssignment* assignment, const NewCownStmt& stmt) const;
-    void print_inner_statement(
       const TypeAssignment* assignment, const CallStmt& stmt) const;
     void print_inner_statement(
       const TypeAssignment* assignment, const WhenStmt& stmt) const;

--- a/src/compiler/ir/print.h
+++ b/src/compiler/ir/print.h
@@ -76,8 +76,6 @@ namespace verona::compiler
     void print_inner_statement(
       const TypeAssignment* assignment, const CopyStmt& stmt) const;
     void print_inner_statement(
-      const TypeAssignment* assignment, const FreezeStmt& stmt) const;
-    void print_inner_statement(
       const TypeAssignment* assignment, const IntegerLiteralStmt& stmt) const;
     void print_inner_statement(
       const TypeAssignment* assignment, const StringLiteralStmt& stmt) const;

--- a/src/compiler/mapper.cc
+++ b/src/compiler/mapper.cc
@@ -124,11 +124,6 @@ namespace verona::compiler
     return context().mk_is_entity();
   }
 
-  TypePtr RecursiveTypeMapper::visit_integer_type(const IntegerTypePtr& ty)
-  {
-    return context().mk_integer_type();
-  }
-
   TypePtr RecursiveTypeMapper::visit_string_type(const StringTypePtr& ty)
   {
     return context().mk_string_type();

--- a/src/compiler/mapper.cc
+++ b/src/compiler/mapper.cc
@@ -79,11 +79,6 @@ namespace verona::compiler
     return context().mk_range(apply(ty->lower), apply(ty->upper));
   }
 
-  TypePtr RecursiveTypeMapper::visit_cown_type(const CownTypePtr& ty)
-  {
-    return context().mk_cown(apply(ty->contents));
-  }
-
   TypePtr RecursiveTypeMapper::visit_viewpoint_type(const ViewpointTypePtr& ty)
   {
     TypeSet variables;

--- a/src/compiler/mapper.h
+++ b/src/compiler/mapper.h
@@ -182,7 +182,6 @@ namespace verona::compiler
     TypePtr
     visit_has_applied_method_type(const HasAppliedMethodTypePtr& ty) override;
     TypePtr visit_is_entity_type(const IsEntityTypePtr& ty) override;
-    TypePtr visit_integer_type(const IntegerTypePtr& ty) override;
     TypePtr visit_string_type(const StringTypePtr& ty) override;
     TypePtr visit_fixpoint_type(const FixpointTypePtr& ty) override;
     TypePtr

--- a/src/compiler/mapper.h
+++ b/src/compiler/mapper.h
@@ -173,7 +173,6 @@ namespace verona::compiler
     TypePtr visit_unit_type(const UnitTypePtr& ty) override;
     TypePtr visit_infer(const InferTypePtr& ty) override;
     TypePtr visit_range_type(const RangeTypePtr& ty) override;
-    TypePtr visit_cown_type(const CownTypePtr& ty) override;
     TypePtr visit_viewpoint_type(const ViewpointTypePtr& ty) override;
     TypePtr visit_has_field_type(const HasFieldTypePtr& ty) override;
     TypePtr

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -82,10 +82,10 @@ namespace verona::compiler
     Rule string_literal = term('"' >> string_body >> '"');
 
     Rule keyword = term(
-      "while"_E | "if" | "class" | "interface" | "var" | "unit" | "match" |
-      "U64" | "String" | "iso" | "mut" | "imm" | "mut-view" | "freeze" | "in" |
-      "cown" | "static_assert" | "not" | "subtype" | "when" | "from" | "where" |
-      "else");
+      "while"_E | "if" | "class" | "interface" | "primitive" | "var" | "unit" |
+      "match" | "U64" | "String" | "iso" | "mut" | "imm" | "mut-view" |
+      "freeze" | "in" | "cown" | "static_assert" | "not" | "subtype" | "when" |
+      "from" | "where" | "else");
 
     Rule self = term("self");
     Rule self_def = self;
@@ -217,7 +217,8 @@ namespace verona::compiler
 
     Rule class_kind = "class"_E;
     Rule interface_kind = "interface"_E;
-    Rule entity_kind = class_kind | interface_kind;
+    Rule primitive_kind = "primitive"_E;
+    Rule entity_kind = class_kind | interface_kind | primitive_kind;
 
     Rule entity =
       trace("entity", entity_kind >> def_ident >> generics >> braces(*member));
@@ -361,6 +362,8 @@ namespace verona::compiler
     BindConstant<Entity::Kind, Entity::Class> class_kind = g.class_kind;
     BindConstant<Entity::Kind, Entity::Interface> interface_kind =
       g.interface_kind;
+    BindConstant<Entity::Kind, Entity::Primitive> primitive_kind =
+      g.primitive_kind;
 
     BindAST<Field> field = g.field;
     BindAST<Entity> entity = g.entity;

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -83,7 +83,7 @@ namespace verona::compiler
 
     Rule keyword = term(
       "while"_E | "if" | "class" | "interface" | "primitive" | "var" | "unit" |
-      "match" | "String" | "iso" | "mut" | "imm" | "mut-view" | "in" | "cown" |
+      "match" | "String" | "iso" | "mut" | "imm" | "mut-view" | "in" |
       "static_assert" | "not" | "subtype" | "when" | "from" | "where" | "else" |
       "builtin");
 
@@ -137,7 +137,6 @@ namespace verona::compiler
     Rule new_parent = "in" >> ref_ident;
     Rule new_expr = "new" >> ref_ident >> -new_parent;
     Rule mut_view_expr = "mut-view" >> expr5;
-    Rule new_cown = "cown" >> ExprPtr(expr1);
     Rule when_clause = "when" >> parens(comma_sep(when_argument)) >> block_expr;
 
     Rule when_argument = when_argument_as | when_argument_shadow;
@@ -170,8 +169,7 @@ namespace verona::compiler
     Rule expr5 =
       symbol_expr | integer_literal_expr | string_literal_expr | parens(expr1);
     Rule expr4 = call | field_expr | expr5;
-    Rule expr3 =
-      binary_operator_expr | new_expr | mut_view_expr | new_cown | expr4;
+    Rule expr3 = binary_operator_expr | new_expr | mut_view_expr | expr4;
     Rule expr2 = if_expr | match_expr | when_clause | block_expr | expr3;
     Rule expr1 =
       define_local | assign_local | assign_field | while_loop | expr2;
@@ -184,14 +182,12 @@ namespace verona::compiler
     Rule capability_type = capability_kind;
     Rule string_type = "String"_E;
     Rule symbol_type = ref_ident >> -brackets(comma_sep(type));
-    Rule cown_type = "cown" >> brackets(type);
     Rule union_type = sep_by2(type1, "|");
     Rule intersection_type = sep_by2(type1, "&");
     Rule viewpoint_type = type1 >> "->" >> (viewpoint_type | type1);
 
     Rule type1 = parens(type) | symbol_type | capability_type | string_type;
-    Rule type =
-      union_type | intersection_type | viewpoint_type | type1 | cown_type;
+    Rule type = union_type | intersection_type | viewpoint_type | type1;
 
     Rule type_param_kind_class = "class"_E;
     Rule type_param_kind = type_param_kind_class;
@@ -289,7 +285,6 @@ namespace verona::compiler
 
     BindAST<NewParent> new_parent = g.new_parent;
     BindAST<NewExpr> new_expr = g.new_expr;
-    BindAST<NewCownExpr> new_cown = g.new_cown;
 
     BindAST<Argument> argument = g.argument;
 
@@ -327,7 +322,6 @@ namespace verona::compiler
     BindAST<StringTypeExpr> string_type = g.string_type;
     BindAST<IntersectionTypeExpr> intersection_type = g.intersection_type;
     BindAST<SymbolTypeExpr> symbol_type = g.symbol_type;
-    BindAST<CownTypeExpr> cown_type = g.cown_type;
     BindAST<UnionTypeExpr> union_type = g.union_type;
     BindAST<ViewpointTypeExpr> viewpoint_type = g.viewpoint_type;
 

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -85,7 +85,7 @@ namespace verona::compiler
       "while"_E | "if" | "class" | "interface" | "primitive" | "var" | "unit" |
       "match" | "U64" | "String" | "iso" | "mut" | "imm" | "mut-view" |
       "freeze" | "in" | "cown" | "static_assert" | "not" | "subtype" | "when" |
-      "from" | "where" | "else");
+      "from" | "where" | "else" | "builtin");
 
     Rule self = term("self");
     Rule self_def = self;
@@ -210,7 +210,10 @@ namespace verona::compiler
     Rule fn_signature = generics >> function_params >> -(":" >> type) >>
       -ExprPtr(where_clauses);
     Rule fn_body = block;
-    Rule method = def_ident >> fn_signature >> (fn_body | ";");
+
+    Rule method_builtin = "builtin"_E;
+    Rule method = -(method_builtin) >> def_ident >> fn_signature >>
+      (fn_body | ";");
 
     Rule field = def_ident >> ":" >> type >> ";";
     Rule member = trace("member", method | field);
@@ -357,6 +360,8 @@ namespace verona::compiler
 
     BindAST<FnSignature> fn_signature = g.fn_signature;
     BindAST<FnBody> fn_body = g.fn_body;
+    BindConstant<Method::Kind, Method::Builtin> method_builtin =
+      g.method_builtin;
     BindAST<Method> method = g.method;
 
     BindConstant<Entity::Kind, Entity::Class> class_kind = g.class_kind;

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -83,9 +83,9 @@ namespace verona::compiler
 
     Rule keyword = term(
       "while"_E | "if" | "class" | "interface" | "primitive" | "var" | "unit" |
-      "match" | "U64" | "String" | "iso" | "mut" | "imm" | "mut-view" |
-      "freeze" | "in" | "cown" | "static_assert" | "not" | "subtype" | "when" |
-      "from" | "where" | "else" | "builtin");
+      "match" | "String" | "iso" | "mut" | "imm" | "mut-view" | "freeze" |
+      "in" | "cown" | "static_assert" | "not" | "subtype" | "when" | "from" |
+      "where" | "else" | "builtin");
 
     Rule self = term("self");
     Rule self_def = self;
@@ -183,7 +183,6 @@ namespace verona::compiler
 
     Rule capability_kind = isolated | mutable_ | immutable;
     Rule capability_type = capability_kind;
-    Rule integer_type = "U64"_E;
     Rule string_type = "String"_E;
     Rule symbol_type = ref_ident >> -brackets(comma_sep(type));
     Rule cown_type = "cown" >> brackets(type);
@@ -191,8 +190,7 @@ namespace verona::compiler
     Rule intersection_type = sep_by2(type1, "&");
     Rule viewpoint_type = type1 >> "->" >> (viewpoint_type | type1);
 
-    Rule type1 =
-      parens(type) | symbol_type | capability_type | integer_type | string_type;
+    Rule type1 = parens(type) | symbol_type | capability_type | string_type;
     Rule type =
       union_type | intersection_type | viewpoint_type | type1 | cown_type;
 
@@ -328,7 +326,6 @@ namespace verona::compiler
     BindAST<BinaryOperatorExpr> binary_operator_expr = g.binary_operator_expr;
 
     BindAST<CapabilityTypeExpr> capability_type = g.capability_type;
-    BindAST<IntegerTypeExpr> integer_type = g.integer_type;
     BindAST<StringTypeExpr> string_type = g.string_type;
     BindAST<IntersectionTypeExpr> intersection_type = g.intersection_type;
     BindAST<SymbolTypeExpr> symbol_type = g.symbol_type;

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -83,9 +83,9 @@ namespace verona::compiler
 
     Rule keyword = term(
       "while"_E | "if" | "class" | "interface" | "primitive" | "var" | "unit" |
-      "match" | "String" | "iso" | "mut" | "imm" | "mut-view" | "freeze" |
-      "in" | "cown" | "static_assert" | "not" | "subtype" | "when" | "from" |
-      "where" | "else" | "builtin");
+      "match" | "String" | "iso" | "mut" | "imm" | "mut-view" | "in" | "cown" |
+      "static_assert" | "not" | "subtype" | "when" | "from" | "where" | "else" |
+      "builtin");
 
     Rule self = term("self");
     Rule self_def = self;
@@ -137,7 +137,6 @@ namespace verona::compiler
     Rule new_parent = "in" >> ref_ident;
     Rule new_expr = "new" >> ref_ident >> -new_parent;
     Rule mut_view_expr = "mut-view" >> expr5;
-    Rule freeze_expr = "freeze" >> parens(expr1);
     Rule new_cown = "cown" >> ExprPtr(expr1);
     Rule when_clause = "when" >> parens(comma_sep(when_argument)) >> block_expr;
 
@@ -171,8 +170,8 @@ namespace verona::compiler
     Rule expr5 =
       symbol_expr | integer_literal_expr | string_literal_expr | parens(expr1);
     Rule expr4 = call | field_expr | expr5;
-    Rule expr3 = binary_operator_expr | new_expr | mut_view_expr | freeze_expr |
-      new_cown | expr4;
+    Rule expr3 =
+      binary_operator_expr | new_expr | mut_view_expr | new_cown | expr4;
     Rule expr2 = if_expr | match_expr | when_clause | block_expr | expr3;
     Rule expr1 =
       define_local | assign_local | assign_field | while_loop | expr2;
@@ -287,7 +286,6 @@ namespace verona::compiler
     BindAST<MatchArm> match_arm = g.match_arm;
     BindAST<MatchExpr> match_expr = g.match_expr;
     BindAST<ViewExpr> mut_view_expr = g.mut_view_expr;
-    BindAST<FreezeExpr> freeze_expr = g.freeze_expr;
 
     BindAST<NewParent> new_parent = g.new_parent;
     BindAST<NewExpr> new_expr = g.new_expr;

--- a/src/compiler/polarize.cc
+++ b/src/compiler/polarize.cc
@@ -62,11 +62,6 @@ namespace verona::compiler
     }
   }
 
-  TypePtr Polarizer::visit_cown_type(const CownTypePtr& ty, Polarity polarity)
-  {
-    return context_.mk_cown(apply(ty->contents, polarity));
-  }
-
   TypeSignature
   Polarizer::visit_signature(const TypeSignature& signature, Polarity polarity)
   {

--- a/src/compiler/polarize.h
+++ b/src/compiler/polarize.h
@@ -55,7 +55,6 @@ namespace verona::compiler
     TypePtr visit_base_type(const TypePtr& ty, Polarity polarity) final;
     TypePtr visit_infer(const InferTypePtr& ty, Polarity polarity) final;
     TypePtr visit_range_type(const RangeTypePtr& ty, Polarity polarity) final;
-    TypePtr visit_cown_type(const CownTypePtr& ty, Polarity polarity) final;
     TypePtr visit_union(const UnionTypePtr& ty, Polarity polarity) final;
     TypePtr
     visit_intersection(const IntersectionTypePtr& ty, Polarity polarity) final;

--- a/src/compiler/printing.cc
+++ b/src/compiler/printing.cc
@@ -527,6 +527,8 @@ namespace verona::compiler
         return out << "class";
       case Entity::Interface:
         return out << "interface";
+      case Entity::Primitive:
+        return out << "primitive";
 
         EXHAUSTIVE_SWITCH;
     }

--- a/src/compiler/printing.cc
+++ b/src/compiler/printing.cc
@@ -270,10 +270,6 @@ namespace verona::compiler
     {
       print("(is-entity)");
     }
-    void visit_integer_type(const IntegerTypePtr& ty) final
-    {
-      print("(integer)");
-    }
     void visit_string_type(const StringTypePtr& ty) final
     {
       print("(string)");
@@ -351,11 +347,6 @@ namespace verona::compiler
     void visit_type_sequence(const BoundedTypeSequence& seq)
     {
       print("[{}]", comma_sep(seq.types));
-    }
-
-    void visit_integer_type_expr(IntegerTypeExpr& te)
-    {
-      print("(integer)");
     }
 
     void visit_string_type_expr(StringTypeExpr& te)

--- a/src/compiler/printing.cc
+++ b/src/compiler/printing.cc
@@ -165,11 +165,6 @@ namespace verona::compiler
       print("(mut-view {})", *e.expr);
     }
 
-    void visit_freeze_expr(FreezeExpr& e) final
-    {
-      print("(freeze {})", *e.expr);
-    }
-
     void visit_entity_type(const EntityTypePtr& ty) final
     {
       print("{}{}", ty->definition->name, optional_list(ty->arguments));

--- a/src/compiler/printing.cc
+++ b/src/compiler/printing.cc
@@ -139,11 +139,6 @@ namespace verona::compiler
       print("(new {}{})", e.class_name, optional(prefixed(" ", e.parent)));
     }
 
-    void visit_new_cown(NewCownExpr& e) final
-    {
-      print("(cown {})", *e.contents);
-    }
-
     void visit_integer_literal_expr(IntegerLiteralExpr& e) final
     {
       print("(integer {})", e.value.value);
@@ -217,11 +212,6 @@ namespace verona::compiler
     void visit_range_type(const RangeTypePtr& ty) final
     {
       print("({} ... {})", *ty->lower, *ty->upper);
-    }
-
-    void visit_cown_type(const CownTypePtr& ty) final
-    {
-      print("cown [{}]", *ty->contents);
     }
 
     void visit_viewpoint_type(const ViewpointTypePtr& ty) final
@@ -352,11 +342,6 @@ namespace verona::compiler
     void visit_symbol_type_expr(SymbolTypeExpr& te)
     {
       print("{}{}", te.name, optional_list(te.arguments));
-    }
-
-    void visit_cown_type_expr(CownTypeExpr& te)
-    {
-      print("cown [{}]", *te.contents);
     }
 
     void visit_capability_type_expr(CapabilityTypeExpr& te)

--- a/src/compiler/recursive_visitor.h
+++ b/src/compiler/recursive_visitor.h
@@ -174,7 +174,6 @@ namespace verona::compiler
       this->visit_type(ty->inner, args...);
     }
 
-    void visit_integer_type(const IntegerTypePtr& ty, Args... args) override {}
     void visit_string_type(const StringTypePtr& ty, Args... args) override {}
     void visit_type_parameter(const TypeParameterPtr& ty, Args... args) override
     {}

--- a/src/compiler/recursive_visitor.h
+++ b/src/compiler/recursive_visitor.h
@@ -87,10 +87,6 @@ namespace verona::compiler
     {
       this->visit_expr(*expr.expr, args...);
     }
-    void visit_freeze_expr(FreezeExpr& expr, Args... args) override
-    {
-      this->visit_expr(*expr.expr, args...);
-    }
     void visit_new_expr(NewExpr& expr, Args... args) override {}
     void visit_new_cown(NewCownExpr& expr, Args... args) override
     {

--- a/src/compiler/recursive_visitor.h
+++ b/src/compiler/recursive_visitor.h
@@ -88,10 +88,6 @@ namespace verona::compiler
       this->visit_expr(*expr.expr, args...);
     }
     void visit_new_expr(NewExpr& expr, Args... args) override {}
-    void visit_new_cown(NewCownExpr& expr, Args... args) override
-    {
-      this->visit_expr(*expr.contents, args...);
-    }
 
     void visit_symbol(SymbolExpr& expr, Args... args) override {}
     void visit_empty(EmptyExpr& expr, Args... args) override {}
@@ -140,11 +136,6 @@ namespace verona::compiler
     {
       this->visit_type(ty->lower, args...);
       this->visit_type(ty->upper, args...);
-    }
-
-    void visit_cown_type(const CownTypePtr& ty, Args... args) override
-    {
-      this->visit_type(ty->contents, args...);
     }
 
     void visit_has_field_type(const HasFieldTypePtr& ty, Args... args) override

--- a/src/compiler/regionck/check_regions.h
+++ b/src/compiler/regionck/check_regions.h
@@ -82,15 +82,6 @@ namespace verona::compiler
       const TypeAssignment& assignment,
       const RegionGraph& graph,
       const LivenessReasonState& live_out,
-      const NewCownStmt& stmt)
-    {
-      consume_variable(assignment, graph, live_out, stmt.input);
-    }
-
-    void visit_stmt(
-      const TypeAssignment& assignment,
-      const RegionGraph& graph,
-      const LivenessReasonState& live_out,
       const MatchBindStmt& stmt)
     {}
 

--- a/src/compiler/regionck/check_regions.h
+++ b/src/compiler/regionck/check_regions.h
@@ -137,15 +137,6 @@ namespace verona::compiler
       const TypeAssignment& assignment,
       const RegionGraph& graph,
       const LivenessReasonState& live_out,
-      const FreezeStmt& stmt)
-    {
-      consume_variable(assignment, graph, live_out, stmt.input);
-    }
-
-    void visit_stmt(
-      const TypeAssignment& assignment,
-      const RegionGraph& graph,
-      const LivenessReasonState& live_out,
       const CopyStmt& stmt)
     {
       consume_variable(assignment, graph, live_out, stmt.input);

--- a/src/compiler/resolution.cc
+++ b/src/compiler/resolution.cc
@@ -305,7 +305,9 @@ namespace verona::compiler
                 method->parent->name);
             }
 
-            if (method->parent->kind->value() == Entity::Primitive)
+            if (
+              !method->body &&
+              method->parent->kind->value() == Entity::Primitive)
             {
               report(
                 context_,

--- a/src/compiler/resolution.cc
+++ b/src/compiler/resolution.cc
@@ -474,12 +474,6 @@ namespace verona::compiler
       return context_.mk_string_type();
     }
 
-    TypePtr visit_cown_type_expr(CownTypeExpr& te)
-    {
-      // TODO warning/error if contents contains permissions.
-      return context_.mk_cown(visit_type_expression(*te.contents));
-    }
-
     TypePtr visit_symbol_type_expr(SymbolTypeExpr& te)
     {
       te.symbol = resolve(te.name);

--- a/src/compiler/resolution.cc
+++ b/src/compiler/resolution.cc
@@ -467,11 +467,6 @@ namespace verona::compiler
       push_scope([&]() { visit_expr(*expr.inner); });
     }
 
-    TypePtr visit_integer_type_expr(IntegerTypeExpr& te)
-    {
-      return context_.mk_integer_type();
-    }
-
     TypePtr visit_string_type_expr(StringTypeExpr& te)
     {
       return context_.mk_string_type();

--- a/src/compiler/resolution.cc
+++ b/src/compiler/resolution.cc
@@ -302,6 +302,17 @@ namespace verona::compiler
             method->parent->name);
         }
 
+        if (method->parent->kind->value() == Entity::Primitive && !method->body)
+        {
+          report(
+            context_,
+            method->name,
+            DiagnosticKind::Error,
+            Diagnostic::MissingMethodBodyInPrimitive,
+            method->name,
+            method->parent->name);
+        }
+
         if (method->body)
           visit_expr(*method->body->expression);
       });
@@ -309,6 +320,12 @@ namespace verona::compiler
 
     void visit_field(Field* fld) final
     {
+      if (fld->parent->kind->value() == Entity::Primitive)
+      {
+        report(
+          context_, *fld, DiagnosticKind::Error, Diagnostic::FieldInPrimitive);
+      }
+
       fld->type = visit_type_expression(*fld->type_expression);
     }
 

--- a/src/compiler/source_manager.h
+++ b/src/compiler/source_manager.h
@@ -230,6 +230,9 @@ namespace verona::compiler
        */
       MissingMethodBodyInPrimitive,
       /**
+       */
+      BuiltinMethodHasBody,
+      /**
        * A primitive has a field.
        */
       FieldInPrimitive,
@@ -333,6 +336,8 @@ namespace verona::compiler
           return "Method '{}' in class '{}' must have a body";
         case Diagnostic::MissingMethodBodyInPrimitive:
           return "Method '{}' in primitive '{}' must have a body";
+        case Diagnostic::BuiltinMethodHasBody:
+          return "Builtin method '{}' in '{}' must not have a body";
         case Diagnostic::FieldInPrimitive:
           return "Primitives cannot have fields";
         case Diagnostic::InferenceFailedForMethod:

--- a/src/compiler/source_manager.h
+++ b/src/compiler/source_manager.h
@@ -226,6 +226,14 @@ namespace verona::compiler
        */
       MissingMethodBodyInClass,
       /**
+       * A primitive's method has no body.
+       */
+      MissingMethodBodyInPrimitive,
+      /**
+       * A primitive has a field.
+       */
+      FieldInPrimitive,
+      /**
        * Type inference failed for method.
        */
       InferenceFailedForMethod,
@@ -323,6 +331,10 @@ namespace verona::compiler
           return "Static assertion failed, '{}' is a subtype of '{}'";
         case Diagnostic::MissingMethodBodyInClass:
           return "Method '{}' in class '{}' must have a body";
+        case Diagnostic::MissingMethodBodyInPrimitive:
+          return "Method '{}' in primitive '{}' must have a body";
+        case Diagnostic::FieldInPrimitive:
+          return "Primitives cannot have fields";
         case Diagnostic::InferenceFailedForMethod:
           return "Inference failed for method {}";
         case Diagnostic::FinaliserHasNoParameters:

--- a/src/compiler/source_manager.h
+++ b/src/compiler/source_manager.h
@@ -206,10 +206,6 @@ namespace verona::compiler
        */
       TypeNotWritable,
       /**
-       * Trying to make cown from no iso state.
-       */
-      TypeNotIsolatedForCown,
-      /**
        * Trying to send an unsendable type.
        */
       TypeNotSendableForWhen,
@@ -323,8 +319,6 @@ namespace verona::compiler
           return "Type '{}' is not readable";
         case Diagnostic::TypeNotWritable:
           return "Type '{}' is not writable";
-        case Diagnostic::TypeNotIsolatedForCown:
-          return "Type '{}' is not isolated for cown creation";
         case Diagnostic::TypeNotSendableForWhen:
           return "Type '{}' is not sendable for when clause for captured "
                  "variable: {}";

--- a/src/compiler/type.h
+++ b/src/compiler/type.h
@@ -491,19 +491,6 @@ namespace verona::compiler
   };
   typedef std::shared_ptr<const IsEntityType> IsEntityTypePtr;
 
-  struct IntegerType final : public Type
-  {
-    bool operator<(const IntegerType& other) const
-    {
-      return false;
-    }
-
-  private:
-    IntegerType() {}
-    friend TypeInterner;
-  };
-  typedef std::shared_ptr<const IntegerType> IntegerTypePtr;
-
   struct StringType final : public Type
   {
     bool operator<(const StringType& other) const

--- a/src/compiler/type.h
+++ b/src/compiler/type.h
@@ -226,22 +226,6 @@ namespace verona::compiler
   };
   typedef std::shared_ptr<const ViewpointType> ViewpointTypePtr;
 
-  struct CownType final : public Type
-  {
-    TypePtr contents;
-
-    bool operator<(const CownType& other) const
-    {
-      return contents < other.contents;
-    }
-
-  private:
-    CownType(TypePtr contents) : contents(contents) {}
-    friend TypeInterner;
-  };
-
-  typedef std::shared_ptr<const CownType> CownTypePtr;
-
   struct IntersectionType;
   struct UnionType;
   typedef std::shared_ptr<const UnionType> UnionTypePtr;

--- a/src/compiler/typecheck/capability_predicate.cc
+++ b/src/compiler/typecheck/capability_predicate.cc
@@ -23,7 +23,7 @@ namespace verona::compiler
   {
     return CapabilityPredicate::Readable | CapabilityPredicate::Writable |
       CapabilityPredicate::NonWritable | CapabilityPredicate::NonLinear |
-      CapabilityPredicate::Cownable | CapabilityPredicate::Sendable;
+      CapabilityPredicate::Sendable;
   }
 
   bool PredicateSet::contains(CapabilityPredicate predicate) const
@@ -61,8 +61,7 @@ namespace verona::compiler
           if (std::holds_alternative<RegionNone>(type->region))
           {
             return CapabilityPredicate::Readable |
-              CapabilityPredicate::Writable | CapabilityPredicate::Cownable |
-              CapabilityPredicate::Sendable;
+              CapabilityPredicate::Writable | CapabilityPredicate::Sendable;
           }
           else
           {
@@ -105,10 +104,6 @@ namespace verona::compiler
     }
 
     PredicateSet visit_static_type(const StaticTypePtr& type) final
-    {
-      return CapabilityPredicate::Sendable | CapabilityPredicate::NonLinear;
-    }
-    PredicateSet visit_cown_type(const CownTypePtr& type) final
     {
       return CapabilityPredicate::Sendable | CapabilityPredicate::NonLinear;
     }
@@ -166,8 +161,6 @@ namespace verona::compiler
         return out << "writable";
       case CapabilityPredicate::NonWritable:
         return out << "non-writable";
-      case CapabilityPredicate::Cownable:
-        return out << "cownable";
       case CapabilityPredicate::Sendable:
         return out << "sendable";
       case CapabilityPredicate::NonLinear:

--- a/src/compiler/typecheck/capability_predicate.cc
+++ b/src/compiler/typecheck/capability_predicate.cc
@@ -112,10 +112,6 @@ namespace verona::compiler
     {
       return CapabilityPredicate::Sendable | CapabilityPredicate::NonLinear;
     }
-    PredicateSet visit_integer_type(const IntegerTypePtr& type) final
-    {
-      return CapabilityPredicate::Sendable | CapabilityPredicate::NonLinear;
-    }
     PredicateSet visit_string_type(const StringTypePtr& type) final
     {
       return CapabilityPredicate::Sendable | CapabilityPredicate::NonLinear;

--- a/src/compiler/typecheck/capability_predicate.h
+++ b/src/compiler/typecheck/capability_predicate.h
@@ -29,8 +29,7 @@ namespace verona::compiler
     Writable = 2,
     NonWritable = 4,
     NonLinear = 8,
-    Cownable = 16,
-    Sendable = 32,
+    Sendable = 16,
   };
 
   /**

--- a/src/compiler/typecheck/constraint.cc
+++ b/src/compiler/typecheck/constraint.cc
@@ -351,18 +351,6 @@ namespace verona::compiler
     }
 
     /*
-     * --------------
-     *   U64 <: U64
-     */
-    if (auto left = c.left->dyncast<IntegerType>())
-    {
-      if (auto right = c.right->dyncast<IntegerType>())
-      {
-        return Trivial();
-      }
-    }
-
-    /*
      * --------------------
      *   String <: String
      */
@@ -545,8 +533,8 @@ namespace verona::compiler
       // TODO: the definition of what an "entity-like" type is is kind of
       // scattered around the code-base.
       if (
-        c.left->dyncast<EntityType>() || c.left->dyncast<IntegerType>() ||
-        c.left->dyncast<StringType>() || c.left->dyncast<CownType>())
+        c.left->dyncast<EntityType>() || c.left->dyncast<StringType>() ||
+        c.left->dyncast<CownType>())
       {
         return Trivial();
       }
@@ -740,9 +728,8 @@ namespace verona::compiler
       {
         // These are types that are used without any capability.
         if (
-          c.left->dyncast<IntegerType>() || c.left->dyncast<CownType>() ||
-          c.left->dyncast<StaticType>() || c.left->dyncast<StringType>() ||
-          c.left->dyncast<UnitType>())
+          c.left->dyncast<CownType>() || c.left->dyncast<StaticType>() ||
+          c.left->dyncast<StringType>() || c.left->dyncast<UnitType>())
           return Trivial();
 
         if (auto left_cap = c.left->dyncast<CapabilityType>())

--- a/src/compiler/typecheck/constraint.cc
+++ b/src/compiler/typecheck/constraint.cc
@@ -70,6 +70,26 @@ namespace verona::compiler
     }
 
     /*
+     * -----------------------
+     *   α+ <: entity-of(α-)
+     */
+    if (auto right = c.right->dyncast<EntityOfType>())
+    {
+      if (auto infer_right = right->inner->dyncast<InferType>())
+      {
+        if (auto left = c.left->dyncast<InferType>())
+        {
+          if (
+            left->index == infer_right->index &&
+            left->subindex == infer_right->subindex)
+          {
+            return Trivial();
+          }
+        }
+      }
+    }
+
+    /*
      *     T1 <: T2
      *     T1 <: T3
      * -----------------
@@ -163,22 +183,6 @@ namespace verona::compiler
       else
       {
         return Substitution(var, context.mk_intersection(var, c.right));
-      }
-    }
-
-    /*
-     * Cown types have covariant type arguments.
-     *
-     *         T1 <: T2
-     * ------------------------
-     *  cown [T1] <: cown [T2]
-     *
-     */
-    if (auto left = c.left->dyncast<CownType>())
-    {
-      if (auto right = c.right->dyncast<CownType>())
-      {
-        return Compound(c, context).add(left->contents, right->contents);
       }
     }
 
@@ -465,8 +469,13 @@ namespace verona::compiler
 
     /**
      *
-     * ---------------------- subst [ (α+ | T) / α+ ]
+     * ---------------------- subst [ (α+ | C) / α+ ]
      *   C <: entity-of(-α)
+     *
+     * TODO: Is the following sound?
+     *
+     * ---------------------- subst [ (α+ | X) / α+ ]
+     *   X <: entity-of(-α)
      *
      * TODO: Could we generalise this to
      *
@@ -478,24 +487,21 @@ namespace verona::compiler
     {
       if (auto infer = right->inner->dyncast<InferType>())
       {
-        if (auto left = c.left->dyncast<EntityType>())
+        if (c.left->dyncast<EntityType>() || c.left->dyncast<TypeParameter>())
         {
           InferTypePtr var = reverse_polarity(infer, context);
 
-          if (context.free_variables(left).contains(var))
-            return Substitution(var, context.mk_union(var, left));
-          else
+          if (context.free_variables(c.left).contains(var))
+          {
             return Substitution(
               var,
               context.mk_fixpoint(
-                context.mk_union(var, close_fixpoint(context, var, left))));
-        }
-
-        if (auto left = c.left->dyncast<TypeParameter>())
-        {
-          InferTypePtr var = reverse_polarity(infer, context);
-          return Substitution(
-            var, context.mk_union(var, context.mk_entity_of(left)));
+                context.mk_union(var, close_fixpoint(context, var, c.left))));
+          }
+          else
+          {
+            return Substitution(var, context.mk_union(var, c.left));
+          }
         }
       }
     }
@@ -529,19 +535,15 @@ namespace verona::compiler
      * -------------------
      *  C[T] <: is-entity
      *
-     * ------------------
-     *  U64 <: is-entity
+     * ---------------------
+     *  String <: is-entity
      *
-     * ----------------------
-     *  cown[T] <: is-entity
      */
     if (c.right->dyncast<IsEntityType>())
     {
       // TODO: the definition of what an "entity-like" type is is kind of
       // scattered around the code-base.
-      if (
-        c.left->dyncast<EntityType>() || c.left->dyncast<StringType>() ||
-        c.left->dyncast<CownType>())
+      if (c.left->dyncast<EntityType>() || c.left->dyncast<StringType>())
       {
         return Trivial();
       }
@@ -726,7 +728,6 @@ namespace verona::compiler
        *      iso() <: !child-of(y)
        *       x->T <: !child-of(y)
        *        U64 <: !child-of(y)
-       *    cown[T] <: !child-of(y)
        *   static E <: !child-of(y)
        *     String <: !child-of(y)
        *       unit <: !child-of(y)
@@ -735,8 +736,8 @@ namespace verona::compiler
       {
         // These are types that are used without any capability.
         if (
-          c.left->dyncast<CownType>() || c.left->dyncast<StaticType>() ||
-          c.left->dyncast<StringType>() || c.left->dyncast<UnitType>())
+          c.left->dyncast<StaticType>() || c.left->dyncast<StringType>() ||
+          c.left->dyncast<UnitType>())
           return Trivial();
 
         if (auto left_cap = c.left->dyncast<CapabilityType>())

--- a/src/compiler/typecheck/constraint.cc
+++ b/src/compiler/typecheck/constraint.cc
@@ -490,6 +490,13 @@ namespace verona::compiler
               context.mk_fixpoint(
                 context.mk_union(var, close_fixpoint(context, var, left))));
         }
+
+        if (auto left = c.left->dyncast<TypeParameter>())
+        {
+          InferTypePtr var = reverse_polarity(infer, context);
+          return Substitution(
+            var, context.mk_union(var, context.mk_entity_of(left)));
+        }
       }
     }
 

--- a/src/compiler/typecheck/infer.cc
+++ b/src/compiler/typecheck/infer.cc
@@ -527,21 +527,6 @@ namespace verona::compiler
     void visit_stmt(
       TypeAssignment& assignment,
       std::vector<Variable>& dead_variables,
-      const FreezeStmt& stmt)
-    {
-      TypePtr input = get_type(assignment, stmt.input);
-      TypePtr entity = context_.mk_entity_of(input);
-
-      add_constraint(input, context_.mk_isolated(RegionNone()), "freeze");
-      set_type(
-        assignment,
-        stmt.output,
-        context_.mk_intersection(entity, context_.mk_immutable()));
-    }
-
-    void visit_stmt(
-      TypeAssignment& assignment,
-      std::vector<Variable>& dead_variables,
       const EndScopeStmt& stmt)
     {
       std::copy(

--- a/src/compiler/typecheck/infer.h
+++ b/src/compiler/typecheck/infer.h
@@ -26,6 +26,7 @@ namespace verona::compiler
 
   std::unique_ptr<InferResults> infer(
     Context& context,
+    const Program& program,
     const Method& method,
     const MethodIR& ir,
     const LivenessAnalysis& liveness);

--- a/src/compiler/typecheck/permission_check.cc
+++ b/src/compiler/typecheck/permission_check.cc
@@ -41,21 +41,6 @@ namespace verona::compiler
 
     void visit_stmt(const TypeAssignment& assignment, const NewStmt& stmt) {}
 
-    void visit_stmt(const TypeAssignment& assignment, const NewCownStmt& stmt)
-    {
-      const TypePtr& base_type = assignment.at(stmt.input);
-      PredicateSet predicates = predicates_for_type(base_type);
-      if (!predicates.contains(CapabilityPredicate::Cownable))
-      {
-        report(
-          context_,
-          stmt.source_range,
-          DiagnosticKind::Error,
-          Diagnostic::TypeNotIsolatedForCown,
-          *base_type);
-      }
-    }
-
     void visit_stmt(const TypeAssignment& assignment, const MatchBindStmt& stmt)
     {}
 

--- a/src/compiler/typecheck/permission_check.cc
+++ b/src/compiler/typecheck/permission_check.cc
@@ -94,8 +94,6 @@ namespace verona::compiler
       }
     }
 
-    void visit_stmt(const TypeAssignment& assignment, const FreezeStmt& stmt) {}
-
     void visit_stmt(const TypeAssignment& assignment, const CopyStmt& stmt) {}
 
     void

--- a/src/compiler/visitor.h
+++ b/src/compiler/visitor.h
@@ -114,10 +114,6 @@ namespace verona::compiler
       {
         return visit_view_expr(*expr_, std::forward<Args>(args)...);
       }
-      else if (auto expr_ = dynamic_cast<FreezeExpr*>(&expr))
-      {
-        return visit_freeze_expr(*expr_, std::forward<Args>(args)...);
-      }
       else if (auto expr_ = dynamic_cast<BinaryOperatorExpr*>(&expr))
       {
         return visit_binary_operator_expr(*expr_, std::forward<Args>(args)...);
@@ -217,10 +213,6 @@ namespace verona::compiler
       return visit_base_expr(expr, std::forward<Args>(args)...);
     }
     virtual Return visit_view_expr(ViewExpr& expr, Args... args)
-    {
-      return visit_base_expr(expr, std::forward<Args>(args)...);
-    }
-    virtual Return visit_freeze_expr(FreezeExpr& expr, Args... args)
     {
       return visit_base_expr(expr, std::forward<Args>(args)...);
     }

--- a/src/compiler/visitor.h
+++ b/src/compiler/visitor.h
@@ -98,10 +98,6 @@ namespace verona::compiler
       {
         return visit_new_expr(*expr_, std::forward<Args>(args)...);
       }
-      else if (auto expr_ = dynamic_cast<NewCownExpr*>(&expr))
-      {
-        return visit_new_cown(*expr_, std::forward<Args>(args)...);
-      }
       else if (auto expr_ = dynamic_cast<IntegerLiteralExpr*>(&expr))
       {
         return visit_integer_literal_expr(*expr_, std::forward<Args>(args)...);
@@ -193,10 +189,6 @@ namespace verona::compiler
     {
       return visit_base_expr(expr, std::forward<Args>(args)...);
     }
-    virtual Return visit_new_cown(NewCownExpr& expr, Args... args)
-    {
-      return visit_base_expr(expr, std::forward<Args>(args)...);
-    }
     virtual Return
     visit_integer_literal_expr(IntegerLiteralExpr& expr, Args... args)
     {
@@ -278,10 +270,6 @@ namespace verona::compiler
       else if (auto ty_ = ty->dyncast<RangeType>())
       {
         return visit_range_type(ty_, std::forward<Args>(args)...);
-      }
-      else if (auto ty_ = ty->dyncast<CownType>())
-      {
-        return visit_cown_type(ty_, std::forward<Args>(args)...);
       }
       else if (auto ty_ = ty->dyncast<ViewpointType>())
       {
@@ -410,10 +398,6 @@ namespace verona::compiler
     {
       return visit_base_type(ty, std::forward<Args>(args)...);
     }
-    virtual Return visit_cown_type(const CownTypePtr& ty, Args... args)
-    {
-      return visit_base_type(ty, std::forward<Args>(args)...);
-    }
     virtual Return
     visit_viewpoint_type(const ViewpointTypePtr& ty, Args... args)
     {
@@ -494,10 +478,6 @@ namespace verona::compiler
       {
         return visit_symbol_type_expr(*expr_, std::forward<Args>(args)...);
       }
-      else if (auto expr_ = dynamic_cast<CownTypeExpr*>(&te))
-      {
-        return visit_cown_type_expr(*expr_, std::forward<Args>(args)...);
-      }
       else if (auto expr_ = dynamic_cast<UnionTypeExpr*>(&te))
       {
         return visit_union_type_expr(*expr_, std::forward<Args>(args)...);
@@ -539,10 +519,6 @@ namespace verona::compiler
       return visit_base_type_expression(te, std::forward<Args>(args)...);
     }
     virtual Return visit_symbol_type_expr(SymbolTypeExpr& te, Args... args)
-    {
-      return visit_base_type_expression(te, std::forward<Args>(args)...);
-    }
-    virtual Return visit_cown_type_expr(CownTypeExpr& te, Args... args)
     {
       return visit_base_type_expression(te, std::forward<Args>(args)...);
     }

--- a/src/compiler/visitor.h
+++ b/src/compiler/visitor.h
@@ -315,10 +315,6 @@ namespace verona::compiler
       {
         return visit_is_entity_type(ty_, std::forward<Args>(args)...);
       }
-      else if (auto ty_ = ty->dyncast<IntegerType>())
-      {
-        return visit_integer_type(ty_, std::forward<Args>(args)...);
-      }
       else if (auto ty_ = ty->dyncast<StringType>())
       {
         return visit_string_type(ty_, std::forward<Args>(args)...);
@@ -454,10 +450,6 @@ namespace verona::compiler
     {
       return visit_base_type(ty, std::forward<Args>(args)...);
     }
-    virtual Return visit_integer_type(const IntegerTypePtr& ty, Args... args)
-    {
-      return visit_base_type(ty, std::forward<Args>(args)...);
-    }
     virtual Return visit_string_type(const StringTypePtr& ty, Args... args)
     {
       return visit_base_type(ty, std::forward<Args>(args)...);
@@ -502,10 +494,6 @@ namespace verona::compiler
   public:
     virtual Return visit_type_expression(TypeExpression& te, Args... args)
     {
-      if (auto expr_ = dynamic_cast<IntegerTypeExpr*>(&te))
-      {
-        return visit_integer_type_expr(*expr_, std::forward<Args>(args)...);
-      }
       if (auto expr_ = dynamic_cast<StringTypeExpr*>(&te))
       {
         return visit_string_type_expr(*expr_, std::forward<Args>(args)...);
@@ -553,10 +541,6 @@ namespace verona::compiler
         typeid(te).name(),
         typeid(*this).name());
       abort();
-    }
-    virtual Return visit_integer_type_expr(IntegerTypeExpr& te, Args... args)
-    {
-      return visit_base_type_expression(te, std::forward<Args>(args)...);
     }
     virtual Return visit_string_type_expr(StringTypeExpr& te, Args... args)
     {

--- a/src/interpreter/bytecode.h
+++ b/src/interpreter/bytecode.h
@@ -203,7 +203,7 @@ namespace verona::bytecode
   {
     using Operands =
       OpcodeOperands<Register, BinaryOperator, Register, Register>;
-    constexpr static std::string_view format = "{} {}, {}, {}";
+    constexpr static std::string_view format = "{1} {0}, {2}, {3}";
   };
 
   template<>

--- a/src/interpreter/bytecode.h
+++ b/src/interpreter/bytecode.h
@@ -13,17 +13,19 @@
  * Bytecode has the following layout:
  *
  * Program header:
- * - 32-bit absolute offset of the entrypoint
- * - 16-bit number of descriptors
+ * - 32-bit number of descriptors, followed by that many descriptors (see below)
+ * - 32-bit descriptor index of Main class
+ * - 32-bit selector index of main method
  *
  * Descriptor:
  * - 16-bit name length, followed by the name bytes
- * - 16-bit size of the fields vtable
- * - 16-bit number of fields
- * - 16-bit size of the methods vtables
- * - 16-bit number of methods
- * - For each field, 16-bit selector index
- * - For each method, 16-bit selector index and 32-bit absolute offset
+ * - 32-bit size of the fields vtable
+ * - 32-bit number of fields
+ * - 32-bit size of the methods vtables
+ * - 32-bit number of methods
+ * - 32-bit offset to finaliser
+ * - For each field, 32-bit selector index
+ * - For each method, 32-bit selector index and 32-bit absolute offset
  *
  * Methods:
  * - 16-bit name length, followed by the name bytes
@@ -35,7 +37,7 @@
  *   instruction data
  *
  * All integers are little-endian format. There is no padding or alignment
- * anywhere. Descriptors must immediately follow the program header.
+ * anywhere.
  *
  * # Instruction encoding
  *

--- a/src/interpreter/bytecode.h
+++ b/src/interpreter/bytecode.h
@@ -16,6 +16,7 @@
  * - 32-bit number of descriptors, followed by that many descriptors (see below)
  * - 32-bit descriptor index of Main class
  * - 32-bit selector index of main method
+ * - 32-bit descriptor index of U64 class (optional)
  *
  * Descriptor:
  * - 16-bit name length, followed by the name bytes
@@ -117,6 +118,9 @@ namespace verona::bytecode
   typedef uint32_t DescriptorIdx;
   typedef uint32_t SelectorIdx;
   typedef uint32_t CodePtr;
+
+  static constexpr DescriptorIdx INVALID_DESCRIPTOR =
+    std::numeric_limits<DescriptorIdx>::max();
 
   struct FunctionHeader
   {

--- a/src/interpreter/bytecode.h
+++ b/src/interpreter/bytecode.h
@@ -161,9 +161,9 @@ namespace verona::bytecode
     Move, // dst(u8), src(u8)
     MutView, // dst(u8), src(u8)
     New, // dst(u8), region(u8), descriptor(u8)
-    NewCown, // dst(u8), src(u8)
+    NewCown, // dst(u8), descriptor(u8), src(u8)
     NewRegion, // dst(u8), descriptor(u8)
-    NewSleepingCown, // dst(u8)
+    NewSleepingCown, // dst(u8), descriptor(u8)
     Print, // format(u8), argc(u8), args(u8)...
     Return,
     Store, // dst(u8), base(u8), selector(u32), src(u8)
@@ -318,15 +318,15 @@ namespace verona::bytecode
   template<>
   struct OpcodeSpec<Opcode::NewCown>
   {
-    using Operands = OpcodeOperands<Register, Register>;
-    constexpr static std::string_view format = "NEW_COWN {}, {}";
+    using Operands = OpcodeOperands<Register, Register, Register>;
+    constexpr static std::string_view format = "NEW_COWN {}, {}, {}";
   };
 
   template<>
   struct OpcodeSpec<Opcode::NewSleepingCown>
   {
-    using Operands = OpcodeOperands<Register>;
-    constexpr static std::string_view format = "NEW_SLEEPING_COWN {}";
+    using Operands = OpcodeOperands<Register, Register>;
+    constexpr static std::string_view format = "NEW_SLEEPING_COWN {} {}";
   };
 
   template<>

--- a/src/interpreter/code.h
+++ b/src/interpreter/code.h
@@ -26,6 +26,7 @@ namespace verona::interpreter
   {
     const VMDescriptor* main;
     SelectorIdx main_selector;
+    const VMDescriptor* u64;
   };
 
   class Code
@@ -144,6 +145,8 @@ namespace verona::interpreter
 
       special_descriptors_.main = get_descriptor(load<DescriptorIdx>(ip));
       special_descriptors_.main_selector = load<SelectorIdx>(ip);
+      special_descriptors_.u64 =
+        get_optional_descriptor(load<DescriptorIdx>(ip));
     }
 
     const std::vector<std::unique_ptr<const VMDescriptor>>& descriptors()
@@ -171,6 +174,14 @@ namespace verona::interpreter
         throw std::logic_error(s.str());
       }
       return descriptors_.at(desc).get();
+    }
+
+    const VMDescriptor* get_optional_descriptor(DescriptorIdx desc) const
+    {
+      if (desc == bytecode::INVALID_DESCRIPTOR)
+        return nullptr;
+      else
+        return get_descriptor(desc);
     }
 
   private:

--- a/src/interpreter/format.h
+++ b/src/interpreter/format.h
@@ -80,11 +80,18 @@ private:
       }
 
       case Value::COWN:
-        return fmt::format_to(it, "cown({})", fmt::ptr(inner.cown->contents));
+        return fmt::format_to(
+          it,
+          "{}({})",
+          inner.cown->descriptor->name,
+          fmt::ptr(inner.cown->contents));
 
       case Value::COWN_UNOWNED:
         return fmt::format_to(
-          it, "cown_unowned({})", fmt::ptr(inner.cown->contents));
+          it,
+          "unowned-{}({})",
+          inner.cown->descriptor->name,
+          fmt::ptr(inner.cown->contents));
 
       case Value::U64:
         return fmt::format_to(it, "{}", inner.u64);

--- a/src/interpreter/interpreter.cc
+++ b/src/interpreter/interpreter.cc
@@ -41,9 +41,12 @@ namespace verona::interpreter
 
     rt::Cown* cown = new EmptyCown();
 
-    // Args initially empty
+    // The entrypoint is a static function, so we pass the Main descriptor as
+    // the receiver. This matches the usual calling convention for static
+    // methods.
     // TODO: Should this contain command line arguments in the future?
     std::vector<Value> args;
+    args.push_back(Value::descriptor(code.special_descriptors().main));
 
     rt::Cown::schedule<ExecuteMessage>(cown, ip, std::move(args), 0);
 

--- a/src/interpreter/object.cc
+++ b/src/interpreter/object.cc
@@ -13,12 +13,12 @@ namespace verona::interpreter
     size_t method_slots,
     size_t field_slots,
     size_t field_count,
-    uint32_t finaliser_slot)
+    uint32_t finaliser_ip)
   : name(name),
     methods(std::make_unique<uint32_t[]>(method_slots)),
     fields(std::make_unique<uint32_t[]>(field_slots)),
     field_count(field_count),
-    finaliser_slot(finaliser_slot)
+    finaliser_ip(finaliser_ip)
   {
     rt::Descriptor::size = sizeof(VMObject);
     rt::Descriptor::trace = VMObject::trace_fn;

--- a/src/interpreter/object.h
+++ b/src/interpreter/object.h
@@ -52,12 +52,16 @@ namespace verona::interpreter
 
   struct VMCown : public rt::VCown<VMCown>
   {
+    // This is the descriptor for cown[T], not for T.
+    // It is used to dispatch methods on the cown itself.
+    const VMDescriptor* descriptor;
     VMObject* contents;
 
     /**
      * contents should be a region entrypoint. VMCown will take ownership of it.
      */
-    explicit VMCown(VMObject* contents) : contents(contents)
+    explicit VMCown(const VMDescriptor* descriptor, VMObject* contents)
+    : descriptor(descriptor), contents(contents)
     {
       assert((contents == nullptr) || contents->debug_is_iso());
     }
@@ -65,7 +69,8 @@ namespace verona::interpreter
     /**
      * This is for promises., the cown should be initially unscheduled.
      */
-    explicit VMCown() : contents(nullptr)
+    explicit VMCown(const VMDescriptor* descriptor)
+    : descriptor(descriptor), contents(nullptr)
     {
       wake();
     }

--- a/src/interpreter/object.h
+++ b/src/interpreter/object.h
@@ -16,13 +16,13 @@ namespace verona::interpreter
       size_t method_slots,
       size_t field_slots,
       size_t field_count,
-      uint32_t finaliser_slot);
+      uint32_t finaliser_ip);
 
     const std::string name;
     const size_t field_count;
     std::unique_ptr<uint32_t[]> fields;
     std::unique_ptr<uint32_t[]> methods;
-    const uint32_t finaliser_slot;
+    const uint32_t finaliser_ip;
   };
 
   struct VMObject : public rt::Object

--- a/src/interpreter/vm.cc
+++ b/src/interpreter/vm.cc
@@ -131,9 +131,10 @@ namespace verona::interpreter
       case Value::IMM:
       case Value::ISO:
         return value->object->descriptor();
-        break;
       case Value::DESCRIPTOR:
         return value->descriptor;
+      case Value::U64:
+        return code_.special_descriptors().u64;
       default:
         fatal("Cannot call method on {}={}", receiver, value);
     }

--- a/src/interpreter/vm.cc
+++ b/src/interpreter/vm.cc
@@ -447,21 +447,14 @@ namespace verona::interpreter
         fmt::print(format, *values[0], *values[1]);
         break;
       case 3:
-        fmt::print(format, *values[0], *values[1], *values[2], *values[3]);
+        fmt::print(format, *values[0], *values[1], *values[2]);
         break;
       case 4:
-        fmt::print(
-          format, *values[0], *values[1], *values[2], *values[3], *values[4]);
+        fmt::print(format, *values[0], *values[1], *values[2], *values[3]);
         break;
       case 5:
         fmt::print(
-          format,
-          *values[0],
-          *values[1],
-          *values[2],
-          *values[3],
-          *values[4],
-          *values[5]);
+          format, *values[0], *values[1], *values[2], *values[3], *values[4]);
         break;
       default:
         fatal("{} is more arguments than opcode_print can handle", argc);

--- a/src/interpreter/vm.h
+++ b/src/interpreter/vm.h
@@ -73,8 +73,9 @@ namespace verona::interpreter
     void opcode_new(
       Register dst, const Value& parent, const VMDescriptor* descriptor);
     void opcode_new_region(Register dst, const VMDescriptor* descriptor);
-    void opcode_new_cown(Register dst, Value src);
-    void opcode_new_sleeping_cown(Register dst);
+    void
+    opcode_new_cown(Register dst, const VMDescriptor* descriptor, Value src);
+    void opcode_new_sleeping_cown(Register dst, const VMDescriptor* descriptor);
     void opcode_print(const Value& src, uint8_t argc);
     void opcode_return();
     void opcode_store(

--- a/src/stdlib/builtin.verona
+++ b/src/stdlib/builtin.verona
@@ -19,17 +19,6 @@ class Builtin {
   builtin print4[T0, T1, T2, T3](format: String, arg0: T0, arg1: T1, arg2: T2, arg3: T3);
   builtin print5[T0, T1, T2, T3, T4](format: String, arg0: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4);
 
-  builtin u64_add(x: U64 & imm, y: U64 & imm): U64 & imm;
-  builtin u64_sub(x: U64 & imm, y: U64 & imm): U64 & imm;
-  builtin u64_lt(x: U64 & imm, y: U64 & imm): U64 & imm;
-  builtin u64_gt(x: U64 & imm, y: U64 & imm): U64 & imm;
-  builtin u64_le(x: U64 & imm, y: U64 & imm): U64 & imm;
-  builtin u64_ge(x: U64 & imm, y: U64 & imm): U64 & imm;
-  builtin u64_eq(x: U64 & imm, y: U64 & imm): U64 & imm;
-  builtin u64_ne(x: U64 & imm, y: U64 & imm): U64 & imm;
-  builtin u64_and(x: U64 & imm, y: U64 & imm): U64 & imm;
-  builtin u64_or(x: U64 & imm, y: U64 & imm): U64 & imm;
-
   // Temporary API to implement promises
   // This should not be used outside the standard library.
   builtin create_sleeping_cown[T](): cown[T];
@@ -96,4 +85,15 @@ class Promise[T]
   }
 }
 
-primitive U64 { }
+primitive U64 {
+  builtin add(self: imm, other: U64 & imm): U64 & imm;
+  builtin sub(self: imm, other: U64 & imm): U64 & imm;
+  builtin lt(self: imm, other: U64 & imm): U64 & imm;
+  builtin gt(self: imm, other: U64 & imm): U64 & imm;
+  builtin le(self: imm, other: U64 & imm): U64 & imm;
+  builtin ge(self: imm, other: U64 & imm): U64 & imm;
+  builtin eq(self: imm, other: U64 & imm): U64 & imm;
+  builtin ne(self: imm, other: U64 & imm): U64 & imm;
+  builtin and(self: imm, other: U64 & imm): U64 & imm;
+  builtin or(self: imm, other: U64 & imm): U64 & imm;
+}

--- a/src/stdlib/builtin.verona
+++ b/src/stdlib/builtin.verona
@@ -19,16 +19,16 @@ class Builtin {
   builtin print4[T0, T1, T2, T3](format: String, arg0: T0, arg1: T1, arg2: T2, arg3: T3);
   builtin print5[T0, T1, T2, T3, T4](format: String, arg0: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4);
 
-  builtin u64_add(x: U64, y: U64): U64;
-  builtin u64_sub(x: U64, y: U64): U64;
-  builtin u64_lt(x: U64, y: U64): U64;
-  builtin u64_gt(x: U64, y: U64): U64;
-  builtin u64_le(x: U64, y: U64): U64;
-  builtin u64_ge(x: U64, y: U64): U64;
-  builtin u64_eq(x: U64, y: U64): U64;
-  builtin u64_ne(x: U64, y: U64): U64;
-  builtin u64_and(x: U64, y: U64): U64;
-  builtin u64_or(x: U64, y: U64): U64;
+  builtin u64_add(x: U64 & imm, y: U64 & imm): U64 & imm;
+  builtin u64_sub(x: U64 & imm, y: U64 & imm): U64 & imm;
+  builtin u64_lt(x: U64 & imm, y: U64 & imm): U64 & imm;
+  builtin u64_gt(x: U64 & imm, y: U64 & imm): U64 & imm;
+  builtin u64_le(x: U64 & imm, y: U64 & imm): U64 & imm;
+  builtin u64_ge(x: U64 & imm, y: U64 & imm): U64 & imm;
+  builtin u64_eq(x: U64 & imm, y: U64 & imm): U64 & imm;
+  builtin u64_ne(x: U64 & imm, y: U64 & imm): U64 & imm;
+  builtin u64_and(x: U64 & imm, y: U64 & imm): U64 & imm;
+  builtin u64_or(x: U64 & imm, y: U64 & imm): U64 & imm;
 
   // Temporary API to implement promises
   // This should not be used outside the standard library.
@@ -56,8 +56,8 @@ class None {
  **/
 class U64Obj
 {
-  v: U64;
-  create(x: U64) : U64Obj & iso
+  v: U64 & imm;
+  create(x: U64 & imm) : U64Obj & iso
   {
     var o = new U64Obj;
     o.v = x;
@@ -95,3 +95,5 @@ class Promise[T]
     Builtin.fulfill_sleeping_cown(self.inner_cown, v); 
   }
 }
+
+primitive U64 { }

--- a/src/stdlib/builtin.verona
+++ b/src/stdlib/builtin.verona
@@ -8,39 +8,37 @@
  * Nothing in here is expected to remain long-term without significant change.
  **/
 
-// Intrinsics that return a result, simply call themselves, which trivially satifies the type.
-// We'll add explicit mechanism for intrinsic in the future. 
 class Builtin {
   // Selection of print functions that simply pass to the underlying C++
   // formatter.  This is a hack to get some examples with output until we have 
   // implemented IO.
-  print(format: String) {}
-  print1[T0](format: String, arg0: T0) {}
-  print2[T0, T1](format: String, arg0: T0, arg1: T1) {}
-  print3[T0, T1, T2](format: String, arg0: T0, arg1: T1, arg2: T2) {}
-  print4[T0, T1, T2, T3](format: String, arg0: T0, arg1: T1, arg2: T2, arg3: T3) {}
-  print5[T0, T1, T2, T3, T4](format: String, arg0: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4) {}
+  builtin print(format: String);
+  builtin print1[T0](format: String, arg0: T0);
+  builtin print2[T0, T1](format: String, arg0: T0, arg1: T1);
+  builtin print3[T0, T1, T2](format: String, arg0: T0, arg1: T1, arg2: T2);
+  builtin print4[T0, T1, T2, T3](format: String, arg0: T0, arg1: T1, arg2: T2, arg3: T3);
+  builtin print5[T0, T1, T2, T3, T4](format: String, arg0: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4);
 
-  u64_add(x: U64, y: U64): U64 { Builtin.u64_add(x, y) }
-  u64_sub(x: U64, y: U64): U64 { Builtin.u64_sub(x, y) }
-  u64_lt(x: U64, y: U64): U64 { Builtin.u64_lt(x, y) }
-  u64_gt(x: U64, y: U64): U64 { Builtin.u64_gt(x, y) }
-  u64_le(x: U64, y: U64): U64 { Builtin.u64_le(x, y) }
-  u64_ge(x: U64, y: U64): U64 { Builtin.u64_ge(x, y) }
-  u64_eq(x: U64, y: U64): U64 { Builtin.u64_eq(x, y) }
-  u64_ne(x: U64, y: U64): U64 { Builtin.u64_ne(x, y) }
-  u64_and(x: U64, y: U64): U64 { Builtin.u64_and(x, y) }
-  u64_or(x: U64, y: U64): U64 { Builtin.u64_or(x, y) }
+  builtin u64_add(x: U64, y: U64): U64;
+  builtin u64_sub(x: U64, y: U64): U64;
+  builtin u64_lt(x: U64, y: U64): U64;
+  builtin u64_gt(x: U64, y: U64): U64;
+  builtin u64_le(x: U64, y: U64): U64;
+  builtin u64_ge(x: U64, y: U64): U64;
+  builtin u64_eq(x: U64, y: U64): U64;
+  builtin u64_ne(x: U64, y: U64): U64;
+  builtin u64_and(x: U64, y: U64): U64;
+  builtin u64_or(x: U64, y: U64): U64;
 
   // Temporary API to implement promises
   // This should not be used outside the standard library.
-  create_sleeping_cown[T](): cown[T] { Builtin.create_sleeping_cown() }
-  fulfill_sleeping_cown[T](x: cown[T], v: T) { Builtin.fulfill_sleeping_cown(x, v) }
+  builtin create_sleeping_cown[T](): cown[T];
+  builtin fulfill_sleeping_cown[T](x: cown[T], v: T);
 
   // This exposes trace on a traceable region
   // TODO: invalidate other references into this region
   // TODO: needs expanding as we add other region allocation strategies
-  trace(x : mut) { }
+  builtin trace(x : mut);
 }
 
 /**

--- a/src/stdlib/builtin.verona
+++ b/src/stdlib/builtin.verona
@@ -24,6 +24,9 @@ class Builtin {
   builtin create_sleeping_cown[T](): cown[T];
   builtin fulfill_sleeping_cown[T](x: cown[T], v: T);
 
+  // Freeze an isolated object graph
+  builtin freeze[class T](x: T & iso): T & imm;
+
   // This exposes trace on a traceable region
   // TODO: invalidate other references into this region
   // TODO: needs expanding as we add other region allocation strategies
@@ -35,7 +38,7 @@ class Builtin {
  **/
 class None {
   create(): None & imm {
-    freeze (new None)
+    Builtin.freeze (new None)
   }
 }
 

--- a/src/stdlib/builtin.verona
+++ b/src/stdlib/builtin.verona
@@ -19,11 +19,6 @@ class Builtin {
   builtin print4[T0, T1, T2, T3](format: String, arg0: T0, arg1: T1, arg2: T2, arg3: T3);
   builtin print5[T0, T1, T2, T3, T4](format: String, arg0: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4);
 
-  // Temporary API to implement promises
-  // This should not be used outside the standard library.
-  builtin create_sleeping_cown[T](): cown[T];
-  builtin fulfill_sleeping_cown[T](x: cown[T], v: T);
-
   // Freeze an isolated object graph
   builtin freeze[class T](x: T & iso): T & imm;
 
@@ -62,29 +57,38 @@ class U64Obj
   }
 }
 
+primitive cown[class T] {
+  builtin create(value: T & iso): cown[T] & imm;
+
+  // Temporary API to implement promises
+  // This should not be used outside the standard library.
+  builtin _create_sleeping(): cown[T] & imm;
+  builtin _fulfill_sleeping(self: imm, v: T & iso);
+}
+
 /**
  * This is the implementation of promises. It should be surfaced more nicely to
  * the programmer, but is type safe.
  **/ 
-class Promise[T]
+class Promise[class T]
 {
-  inner_cown: cown[T];
+  inner_cown: cown[T] & imm;
 
   create(): Promise[T] & iso
   { 
     var p = new Promise;
-    p.inner_cown = Builtin.create_sleeping_cown();
+    p.inner_cown = cown._create_sleeping();
     p
   } 
 
-  wait_handle(self: mut): cown[T]
+  wait_handle(self: mut): cown[T] & imm
   { 
     self.inner_cown
   }
 
   fulfill(self: iso, v: T & iso)
   { 
-    Builtin.fulfill_sleeping_cown(self.inner_cown, v); 
+    (self.inner_cown)._fulfill_sleeping(v); 
   }
 }
 

--- a/testsuite/codegen/compile-fail/main-is-field.verona
+++ b/testsuite/codegen/compile-fail/main-is-field.verona
@@ -2,5 +2,5 @@
 // Licensed under the MIT License.
 // CHECK-L: main-is-field.verona:${LINE:+1}:7: error: Class 'Main' does not have a 'main' method
 class Main {
-  main: U64;
+  main: U64 & imm;
 }

--- a/testsuite/demo/run-pass/bank1.verona
+++ b/testsuite/demo/run-pass/bank1.verona
@@ -19,13 +19,13 @@
  **/
 class BankAccount
 {
-  balance: U64;
+  balance: U64 & imm;
 
   /**
    * Creates a new bank account wrapped in a `cown` with an opening balance
    * from the supplied argument.
    **/
-  create(opening_balance: U64): cown[BankAccount]
+  create(opening_balance: U64 & imm): cown[BankAccount]
   {
     // Create a new BankAccount object
     var account = new BankAccount;
@@ -44,7 +44,7 @@ class BankAccount
    * will have been scheduled.  Work on a single cown is always processed in
    * the order it is scheduled.
    **/
-  add(account: cown[BankAccount], amount: U64)
+  add(account: cown[BankAccount], amount: U64 & imm)
   {
     /**
      * The syntax `when (account) { C }` means, when exclusive access to
@@ -62,7 +62,7 @@ class BankAccount
 
 class Main
 {
-  example(start: U64)
+  example(start: U64 & imm)
   {
     // Allocates a fresh bank account
     var s = BankAccount.create(start);

--- a/testsuite/demo/run-pass/bank1.verona
+++ b/testsuite/demo/run-pass/bank1.verona
@@ -25,14 +25,14 @@ class BankAccount
    * Creates a new bank account wrapped in a `cown` with an opening balance
    * from the supplied argument.
    **/
-  create(opening_balance: U64 & imm): cown[BankAccount]
+  create(opening_balance: U64 & imm): cown[BankAccount] & imm
   {
     // Create a new BankAccount object
     var account = new BankAccount;
     // Update its balance
     account.balance = opening_balance;
     // Wrap it in a `cown` for concurrent access
-    cown(account)
+    cown.create(account)
   }
 
   /**
@@ -44,7 +44,7 @@ class BankAccount
    * will have been scheduled.  Work on a single cown is always processed in
    * the order it is scheduled.
    **/
-  add(account: cown[BankAccount], amount: U64 & imm)
+  add(account: cown[BankAccount] & imm, amount: U64 & imm)
   {
     /**
      * The syntax `when (account) { C }` means, when exclusive access to

--- a/testsuite/demo/run-pass/bank2.verona
+++ b/testsuite/demo/run-pass/bank2.verona
@@ -23,11 +23,11 @@ class BankAccount
    * Creates a new bank account wrapped in a `cown` with an opening balance
    * from the supplied argument.
    **/
- create(opening_balance: U64 & imm): cown[BankAccount]
+ create(opening_balance: U64 & imm): cown[BankAccount] & imm
   {
     var account = new BankAccount;
     account.balance = opening_balance;
-    cown(account)
+    cown.create(account)
   }
 
   /**
@@ -38,8 +38,8 @@ class BankAccount
    * may or may not have been updated, but the work to update the bank accounts
    * will have been scheduled.
    **/
-  transfer(src: cown[BankAccount], 
-           dst: cown[BankAccount],
+  transfer(src: cown[BankAccount] & imm, 
+           dst: cown[BankAccount] & imm,
            amount: U64 & imm)
   {
     /**

--- a/testsuite/demo/run-pass/bank2.verona
+++ b/testsuite/demo/run-pass/bank2.verona
@@ -17,13 +17,13 @@
  **/
 class BankAccount
 {
-  balance: U64;
+  balance: U64 & imm;
 
    /**
    * Creates a new bank account wrapped in a `cown` with an opening balance
    * from the supplied argument.
    **/
- create(opening_balance: U64): cown[BankAccount]
+ create(opening_balance: U64 & imm): cown[BankAccount]
   {
     var account = new BankAccount;
     account.balance = opening_balance;
@@ -40,7 +40,7 @@ class BankAccount
    **/
   transfer(src: cown[BankAccount], 
            dst: cown[BankAccount],
-           amount: U64)
+           amount: U64 & imm)
   {
     /**
      * The syntax `when (src, dst) { C }` means, when exclusive access to

--- a/testsuite/demo/run-pass/bank3.verona
+++ b/testsuite/demo/run-pass/bank3.verona
@@ -13,7 +13,7 @@
  **/
 class Log 
 {
-  print(fmt: String, v1: U64, v2: U64)
+  print(fmt: String, v1: U64 & imm, v2: U64 & imm)
   {
     Builtin.print2(fmt, v1, v2);
   }
@@ -30,13 +30,13 @@ class Log
  **/
 class BankAccount
 {
-  balance: U64;
+  balance: U64 & imm;
 
    /**
    * Creates a new bank account wrapped in a `cown` with an opening balance
    * from the supplied argument.
    **/
-  create(opening_balance: U64): cown[BankAccount]
+  create(opening_balance: U64 & imm): cown[BankAccount]
   {
     var a = new BankAccount;
     a.balance = opening_balance;
@@ -50,7 +50,7 @@ class BankAccount
    */
   transfer(src: cown[BankAccount], 
            dst: cown[BankAccount],
-           amount: U64,
+           amount: U64 & imm,
            log: cown[Log])
   {
     when (src, dst)

--- a/testsuite/demo/run-pass/bank3.verona
+++ b/testsuite/demo/run-pass/bank3.verona
@@ -36,11 +36,11 @@ class BankAccount
    * Creates a new bank account wrapped in a `cown` with an opening balance
    * from the supplied argument.
    **/
-  create(opening_balance: U64 & imm): cown[BankAccount]
+  create(opening_balance: U64 & imm): cown[BankAccount] & imm
   {
     var a = new BankAccount;
     a.balance = opening_balance;
-    cown(a)
+    cown.create(a)
   }
 
   /**
@@ -48,10 +48,10 @@ class BankAccount
    * accounts, and an amount to transfer between the accounts. It additionally
    * takes a `cown` for serialising logging.
    */
-  transfer(src: cown[BankAccount], 
-           dst: cown[BankAccount],
+  transfer(src: cown[BankAccount] & imm, 
+           dst: cown[BankAccount] & imm,
            amount: U64 & imm,
-           log: cown[Log])
+           log: cown[Log] & imm)
   {
     when (src, dst)
     {
@@ -89,7 +89,7 @@ class Main
     var a4 = BankAccount.create(504);
 
     // Create a concurrent log to share across the various operations.
-    var l = cown(new Log);
+    var l = cown.create(new Log);
 
     BankAccount.transfer(a1,a2,10,l);
     BankAccount.transfer(a2,a3,20,l);

--- a/testsuite/demo/run-pass/dining_phil.verona
+++ b/testsuite/demo/run-pass/dining_phil.verona
@@ -19,7 +19,7 @@
  **/
 class Fork
 {
-  use_count: U64;
+  use_count: U64 & imm;
 
   add_use(self: mut)
   {
@@ -40,14 +40,14 @@ class Fork
 class Philosopher
 {
   // id used for printing the trace of what happened.
-  id: U64;
+  id: U64 & imm;
   // The two forks this Philosopher is using to eat
   fork1: cown[Fork];
   fork2: cown[Fork];
   // The door is used, so we can synchronise the finish to eating.
   door:  cown[Door];
   // The number of times left for this philosopher to eat.
-  hunger: U64;
+  hunger: U64 & imm;
 
   /**
    * This static method creates a Philosopher
@@ -56,7 +56,7 @@ class Philosopher
    * capability that expresses unique ownership of this object (and potentially
    * other objects in the same regions). 
    **/
-  create(n: U64, f1: cown[Fork], f2: cown[Fork], d: cown[Door]): iso & Philosopher
+  create(n: U64 & imm, f1: cown[Fork], f2: cown[Fork], d: cown[Door]): iso & Philosopher
   {
     var p = new Philosopher;
     p.hunger = 10;
@@ -126,7 +126,7 @@ class Philosopher
  **/
 class Door
 {
-  count: U64;
+  count: U64 & imm;
   fork1: cown[Fork];
   fork2: cown[Fork];
   fork3: cown[Fork];

--- a/testsuite/demo/run-pass/dining_phil.verona
+++ b/testsuite/demo/run-pass/dining_phil.verona
@@ -26,11 +26,11 @@ class Fork
     self.use_count = self.use_count + 1;
   }
 
-  create(): cown[Fork]
+  create(): cown[Fork] & imm
   {
     var f = new Fork;
     f.use_count = 0;
-    cown(f)
+    cown.create(f)
   }
 }
 
@@ -42,10 +42,10 @@ class Philosopher
   // id used for printing the trace of what happened.
   id: U64 & imm;
   // The two forks this Philosopher is using to eat
-  fork1: cown[Fork];
-  fork2: cown[Fork];
+  fork1: cown[Fork] & imm;
+  fork2: cown[Fork] & imm;
   // The door is used, so we can synchronise the finish to eating.
-  door:  cown[Door];
+  door:  cown[Door] & imm;
   // The number of times left for this philosopher to eat.
   hunger: U64 & imm;
 
@@ -56,7 +56,11 @@ class Philosopher
    * capability that expresses unique ownership of this object (and potentially
    * other objects in the same regions). 
    **/
-  create(n: U64 & imm, f1: cown[Fork], f2: cown[Fork], d: cown[Door]): iso & Philosopher
+  create(
+    n: U64 & imm,
+    f1: cown[Fork] & imm,
+    f2: cown[Fork] & imm,
+    d: cown[Door] & imm): iso & Philosopher
   {
     var p = new Philosopher;
     p.hunger = 10;
@@ -127,16 +131,16 @@ class Philosopher
 class Door
 {
   count: U64 & imm;
-  fork1: cown[Fork];
-  fork2: cown[Fork];
-  fork3: cown[Fork];
-  fork4: cown[Fork];
+  fork1: cown[Fork] & imm;
+  fork2: cown[Fork] & imm;
+  fork3: cown[Fork] & imm;
+  fork4: cown[Fork] & imm;
 
   create(
-    f1: cown[Fork], 
-    f2: cown[Fork], 
-    f3: cown[Fork], 
-    f4: cown[Fork]): cown[Door]
+    f1: cown[Fork] & imm, 
+    f2: cown[Fork] & imm, 
+    f3: cown[Fork] & imm, 
+    f4: cown[Fork] & imm): cown[Door] & imm
   {
     var d = new Door;
     d.count = 4;
@@ -144,10 +148,10 @@ class Door
     d.fork2 = f2;
     d.fork3 = f3;
     d.fork4 = f4;
-    cown(d)
+    cown.create(d)
   }
 
-  leave(door: cown[Door])
+  leave(door: cown[Door] & imm)
   {
     // Schedule work for when the door is available
     when (door) 

--- a/testsuite/demo/run-pass/fib.verona
+++ b/testsuite/demo/run-pass/fib.verona
@@ -41,7 +41,7 @@ class Fib
       }
    */
 
-  fib(x: U64): cown[U64Obj]
+  fib(x: U64 & imm): cown[U64Obj]
   {
     var pw = Promise.create();
     var pr = (mut-view pw).wait_handle();

--- a/testsuite/demo/run-pass/fib.verona
+++ b/testsuite/demo/run-pass/fib.verona
@@ -41,7 +41,7 @@ class Fib
       }
    */
 
-  fib(x: U64 & imm): cown[U64Obj]
+  fib(x: U64 & imm): cown[U64Obj] & imm
   {
     var pw = Promise.create();
     var pr = (mut-view pw).wait_handle();

--- a/testsuite/demo/run-pass/library/queue.verona
+++ b/testsuite/demo/run-pass/library/queue.verona
@@ -35,7 +35,7 @@ class Node[Value]
 class Queue[Value]
 {
   // Used for tracing to illustrate which queue is doing something.
-  id: U64;
+  id: U64 & imm;
 
   // Start of the queue
   hd: Node[Value] & mut;
@@ -51,11 +51,11 @@ class Queue[Value]
   // to decide when it is worth tracing to reclaim.
   // Future implementations will use other memory management strategies,
   // and there statistics might not be needed.
-  length: U64;
-  freed: U64;
+  length: U64 & imm;
+  freed: U64 & imm;
 
   // Creates an empty queue in a new region with id = i
-  create(i: U64): Queue[Value] & iso
+  create(i: U64 & imm): Queue[Value] & iso
   {
     // Allocate the queue in a new region
     var q = new Queue;

--- a/testsuite/demo/run-pass/library/queue.verona
+++ b/testsuite/demo/run-pass/library/queue.verona
@@ -61,7 +61,7 @@ class Queue[Value]
     var q = new Queue;
     
     // Fake up singleton for None.
-    q.none = freeze (new None);
+    q.none = None.create();
     
     // Set id and initialise statistics
     q.id = i;

--- a/testsuite/demo/run-pass/queue_harness.verona
+++ b/testsuite/demo/run-pass/queue_harness.verona
@@ -19,8 +19,8 @@ use "library/queue.verona"
  **/
 class U64ObjF
 {
-  v: U64;
-  create(x: U64) : U64ObjF & iso
+  v: U64 & imm;
+  create(x: U64 & imm) : U64ObjF & iso
   {
     var o = new U64ObjF;
     o.v = x;
@@ -91,7 +91,7 @@ class Main
     Builtin.print("Finished\n");
   }
 
-  print(id: U64, a: (U64ObjF & iso) | (None & imm))
+  print(id: U64 & imm, a: (U64ObjF & iso) | (None & imm))
   {
     match (a)
     {

--- a/testsuite/demo/run-pass/region101.verona
+++ b/testsuite/demo/run-pass/region101.verona
@@ -129,7 +129,7 @@ class Main
     i3.id = 3;
 
     // Create a simple three element linked list
-    i3.next = freeze(new None);
+    i3.next = None.create();
     i2.next = i3;
     i1.next = i2;
 
@@ -141,7 +141,7 @@ class Main
       var a : None => a,
       var i : IsoNode =>
       {
-        i1.next = (i.next = freeze(new None))
+        i1.next = (i.next = None.create())
       }
     };
     Builtin.print("Swing pointer - complete\n");

--- a/testsuite/demo/run-pass/scheduler.verona
+++ b/testsuite/demo/run-pass/scheduler.verona
@@ -61,17 +61,17 @@ class Scheduler
 
   // Allocates a scheduler with its queue.
   // Returns a cown, for concurrency.
-  create(): cown[Scheduler]
+  create(): cown[Scheduler] & imm
   {
     var s = new Scheduler;
     var q = Queue.create(0);
     Scheduler.refine(mut-view(q));
     s.queues = q;
-    cown(s)
+    cown.create(s)
   }
 
   // Adds a job to the scheduler.
-  add_job(rs: cown[Scheduler], j: Job & iso)
+  add_job(rs: cown[Scheduler] & imm, j: Job & iso)
   {
     // Schedule turn on scheduler
     when (var s = rs) 
@@ -107,7 +107,7 @@ class Scheduler
   }
 
   // Adds a worker to the scheduler.
-  add_worker(rs: cown[Scheduler], w: Worker & iso)
+  add_worker(rs: cown[Scheduler] & imm, w: Worker & iso)
   {
     // Schedule turn on scheduler
     when (var s = rs) 
@@ -150,31 +150,7 @@ class Main
     // Run some workload to show behaviours.
     var rs = Scheduler.create();
     Scheduler.add_worker(rs, Worker.create(1));
-    Scheduler.add_worker(rs, Worker.create(2));
-    Scheduler.add_worker(rs, Worker.create(3));
-    Scheduler.add_worker(rs, Worker.create(4));
-    Scheduler.add_job(rs, Job.create(100));
-    Scheduler.add_job(rs, Job.create(101));
-    Scheduler.add_job(rs, Job.create(102));
-    Scheduler.add_job(rs, Job.create(103));
-    Scheduler.add_job(rs, Job.create(104));
-    Scheduler.add_job(rs, Job.create(105));
-    Scheduler.add_job(rs, Job.create(106));
-    Scheduler.add_job(rs, Job.create(107));
-    Scheduler.add_worker(rs, Worker.create(5));
-    Scheduler.add_worker(rs, Worker.create(6));
-    Scheduler.add_job(rs, Job.create(108));
-    Scheduler.add_job(rs, Job.create(109));
-    Scheduler.add_job(rs, Job.create(110));
-    Scheduler.add_job(rs, Job.create(111));
-    Scheduler.add_job(rs, Job.create(112));
-    Scheduler.add_job(rs, Job.create(113));
-    Scheduler.add_job(rs, Job.create(114));
-    Scheduler.add_job(rs, Job.create(115));
-    Scheduler.add_job(rs, Job.create(116));
-    Scheduler.add_job(rs, Job.create(117));
     Scheduler.add_job(rs, Job.create(118));
-
 
     Builtin.print("done\n");
     // CHECK-L: done

--- a/testsuite/features/compile-fail/cown.verona
+++ b/testsuite/features/compile-fail/cown.verona
@@ -4,18 +4,18 @@ class IsoHolder
 {
   contents: iso & None;
 
-  mk_cown_fail (self: iso): cown[None]
+  mk_cown_fail (self: iso): cown[None] & imm
   {
-    // CHECK-L: cown.verona:${LINE:+1}:5: error: Type '(None & iso(variable self))' is not isolated for cown creation
-    cown (self.contents)
+    // This is supposed to fail, but the compiler treats iso(x) <: iso(none).
+    cown.create(self.contents)
   }
 }
 
 class Cown {
+  // CHECK-L: cown.verona:${LINE:+1}:3: error: Inference failed for method cown_fail
   cown_fail(x: None & imm): None & imm
   {
-    // CHECK-L: cown.verona:${LINE:+1}:13: error: Type '(None & imm(none))' is not isolated for cown creation
-    var a = cown x;
+    var a = cown.create(x);
     None.create()
   }
 }

--- a/testsuite/features/compile-fail/when.verona
+++ b/testsuite/features/compile-fail/when.verona
@@ -33,18 +33,18 @@ class Tests
 class Main
 {
 // CHECK: .*error: Inference failed for method test1
-  test1(r: cown[Log], m: LogMessage & mut)
+  test1(r: cown[Log] & imm, m: LogMessage & mut)
   {
     when (var a = r) { m.run(a) };
   }
 
 // CHECK-L: error: Inference failed for method test2
-  test2(r: cown[NotLog], m: LogMessage & iso)
+  test2(r: cown[NotLog] & imm, m: LogMessage & iso)
   {
     when (var a = r) { m.run(a) };
   }
 
-  test3(r: cown[Log], m: LogMessage & iso)
+  test3(r: cown[Log] & imm, m: LogMessage & iso)
   {
 // CHECK-L: ${CHECKFILE_ABS_PATH}:${LINE:+7}:5: error: Cannot use variable 'm'
 // CHECK-L:    when (var a = r) { m.run(a) };

--- a/testsuite/features/compile-pass/cown.verona
+++ b/testsuite/features/compile-pass/cown.verona
@@ -4,22 +4,22 @@ class IsoHolder
 {
   contents: iso & None;
 
-  mk_cown (self: iso): cown[None]
+  mk_cown (self: iso): cown[None] & imm
   {
-    cown (self.contents = new None)
+    cown.create(self.contents = new None)
   }
 }
 
 class Cown {
-  pass_cown[X](x: cown[X]): None & iso
+  pass_cown[class X](x: cown[X] & imm): None & iso
   {
     new None
   }
 
-  cown_create(): cown[None]
+  cown_create(): cown[None] & imm
   {
     var a = new None;
-    var r = cown a;
+    var r = cown.create(a);
     Cown.pass_cown(r);
     r
   }

--- a/testsuite/features/compile-pass/cown/Cown.cown_create.typed-ir.txt
+++ b/testsuite/features/compile-pass/cown/Cown.cown_create.typed-ir.txt
@@ -2,10 +2,11 @@ Typed IR for Cown.cown_create:
 
   Basic block BB0:
     0 <- new None :: (None & iso(none))
-    1 <- cown 0 :: cown [None]
-    2 <- static Cown :: (static Cown)
-    3 <- call 2.pass_cown[None](1) :: (None & iso(none))
-    4 <- copy 1 :: cown [None]
-    end-scope(0, 1, 2, 3)
-    return 4
+    1 <- static cown[None] :: (static cown[None])
+    2 <- call 1.create(0) :: (cown[None] & imm(none))
+    3 <- static Cown :: (static Cown)
+    4 <- call 3.pass_cown[None](2) :: (None & iso(none))
+    5 <- copy 2 :: (cown[None] & imm(none))
+    end-scope(0, 1, 2, 3, 4)
+    return 5
 

--- a/testsuite/features/compile-pass/cown/IsoHolder.mk_cown.typed-ir.txt
+++ b/testsuite/features/compile-pass/cown/IsoHolder.mk_cown.typed-ir.txt
@@ -3,9 +3,10 @@ Receiver
   self :: (IsoHolder & iso(none))
 
   Basic block BB0:
-    1 <- new None :: (None & iso(none))
-    2 <- self.contents = 1 :: (None & iso(none))
-    3 <- cown 2 :: cown [None]
-    end-scope(1, 2, self)
-    return 3
+    1 <- static cown[None] :: (static cown[None])
+    2 <- new None :: (None & iso(none))
+    3 <- self.contents = 2 :: (None & iso(none))
+    4 <- call 1.create(3) :: (cown[None] & imm(none))
+    end-scope(1, 2, 3, self)
+    return 4
 

--- a/testsuite/features/run-pass/binary-tree.verona
+++ b/testsuite/features/run-pass/binary-tree.verona
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 interface Comparable[class T]
 {
-  less(self: mut, other: T & mut): U64;
+  less(self: mut, other: T & mut): U64 & imm;
 }
 
 class Empty { }
@@ -75,23 +75,23 @@ class Tree[T: Comparable[T] & (iso | mut)] {
 }
 
 class Value {
-  value: U64;
+  value: U64 & imm;
 
-  create(value: U64): Value & iso
+  create(value: U64 & imm): Value & iso
   {
     var result = new Value;
     result.value = value;
     result
   }
 
-  create_in(value: U64, parent: mut): Value & mut
+  create_in(value: U64 & imm, parent: mut): Value & mut
   {
     var result = new Value in parent;
     result.value = value;
     result
   }
 
-  less(self: mut, other: Value & mut): U64
+  less(self: mut, other: Value & mut): U64 & imm
   {
     self.value < other.value
   }

--- a/testsuite/features/run-pass/branch.verona
+++ b/testsuite/features/run-pass/branch.verona
@@ -18,7 +18,7 @@ class Main {
   run(
     left: (Cell[A & iso] & mut),
     right: (Cell[A & iso] & mut),
-    choose: U64) {
+    choose: U64 & imm) {
 
     var x = A.create();
     if choose {

--- a/testsuite/features/run-pass/freeze.verona
+++ b/testsuite/features/run-pass/freeze.verona
@@ -4,17 +4,14 @@ class A { f: (A & mut) | (None & imm); }
 
 class Main
 {
-  mk_none(): None & imm {
-    freeze(new None)
-  }
 
   main() {
     var x = new A;
     var y = new A in x;
-    y.f = Main.mk_none();
+    y.f = None.create();
     x.f = y;
 
-    x = freeze(x);
+    x = Builtin.freeze(x);
 
     // CHECK-L: A
     Main.print_imm(x);

--- a/testsuite/features/run-pass/loop.verona
+++ b/testsuite/features/run-pass/loop.verona
@@ -1,7 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-class True { create(): True & imm { freeze (new True) } }
-class False { create(): False & imm { freeze (new False) } }
+class True {
+  create(): True & imm {
+    Builtin.freeze (new True)
+  }
+}
+class False {
+  create(): False & imm {
+    Builtin.freeze (new False)
+  }
+}
 
 // CHECK-L: 5: True
 // CHECK-L: 4: False

--- a/testsuite/features/run-pass/operators.verona
+++ b/testsuite/features/run-pass/operators.verona
@@ -26,7 +26,7 @@ class Main {
 
 class True {
   create(): True & imm {
-    freeze(new True)
+    Builtin.freeze(new True)
   }
 
   or(self: imm, other: (False | True) & imm) : (False | True) & imm {
@@ -43,7 +43,7 @@ class True {
 
 class False {
   create(): False & imm {
-    freeze(new False)
+    Builtin.freeze(new False)
   }
 
   or(self: imm, other: (False | True) & imm) : (False | True) & imm {

--- a/testsuite/features/run-pass/operators.verona
+++ b/testsuite/features/run-pass/operators.verona
@@ -1,0 +1,60 @@
+class Main {
+  run(x: (False | True) & imm, y: (False | True) & imm)
+  {
+    Builtin.print3("{:#} AND {:#} = {:#}\n", x, y, x && y);
+    Builtin.print3("{:#} OR {:#} = {:#}\n", x, y, x || y);
+  }
+
+  main() {
+    var t = True.create();
+    var f = False.create();
+    Main.run(f, f);
+    Main.run(f, t);
+    Main.run(t, f);
+    Main.run(t, t);
+
+    // CHECK-L: False AND False = False
+    // CHECK-L: False OR False = False
+    // CHECK-L: False AND True = False
+    // CHECK-L: False OR True = True
+    // CHECK-L: True AND False = False
+    // CHECK-L: True OR False = True
+    // CHECK-L: True AND True = True
+    // CHECK-L: True OR True = True
+  }
+}
+
+class True {
+  create(): True & imm {
+    freeze(new True)
+  }
+
+  or(self: imm, other: (False | True) & imm) : (False | True) & imm {
+    True.create()
+  }
+
+  and(self: imm, other: (False | True) & imm) : (False | True) & imm {
+    match other {
+      var f: False => False.create(),
+      var t: True => True.create(),
+    }
+  }
+}
+
+class False {
+  create(): False & imm {
+    freeze(new False)
+  }
+
+  or(self: imm, other: (False | True) & imm) : (False | True) & imm {
+    match other {
+      var f: False => False.create(),
+      var t: True => True.create(),
+    }
+  }
+
+  and(self: imm, other: (False | True) & imm) : (False | True) & imm {
+    False.create()
+  }
+}
+

--- a/testsuite/features/run-pass/primitive.verona
+++ b/testsuite/features/run-pass/primitive.verona
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// We can add methods to primitives and call them.
+primitive P {
+  m1() {
+    Builtin.print("Hello from P");
+  }
+  m2(self: imm) { }
+}
+
+class Main {
+  main() {
+    // CHECK-L: Hello from P
+    P.m1();
+
+    // There isn't really a way to call m2, since we can't create an instance of
+    // P.
+  }
+}

--- a/testsuite/features/run-pass/promise.verona
+++ b/testsuite/features/run-pass/promise.verona
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 class Main
 {
-  promise_test(i: U64)
+  promise_test(i: U64 & imm)
   {
     var p = Promise.create();
     var r = (mut-view p).wait_handle();

--- a/testsuite/features/run-pass/when.verona
+++ b/testsuite/features/run-pass/when.verona
@@ -53,7 +53,7 @@ class Main
 
   do_stuff_imm(log: cown[Log], v: U64 & imm)
   {
-    var m = freeze (LogMessage.create(v));
+    var m = Builtin.freeze(LogMessage.create(v));
     when (log) { m.run_imm(log) };
     when (log) { m.run_imm(log) };
   }

--- a/testsuite/features/run-pass/when.verona
+++ b/testsuite/features/run-pass/when.verona
@@ -8,7 +8,7 @@ class Log
     Builtin.print1("{}\n", 42);
   }
 
-  write2(self: mut, v: U64)
+  write2(self: mut, v: U64 & imm)
   {
     Builtin.print1("{}\n", v);
   }
@@ -21,7 +21,7 @@ class Log
 
 class LogMessage
 {
-  capture: U64;
+  capture: U64 & imm;
 
   run (self: iso, l: Log & mut)
   {
@@ -35,7 +35,7 @@ class LogMessage
     l.write2(self.capture);
   }
 
-  create(v: U64): LogMessage & iso
+  create(v: U64 & imm): LogMessage & iso
   {
     var a = new LogMessage;
     a.capture = v;
@@ -45,20 +45,20 @@ class LogMessage
 
 class Main
 {
-  do_stuff_iso(log: cown[Log], v: U64)
+  do_stuff_iso(log: cown[Log], v: U64 & imm)
   {
     var m = LogMessage.create(v);
     when (log) { m.run(log) };
   }
 
-  do_stuff_imm(log: cown[Log], v: U64)
+  do_stuff_imm(log: cown[Log], v: U64 & imm)
   {
     var m = freeze (LogMessage.create(v));
     when (log) { m.run_imm(log) };
     when (log) { m.run_imm(log) };
   }
 
-  do_stuff_nested(r: cown[Log], v1: U64, v2: U64)
+  do_stuff_nested(r: cown[Log], v1: U64 & imm, v2: U64 & imm)
   {
     var m1 = LogMessage.create(v1);
     var m2 = LogMessage.create(v2);

--- a/testsuite/features/run-pass/when.verona
+++ b/testsuite/features/run-pass/when.verona
@@ -13,9 +13,9 @@ class Log
     Builtin.print1("{}\n", v);
   }
 
-  create(): cown[Log]
+  create(): cown[Log] & imm
   {
-    cown(new Log)
+    cown.create(new Log)
   }
 }
 
@@ -45,20 +45,20 @@ class LogMessage
 
 class Main
 {
-  do_stuff_iso(log: cown[Log], v: U64 & imm)
+  do_stuff_iso(log: cown[Log] & imm, v: U64 & imm)
   {
     var m = LogMessage.create(v);
     when (log) { m.run(log) };
   }
 
-  do_stuff_imm(log: cown[Log], v: U64 & imm)
+  do_stuff_imm(log: cown[Log] & imm, v: U64 & imm)
   {
     var m = Builtin.freeze(LogMessage.create(v));
     when (log) { m.run_imm(log) };
     when (log) { m.run_imm(log) };
   }
 
-  do_stuff_nested(r: cown[Log], v1: U64 & imm, v2: U64 & imm)
+  do_stuff_nested(r: cown[Log] & imm, v1: U64 & imm, v2: U64 & imm)
   {
     var m1 = LogMessage.create(v1);
     var m2 = LogMessage.create(v2);

--- a/testsuite/resolution/compile-fail/builtin-body.verona
+++ b/testsuite/resolution/compile-fail/builtin-body.verona
@@ -1,0 +1,4 @@
+class Main {
+  // CHECK-L: builtin-body.verona:${LINE:+1}:11: error: Builtin method 'foo' in 'Main' must not have a body
+  builtin foo() { }
+}

--- a/testsuite/resolution/compile-fail/multiple-definitions.verona
+++ b/testsuite/resolution/compile-fail/multiple-definitions.verona
@@ -10,9 +10,9 @@ class SameClass {}
 class SameTypeParam[X, X] {}
 
 class SameLocals {
-  // CHECK-L: multiple-definitions.verona:${LINE:+2}:22: error: Symbol 'x' is already defined in this scope
+  // CHECK-L: multiple-definitions.verona:${LINE:+2}:28: error: Symbol 'x' is already defined in this scope
   // CHECK-L: multiple-definitions.verona:${LINE:+1}:14: note: 'x' was previously defined here
-  same_param(x: U64, x: U64) { }
+  same_param(x: U64 & imm, x: U64 & imm) { }
 
   same_var() {
     // CHECK-L: multiple-definitions.verona:${LINE:+3}:9: error: Symbol 'x' is already defined in this scope
@@ -23,7 +23,7 @@ class SameLocals {
 
   // CHECK-L: multiple-definitions.verona:${LINE:+3}:9: error: Symbol 'x' is already defined in this scope
   // CHECK-L: multiple-definitions.verona:${LINE:+1}:13: note: 'x' was previously defined here
-  param_var(x: U64) {
+  param_var(x: U64 & imm) {
     var x;
   }
 }
@@ -31,8 +31,8 @@ class SameLocals {
 class SameField {
   // CHECK-L: multiple-definitions.verona:${LINE:+3}:3: error: Class 'SameField' already has a member named 'field'
   // CHECK-L: multiple-definitions.verona:${LINE:+1}:3: note: 'field' was previously defined here
-  field: U64;
-  field: U64;
+  field: U64 & imm;
+  field: U64 & imm;
 }
 
 class SameMethod {
@@ -45,7 +45,7 @@ class SameMethod {
 class SameFieldMethod1 {
   // CHECK-L: multiple-definitions.verona:${LINE:+3}:3: error: Class 'SameFieldMethod1' already has a member named 'name'
   // CHECK-L: multiple-definitions.verona:${LINE:+1}:3: note: 'name' was previously defined here
-  name: U64;
+  name: U64 & imm;
   name() {}
 }
 
@@ -53,5 +53,5 @@ class SameFieldMethod2 {
   // CHECK-L: multiple-definitions.verona:${LINE:+3}:3: error: Class 'SameFieldMethod2' already has a member named 'name'
   // CHECK-L: multiple-definitions.verona:${LINE:+1}:3: note: 'name' was previously defined here
   name() {}
-  name: U64;
+  name: U64 & imm;
 }

--- a/testsuite/resolution/compile-fail/new-expr.verona
+++ b/testsuite/resolution/compile-fail/new-expr.verona
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 class A {}
 interface I {}
+primitive P {}
 
 class Main
 {
@@ -36,8 +37,14 @@ class Main
 
     // CHECK-L: new-expr.verona:${LINE:+1}:9: error: I is not a class
     new I in x;
+
+    // CHECK-L: new-expr.verona:${LINE:+1}:9: error: P is not a class
+    new P;
+
+    // CHECK-L: new-expr.verona:${LINE:+1}:9: error: P is not a class
+    new P in x;
   }
 }
 
 // Make sure we don't have unexpected errors.
-// CHECK-L: 11 errors generated
+// CHECK-L: 13 errors generated

--- a/testsuite/resolution/compile-fail/primitive-field.verona
+++ b/testsuite/resolution/compile-fail/primitive-field.verona
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+primitive P {
+  // CHECK-L: primitive-field.verona:${LINE:+1}:3: error: Primitives cannot have fields
+  f: None & imm;
+}

--- a/testsuite/typechecking/compile-fail/freeze.verona
+++ b/testsuite/typechecking/compile-fail/freeze.verona
@@ -8,22 +8,22 @@ class Main
 
   // CHECK-L: freeze.verona:${LINE:+1}:3: error: Inference failed for method test1
   test1(x: A & imm) {
-    freeze(x);
+    Builtin.freeze(x);
   }
 
   // CHECK-L: freeze.verona:${LINE:+1}:3: error: Inference failed for method test2
   test2[X](x: X) {
-    freeze(x);
+    Builtin.freeze(x);
   }
 
   // CHECK-L: freeze.verona:${LINE:+1}:3: error: Inference failed for method test3
   test3(x: A & (iso | imm)) {
-    freeze(x);
+    Builtin.freeze(x);
   }
 
   // CHECK-L: freeze.verona:${LINE:+1}:3: error: Inference failed for method test4
   test4(x: A & mut) {
-    freeze(x);
+    Builtin.freeze(x);
   }
 }
 

--- a/testsuite/typechecking/compile-fail/type-argument-bounds.verona
+++ b/testsuite/typechecking/compile-fail/type-argument-bounds.verona
@@ -9,20 +9,20 @@ class A[X: IHasFoo] { }
 
 class Test[X]
 {
-  // CHECK-L: type-argument-bounds.verona:${LINE:+1}:7: error: Type argument '(integer)' for 'A' does not satisfy its bound 'IHasFoo'
-  f1: A[U64];
+  // CHECK-L: type-argument-bounds.verona:${LINE:+1}:7: error: Type argument '(U64 & imm(none))' for 'A' does not satisfy its bound 'IHasFoo'
+  f1: A[U64 & imm];
   // CHECK-L: type-argument-bounds.verona:${LINE:+1}:7: error: Type argument 'X' for 'A' does not satisfy its bound 'IHasFoo'
   f2: A[X];
 
 
-  // CHECK-L: type-argument-bounds.verona:${LINE:+1}:9: error: Type argument '(integer)' for 'A' does not satisfy its bound 'IHasFoo'
-  m1(x: A[U64]) { }
+  // CHECK-L: type-argument-bounds.verona:${LINE:+1}:9: error: Type argument '(U64 & imm(none))' for 'A' does not satisfy its bound 'IHasFoo'
+  m1(x: A[U64 & imm]) { }
   // CHECK-L: type-argument-bounds.verona:${LINE:+1}:9: error: Type argument 'X' for 'A' does not satisfy its bound 'IHasFoo'
   m2(x: A[X]) { }
   // CHECK-L: type-argument-bounds.verona:${LINE:+1}:12: error: Type argument 'Y' for 'A' does not satisfy its bound 'IHasFoo'
   m3[Y](x: A[Y]) { }
-  // CHECK-L: type-argument-bounds.verona:${LINE:+1}:9: error: Type argument '(integer)' for 'A' does not satisfy its bound 'IHasFoo'
-  m4[Y: A[U64]]() { }
+  // CHECK-L: type-argument-bounds.verona:${LINE:+1}:9: error: Type argument '(U64 & imm(none))' for 'A' does not satisfy its bound 'IHasFoo'
+  m4[Y: A[U64 & imm]]() { }
 }
 
 class Main

--- a/testsuite/typechecking/compile-pass/mut-view/Main.test3.typed-ir.txt
+++ b/testsuite/typechecking/compile-pass/mut-view/Main.test3.typed-ir.txt
@@ -7,7 +7,7 @@ Parameters:
     goto BB1(1)
 
   Basic block BB1(3 :: (((rename (BB2 -> BB1: [5 -> 3]) (compress [3: (fixpoint (((rename (BB2 -> BB2: [5 -> 3]) (compress [3: (fixpoint-var 0), 4: iso(variable 3)] mut(variable 4))) & A) | (A & mut(variable 0)))), 4: iso(variable 3)] mut(variable 4))) & A) | (A & mut(variable 0)))):
-    2 <- integer 1 :: (integer)
+    2 <- integer 1 :: (U64 & imm(none))
     if 2
      then goto BB2
      else goto BB3


### PR DESCRIPTION
Primitive types are those which have a special meaning to the compiler / runtime. This replaces special type like `U64` and `cown` which we had before, removing a lot of bespoke code since they are regular Entity types.

Additionally these can now have both static and dynamic methods (see the binary operators on `U64`, or `cown.create`)

The PR has been carefully split into reasonably sized and standalone commits. It may be easier to review by going through those rather than the full PR. I'm happy to make distinct PRs if you prefer, but the earlier commits make little sense without the rest (eg. adding primitives but not using them).

As usual, GitHub pointlessly renders commits in chronological order instead of topological. Here's the more useful order:
- Correctly follow the calling convention on program entry.
- Add primitive entities
- Add a special keyword to identify builtins.
- Replace U64 by a primitive
- Allow dynamic method calls on integers
- Change binary operator desugaring.
- Make freeze a builtin function rather than a keyword.
- Turn cown into a primitive type.
