### PR TITLE
Support relative importing without requiring "./" in the input file path

### DIFF
--- a/src/compiler/fs.h
+++ b/src/compiler/fs.h
@@ -19,7 +19,7 @@ namespace fs
   struct path : std::string
   {
     path(const std::string& p) : std::string(p) {}
-    path(char* p) : std::string(p) {}
+    path(const char* p) : std::string(p) {}
 
     std::string string()
     {

--- a/src/compiler/main.cc
+++ b/src/compiler/main.cc
@@ -120,9 +120,11 @@ namespace verona::compiler
       // Add nested includes to the work list.
       for (auto& include : file->modules)
       {
-        auto directory = input_file.remove_filename();
-        directory += "/" + (std::string)*include;
-        work_list.push(directory);
+        auto new_input_file = input_file.remove_filename();
+        if (new_input_file.empty())
+          new_input_file = ".";
+        new_input_file += "/" + (std::string)*include;
+        work_list.push(new_input_file);
       }
 
       program->files.push_back(std::move(file));

--- a/src/compiler/main.cc
+++ b/src/compiler/main.cc
@@ -120,10 +120,10 @@ namespace verona::compiler
       // Add nested includes to the work list.
       for (auto& include : file->modules)
       {
-        auto new_input_file = input_file.remove_filename();
-        if (new_input_file.empty())
-          new_input_file = ".";
-        new_input_file += "/" + (std::string)*include;
+        auto directory = input_file.remove_filename();
+        if (directory.empty())
+          directory = ".";
+        auto new_input_file = directory.string() + "/" + (std::string)*include;
         work_list.push(new_input_file);
       }
 

--- a/testsuite/features/compile-pass/library/child.verona
+++ b/testsuite/features/compile-pass/library/child.verona
@@ -1,0 +1,1 @@
+use "sibling.verona"

--- a/testsuite/features/compile-pass/use.verona
+++ b/testsuite/features/compile-pass/use.verona
@@ -1,0 +1,5 @@
+use "library/child.verona"
+
+class Main {
+    main() {}
+}


### PR DESCRIPTION
Currently the following code:
```rust
// foo.verona
use "bar.verona"
```
```java
// bar.verona
class Main {
  main() {}
}
```
and running `veronac foo.verona` will produce the following error:
```
Cannot open file ""/bar.verona""
```
You can only run a file with dependencies, from the current directory, if you prepend it with a `./`.
For example this, `veronac ./foo.verona`, works perfectly fine.

This PR makes it so that is no longer required.