### PR TITLE
clang-format: Add break after case label

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -21,6 +21,7 @@ AlwaysBreakTemplateDeclarations: true
 BinPackArguments: false
 BinPackParameters: false
 BraceWrapping:
+  AfterCaseLabel:  true
   AfterClass:      true
   AfterControlStatement: true
   AfterEnum:       true


### PR DESCRIPTION
I found that my local clang-format tool was reformatting files to be inconsistent with the existing style for braces after case labels. This makes the rule explicit in `.clang-format`.