### PR TITLE
Fix the "extract in finaliser" pattern.

### DIFF
--- a/src/interpreter/object.h
+++ b/src/interpreter/object.h
@@ -45,6 +45,7 @@ namespace verona::interpreter
 
     static void trace_fn(const rt::Object* base_object, rt::ObjectStack* stack);
     static void finaliser_fn(rt::Object* base_object);
+    static void destructor_fn(rt::Object* base_object);
 
   private:
     VMObject* parent_;

--- a/src/interpreter/vm.h
+++ b/src/interpreter/vm.h
@@ -43,9 +43,11 @@ namespace verona::interpreter
     /**
      * Run finaliser for this VM object.
      *
-     * This creates a new frame in the thread local VMs state.
+     * This creates a new frame in the thread local VMs state. Existing running
+     * frames will be restored after the finaliser completes.
      *
-     * Existing running frames will be restored after the finaliser completes.
+     * This assumes that `object` does indeed have a finaliser, found in its
+     * descriptor's finaliser_ip field.
      **/
     static void execute_finaliser(VMObject* object);
 

--- a/src/rt/cpp/vobject.h
+++ b/src/rt/cpp/vobject.h
@@ -109,17 +109,6 @@ namespace verona::rt
 
     void trace(ObjectStack*) {}
 
-    // Dummy functions to make compiler happy.
-    void trace_possibly_iso(ObjectStack*)
-    {
-      abort();
-    }
-
-    void notified(Object*)
-    {
-      abort();
-    }
-
     static EpochMark get_alloc_epoch()
     {
       return Scheduler::alloc_epoch();

--- a/src/rt/cpp/vobject.h
+++ b/src/rt/cpp/vobject.h
@@ -10,36 +10,36 @@ namespace verona::rt
 {
   using namespace snmalloc;
 
-  template<typename A>
-  struct has_trace_possibly_iso
+  // These helpers are used to determine if various methods are provided by the
+  // child class of V<>. They intentionally only check for the name of the
+  // method, not for its precise signature.
+  //
+  // If for example a class C has a notified method with an incorrect
+  // signature, `has_notified<C>` will still be true. However the
+  // implementation of V<C> (in this case `gc_notified`) would not compile.
+  //
+  // This is better than ignoring methods with the right name but the wrong
+  // signature.
+  template<class T, class = void>
+  struct has_trace_possibly_iso : std::false_type
+  {};
+  template<class T>
+  struct has_trace_possibly_iso<
+    T,
+    std::void_t<decltype(&T::trace_possibly_iso)>> : std::true_type
+  {};
+
+  template<class T, class = void>
+  struct has_notified : std::false_type
+  {};
+  template<class T>
+  struct has_notified<T, std::void_t<decltype(&T::notified)>> : std::true_type
+  {};
+
+  template<class T>
+  struct has_finaliser
   {
-  private:
-    template<typename B>
-    static auto test(ObjectStack* st)
-      -> decltype(std::declval<B>().trace_possibly_iso(st), std::true_type());
-
-    template<typename>
-    static std::false_type test(...);
-
-  public:
-    static constexpr bool value =
-      std::is_same_v<std::true_type, decltype(test<A>(nullptr))>;
-  };
-
-  template<typename A>
-  struct has_notified
-  {
-  private:
-    template<typename B>
-    static auto test(Object* o)
-      -> decltype(std::declval<B>().notified(o), std::true_type());
-
-    template<typename>
-    static std::false_type test(...);
-
-  public:
-    static constexpr bool value =
-      std::is_same_v<std::true_type, decltype(test<A>(nullptr))>;
+    constexpr static bool value = !std::is_trivially_destructible_v<T>;
   };
 
   template<
@@ -66,12 +66,14 @@ namespace verona::rt
 
     static void gc_trace_possibly_iso(const Object* o, ObjectStack* st)
     {
-      ((T*)o)->trace_possibly_iso(st);
+      if constexpr (has_trace_possibly_iso<T>::value)
+        ((T*)o)->trace_possibly_iso(st);
     }
 
     static void gc_notified(Object* o)
     {
-      ((T*)o)->notified(o);
+      if constexpr (has_notified<T>::value)
+        ((T*)o)->notified(o);
     }
 
     static void gc_final(Object* o)
@@ -85,7 +87,7 @@ namespace verona::rt
         sizeof(T),
         gc_trace,
         has_trace_possibly_iso<T>::value ? gc_trace_possibly_iso : nullptr,
-        std::is_trivially_destructible_v<T> ? nullptr : gc_final,
+        has_finaliser<T>::value ? gc_final : nullptr,
         has_notified<T>::value ? gc_notified : nullptr};
 
       return &desc;

--- a/src/rt/object/object.h
+++ b/src/rt/object/object.h
@@ -684,9 +684,14 @@ namespace verona::rt
       return get_descriptor()->trace_possibly_iso != nullptr;
     }
 
-    inline bool needs_finaliser_ring()
+    static inline bool is_trivial(const Descriptor* desc)
     {
-      return has_finaliser() || has_possibly_iso_fields();
+      return desc->finaliser == nullptr && desc->trace_possibly_iso == nullptr;
+    }
+
+    inline bool is_trivial()
+    {
+      return is_trivial(get_descriptor());
     }
 
   public:

--- a/src/rt/object/object.h
+++ b/src/rt/object/object.h
@@ -87,14 +87,32 @@ namespace verona::rt
     //  st.push(o.field)
     using TraceFunction = void (*)(const Object* o, ObjectStack* st);
     using TraceIsoFunction = void (*)(const Object* o, ObjectStack* st);
-    using FinalFunction = void (*)(Object* o);
+
     using NotifiedFunction = void (*)(Object* o);
+
+    // We distinguish between an object's finaliser and its destructor.
+    //
+    // The finaliser is run while all objects in the region are valid. It may
+    // follow pointers and examine other objects. On the other hand it must
+    // leave the object in a valid state as well, for other finalisers to run.
+    //
+    // When the destructor runs, other objects of the region may have already
+    // been destroyed and deallocated. Therefore the destructor must not follow
+    // any of its fields. On the other hand, it may leave the object in an
+    // invalid state ie. close file descriptors or deallocate some auxiliary
+    // storage.
+    //
+    // The finaliser can extract sub-regions and eg. send them in a
+    // multi-message. The destructor on the other hand may not do this.
+    using FinalFunction = void (*)(Object* o);
+    using DestructorFunction = void (*)(Object* o);
 
     size_t size;
     TraceFunction trace;
     TraceIsoFunction trace_possibly_iso;
     FinalFunction finaliser;
     NotifiedFunction notified = nullptr;
+    DestructorFunction destructor = nullptr;
     // TODO: virtual dispatch, pattern matching on type, reflection
   };
 
@@ -679,6 +697,11 @@ namespace verona::rt
       return get_descriptor()->notified != nullptr;
     }
 
+    inline bool has_destructor()
+    {
+      return get_descriptor()->destructor != nullptr;
+    }
+
     inline bool has_possibly_iso_fields()
     {
       return get_descriptor()->trace_possibly_iso != nullptr;
@@ -686,7 +709,8 @@ namespace verona::rt
 
     static inline bool is_trivial(const Descriptor* desc)
     {
-      return desc->finaliser == nullptr && desc->trace_possibly_iso == nullptr;
+      return desc->destructor == nullptr && desc->finaliser == nullptr &&
+        desc->trace_possibly_iso == nullptr;
     }
 
     inline bool is_trivial()
@@ -723,6 +747,12 @@ namespace verona::rt
     {
       if (has_notified())
         get_descriptor()->notified(this);
+    }
+
+    inline void destructor()
+    {
+      if (has_destructor())
+        get_descriptor()->destructor(this);
     }
 
     inline void dealloc(Alloc* alloc)

--- a/src/rt/region/freeze.h
+++ b/src/rt/region/freeze.h
@@ -317,7 +317,9 @@ namespace verona::rt
         // Finally deallocate objects.
         while (!to_dealloc.empty())
         {
-          to_dealloc.pop()->dealloc(alloc);
+          Object* q = to_dealloc.pop();
+          q->destructor();
+          q->dealloc(alloc);
         }
 
         reg->discard(alloc);

--- a/src/rt/region/immutable.h
+++ b/src/rt/region/immutable.h
@@ -127,10 +127,12 @@ namespace verona::rt
         {
           Object* w = fl.pop();
           total += w->size();
+          w->destructor();
           w->dealloc(alloc);
         }
 
         total += v->size();
+        v->destructor();
         v->dealloc(alloc);
       }
 

--- a/src/rt/region/region.h
+++ b/src/rt/region/region.h
@@ -237,8 +237,6 @@ namespace verona::rt
      * pointers to cowns, and immutables and subregions (which might contain
      * pointers to cowns).
      *
-     * TODO: Note that there is a misnomer, as these objects are classified as
-     * "needing finalisation."
      **/
     template<class RegionType>
     static void cown_scan_internal(
@@ -248,13 +246,11 @@ namespace verona::rt
       ObjectStack& recurse,
       EpochMark epoch)
     {
-      // First, iterate over all objects "needing finalisation" and trace them.
+      // First, iterate over all objects and trace them.
       auto reg = RegionType::get(o);
-      for (auto b_it = reg->template begin<RegionBase::NeedsFinaliser>();
-           b_it != reg->template end<RegionBase::NeedsFinaliser>();
-           ++b_it)
+      for (auto b : *reg)
       {
-        (*b_it)->trace(f);
+        b->trace(f);
       }
 
       // Now process the pointers we traced.

--- a/src/rt/region/region_arena.h
+++ b/src/rt/region/region_arena.h
@@ -33,11 +33,11 @@ namespace verona::rt
    * Objects that are too large to be allocated within an arena are allocated
    * by snmalloc and placed into the large object ring, a circular linked list
    * of objects accessed via the Object::next pointer. This ring mixes both
-   * objects needing finalisers and objects not needing finalisers. Since the
-   * iso object may not be in the large object ring, we need a pointer to the
-   * last object in the ring, to ensure merges are fast. If the iso object is
-   * in the large object ring, then it must be in the last position, so it can
-   * point to the region metadata object.
+   * trivial and non-trivial objects. Since the iso object may not be in the
+   * large object ring, we need a pointer to the last object in the ring, to
+   * ensure merges are fast. If the iso object is in the large object ring,
+   * then it must be in the last position, so it can point to the region
+   * metadata object.
    **/
   class RegionArena : public RegionBase
   {
@@ -57,54 +57,54 @@ namespace verona::rt
      * objects inside an arena are set to nullptr. An initialized arena is
      * guaranteed to have at least one object.
      *
-     * Objects not needing finalisers are allocated from the beginning of the
-     * arena, starting at `objects_begin`. `objects_end` points to the first
-     * byte after the last object, i.e. the place where the next object will be
-     * allocated.
+     * Trivial objects (ie. those with no destructor, no finaliser and no iso
+     * fields) are allocated from the beginning of the arena, starting at
+     * `objects_begin`. `objects_end` points to the first byte after the last
+     * object, i.e. the place where the next object will be allocated.
      *
-     * Objects needing finalisers are allocated from the end of the arena.
-     * `finalisers_end` points past the end of the arena and `finalisers_begin`
-     * points to the first object that needs a finaliser.
+     * Non-trivial objects are allocated from the end of the arena.
+     * `non_trivial_end` points past the end of the arena and
+     * `non_trivial_begin` points to the first non-trivial object.
      *
      * Note that certain operations require the bottom `MIN_ALLOC_BITS` to be
      * free, so we need to ensure all objects allocated within an arena are
      * properly aligned. This may involve extra padding in the "header" of an
      * Arena object, and also rounding up object sizes.
      *
-     *                       +------------------+
-     *                       | next arena --------> ...
-     *                       | objects_end      |
-     *                       | finalisers_begin |
-     *                       | finalisers_end   |
-     *                       |==================|
-     *    objects_begin ---> | object_1         |
-     *                       +------------------+
-     *                       | ...              |
-     *                       +------------------+
-     *                       | object_n         |
-     *                       +~~~~~~~~~~~~~~~~~~+
-     *      objects_end ---> | free space       |
-     *                       |                  |
-     *                       +~~~~~~~~~~~~~~~~~~+
-     * finalisers_begin ---> | finaliser_m      |
-     *                       +------------------+
-     *                       | ...              |
-     *                       +------------------+
-     *                       | finaliser_1      |
-     *                       +------------------+
-     *   finalisers_end --->
+     *                       +-------------------+
+     *                       | next arena ---------> ...
+     *                       | objects_end       |
+     *                       | non_trivial_begin |
+     *                       | non_trivial_end   |
+     *                       |===================|
+     *    objects_begin ---> | object_1          |
+     *                       +-------------------+
+     *                       | ...               |
+     *                       +-------------------+
+     *                       | object_n          |
+     *                       +~~~~~~~~~~~~~~~~~~~+
+     *      objects_end ---> | free space        |
+     *                       |                   |
+     *                       +~~~~~~~~~~~~~~~~~~~+
+     * non_trivial_begin --> | non_trivial_m     |
+     *                       +-------------------+
+     *                       | ...               |
+     *                       +-------------------+
+     *                       | non_trivial_1     |
+     *                       +-------------------+
+     *   non_trivial_end --->
      *
      * We can iterate over objects by starting from `objects_begin`, moving the
      * pointer by the size of the current object, until we reach `objects_end`.
      * We iterate from the first allocated object to the last allocated object.
      *
-     * We can iterate over objects needing finaliers by starting from
-     * `finalisers_begin`, moving the pointer by the size of the current
-     * object, until we reach `finalisers_end`. We iterate from the last
+     * We can iterate over non-trivial objects by starting from
+     * `non_trivial_begin`, moving the pointer by the size of the current
+     * object, until we reach `non_trivial_end`. We iterate from the last
      * allocated object to the first allocated object.
      *
      * We can calculate the remaining free space by taking the difference of
-     * `finalisers_begin` and `objects_end`.
+     * `non_trivial_begin` and `objects_end`.
      **/
     class Arena
     {
@@ -127,16 +127,16 @@ namespace verona::rt
       std::byte* objects_end;
 
       /**
-       * Pointer to the first allocated object that needs a finaliser.
+       * Pointer to the first allocated non-trivial object.
        **/
-      std::byte* finalisers_begin;
+      std::byte* non_trivial_begin;
 
       /**
        * Pointer to the byte after the Arena. We technically don't need to
        * store this pointer, but we have some space because `objects_begin`
        * needs to be aligned.
        **/
-      std::byte* finalisers_end;
+      std::byte* non_trivial_end;
 
       /**
        * Where objects will actually be allocated.
@@ -147,8 +147,8 @@ namespace verona::rt
       Arena()
       : next(nullptr),
         objects_end(objects_begin),
-        finalisers_begin(objects_begin + SIZE),
-        finalisers_end(finalisers_begin)
+        non_trivial_begin(objects_begin + SIZE),
+        non_trivial_end(non_trivial_begin)
       {
         assert(free_space() == SIZE);
       }
@@ -156,7 +156,7 @@ namespace verona::rt
       inline size_t free_space() const
       {
         assert(debug_invariant());
-        std::ptrdiff_t diff = finalisers_begin - objects_end;
+        std::ptrdiff_t diff = non_trivial_begin - objects_end;
         return (size_t)diff;
       }
 
@@ -178,15 +178,15 @@ namespace verona::rt
 
         Object* o = nullptr;
 
-        if (desc->finaliser != nullptr || desc->trace_possibly_iso != nullptr)
-        {
-          finalisers_begin -= sz;
-          o = (Object*)finalisers_begin;
-        }
-        else
+        if (Object::is_trivial(desc))
         {
           o = (Object*)objects_end;
           objects_end += sz;
+        }
+        else
+        {
+          non_trivial_begin -= sz;
+          o = (Object*)non_trivial_begin;
         }
 
         o->set_descriptor(desc);
@@ -200,13 +200,13 @@ namespace verona::rt
       bool debug_invariant() const
       {
         bool objects_ptrs = objects_begin <= objects_end;
-        bool finalisers_ptrs = finalisers_begin <= finalisers_end;
-        bool no_overlap = (finalisers_begin - objects_end) >= 0;
+        bool non_trivial_ptrs = non_trivial_begin <= non_trivial_end;
+        bool no_overlap = (non_trivial_begin - objects_end) >= 0;
         auto alignment1 = Object::debug_is_aligned(objects_begin);
         auto alignment2 = Object::debug_is_aligned(objects_end);
-        auto alignment3 = Object::debug_is_aligned(finalisers_begin);
-        auto alignment4 = Object::debug_is_aligned(finalisers_end);
-        return objects_ptrs && finalisers_ptrs && no_overlap && alignment1 &&
+        auto alignment3 = Object::debug_is_aligned(non_trivial_begin);
+        auto alignment4 = Object::debug_is_aligned(non_trivial_end);
+        return objects_ptrs && non_trivial_ptrs && no_overlap && alignment1 &&
           alignment2 && alignment3 && alignment4;
       }
     };
@@ -543,13 +543,12 @@ namespace verona::rt
 
       Systematic::cout() << "Region release: arena region: " << o << std::endl;
 
-      // Run all finalisers.
-      for (auto it = begin<NeedsFinaliser>(); it != end<NeedsFinaliser>(); ++it)
+      // Run all finalisers
+      for (auto it = begin<NonTrivial>(); it != end<NonTrivial>(); ++it)
       {
         Object* p = *it;
         p->find_iso_fields(o, f, collect);
-        if (p->has_finaliser())
-          p->finalise();
+        p->finalise();
       }
 
       // Now we can deallocate large object ring.
@@ -579,13 +578,13 @@ namespace verona::rt
     }
 
   public:
-    template<IteratorType type = Both>
+    template<IteratorType type = AllObjects>
     class iterator
     {
       friend class RegionArena;
 
       static_assert(
-        type == NoFinaliser || type == NeedsFinaliser || type == Both);
+        type == Trivial || type == NonTrivial || type == AllObjects);
 
       iterator(RegionArena* r) : reg(r), arena(r->first_arena), ptr(nullptr)
       {
@@ -642,7 +641,7 @@ namespace verona::rt
         assert(arena->debug_invariant());
         size_t sz = snmalloc::bits::align_up(ptr->size(), Object::ALIGNMENT);
         std::byte* q = (std::byte*)ptr + sz;
-        if constexpr (type == NoFinaliser)
+        if constexpr (type == Trivial)
         {
           assert(q > arena->objects_begin && q <= arena->objects_end);
 
@@ -650,39 +649,37 @@ namespace verona::rt
           if (q != arena->objects_end)
             return (Object*)q;
         }
-        else if constexpr (type == NeedsFinaliser)
+        else if constexpr (type == NonTrivial)
         {
-          assert(q > arena->finalisers_begin && q <= arena->finalisers_end);
+          assert(q > arena->non_trivial_begin && q <= arena->non_trivial_end);
 
           // We have not yet reached the end, so q is valid.
-          if (q != arena->finalisers_end)
+          if (q != arena->non_trivial_end)
             return (Object*)q;
         }
-        else if constexpr (type == Both)
+        else if constexpr (type == AllObjects)
         {
           assert(
             (q > arena->objects_begin && q <= arena->objects_end) ||
-            (q > arena->finalisers_begin && q <= arena->finalisers_end));
+            (q > arena->non_trivial_begin && q <= arena->non_trivial_end));
 
           // We have not yet reached either end, so q is valid.
-          if (q != arena->objects_end && q != arena->finalisers_end)
+          if (q != arena->objects_end && q != arena->non_trivial_end)
             return (Object*)q;
 
-          // We reached the end of non-finaliser objects and there are finaliser
+          // We reached the end of trivial objects and there are non-trivial
           // objects to iterate over.
           if (
             q == arena->objects_end &&
-            arena->finalisers_begin != arena->finalisers_end)
-            return (Object*)arena->finalisers_begin;
+            arena->non_trivial_begin != arena->non_trivial_end)
+            return (Object*)arena->non_trivial_begin;
         }
         return nullptr;
       }
 
       /**
        * Starting from the current `arena`, set `ptr` to the first
-       * "appropriate" Object, i.e. the first object without a finaliser, the
-       * first object that needs a finaliser, or the first object regardless
-       * of finalisation.
+       * "appropriate" Object.
        *
        * If no object can be found in the arena list, then we try the large
        * object ring. If no objects are left, then `ptr` is set to nullptr.
@@ -715,20 +712,20 @@ namespace verona::rt
         {
           assert(
             arena->objects_begin < arena->objects_end ||
-            arena->finalisers_begin < arena->finalisers_end);
+            arena->non_trivial_begin < arena->non_trivial_end);
           assert(arena->debug_invariant());
-          if constexpr (type == NoFinaliser || type == Both)
+          if constexpr (type == Trivial || type == AllObjects)
           {
             if (arena->objects_begin != arena->objects_end)
               return (Object*)arena->objects_begin;
           }
-          if constexpr (type == NeedsFinaliser || type == Both)
+          if constexpr (type == NonTrivial || type == AllObjects)
           {
-            if (arena->finalisers_begin != arena->finalisers_end)
-              return (Object*)arena->finalisers_begin;
+            if (arena->non_trivial_begin != arena->non_trivial_end)
+              return (Object*)arena->non_trivial_begin;
           }
           // Every arena contains at least one object.
-          if constexpr (type == Both)
+          if constexpr (type == AllObjects)
             assert(0);
           arena = arena->next;
         }
@@ -747,10 +744,10 @@ namespace verona::rt
         while (q != reg)
         {
           bool cond;
-          if constexpr (type == NoFinaliser)
-            cond = !q->needs_finaliser_ring();
-          else if constexpr (type == NeedsFinaliser)
-            cond = q->needs_finaliser_ring();
+          if constexpr (type == Trivial)
+            cond = q->is_trivial();
+          else if constexpr (type == NonTrivial)
+            cond = !q->is_trivial();
           else
             cond = true;
 
@@ -762,13 +759,13 @@ namespace verona::rt
       }
     };
 
-    template<IteratorType type = Both>
+    template<IteratorType type = AllObjects>
     inline iterator<type> begin()
     {
       return {this};
     }
 
-    template<IteratorType type = Both>
+    template<IteratorType type = AllObjects>
     inline iterator<type> end()
     {
       return {this, nullptr, nullptr};

--- a/src/rt/region/region_base.h
+++ b/src/rt/region/region_base.h
@@ -38,9 +38,9 @@ namespace verona::rt
   public:
     enum IteratorType
     {
-      NeedsFinaliser,
-      NoFinaliser,
-      Both
+      Trivial,
+      NonTrivial,
+      AllObjects,
     };
 
   private:

--- a/src/rt/region/region_trace.h
+++ b/src/rt/region/region_trace.h
@@ -434,6 +434,7 @@ namespace verona::rt
         p->get_class() == Object::ISO || p->get_class() == Object::UNMARKED);
       if constexpr (ring == TrivialRing)
       {
+        UNUSED(gc);
         assert(p->is_trivial());
 
         // p is about to be collected; remove the entry for it in
@@ -445,6 +446,8 @@ namespace verona::rt
       }
       else
       {
+        UNUSED(alloc);
+
         assert(!p->is_trivial());
         p->finalise();
 
@@ -548,6 +551,12 @@ namespace verona::rt
           p->dealloc(alloc);
           p = q;
         }
+      }
+      else
+      {
+        UNUSED(o);
+        UNUSED(f);
+        UNUSED(collect);
       }
     }
 

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -921,6 +921,9 @@ namespace verona::rt
         }
       }
 
+      // Now we may run our destructor.
+      destructor();
+
       MultiMessage* last = queue.destroy();
       alloc->dealloc<sizeof(MultiMessage)>(last);
     }

--- a/src/rt/test/func/cown_weak_ref/cown_weak_ref.cc
+++ b/src/rt/test/func/cown_weak_ref/cown_weak_ref.cc
@@ -41,7 +41,7 @@ struct MyCown : VCown<MyCown>
     if (parent != nullptr)
       parent->weak_release(ThreadAlloc::get_noncachable());
 
-    Systematic::cout() << "Finalising " << this << " up_count " << up_count
+    Systematic::cout() << "Destroying " << this << " up_count " << up_count
                        << std::endl;
   }
 };

--- a/src/rt/test/func/cowngc1/cowngc1.cc
+++ b/src/rt/test/func/cowngc1/cowngc1.cc
@@ -94,13 +94,6 @@ struct O : public V<O<region_type>, region_type>
     if (cown != nullptr)
       st->push(cown);
   }
-
-  // We need this so O is considered as needing finalisation, so that
-  // `Region::cown_scan` will trace the cown pointer.
-  void trace_possibly_iso(ObjectStack* st)
-  {
-    trace(st);
-  }
 };
 using OTrace = O<RegionType::Trace>;
 using OArena = O<RegionType::Arena>;

--- a/src/rt/test/func/cowngc4/cowngc4.cc
+++ b/src/rt/test/func/cowngc4/cowngc4.cc
@@ -100,9 +100,13 @@ struct O : public V<O<region_type>, region_type>
 
   void trace_possibly_iso(ObjectStack* st)
   {
-    trace(st);
+    if (f1 != nullptr)
+      st->push(f1);
+    if (f2 != nullptr)
+      st->push(f2);
   }
 };
+
 using OTrace = O<RegionType::Trace>;
 using OArena = O<RegionType::Arena>;
 

--- a/src/rt/test/func/diningphilosophers/diningphil.cc
+++ b/src/rt/test/func/diningphilosophers/diningphil.cc
@@ -53,7 +53,6 @@ struct KeepAlive : public VAction<KeepAlive>
 
 struct Philosopher : public VCown<Philosopher>
 {
-  bool final = false;
   size_t id;
   std::vector<Cown*> forks;
   size_t to_eat;
@@ -64,20 +63,9 @@ struct Philosopher : public VCown<Philosopher>
 
   void trace(ObjectStack* fields) const
   {
-    if (!final)
-      for (auto f : forks)
-      {
-        fields->push(f);
-      }
-  }
-
-  ~Philosopher()
-  {
-    assert(to_eat == 0);
-    final = true;
     for (auto f : forks)
     {
-      Cown::release(ThreadAlloc::get_noncachable(), f);
+      fields->push(f);
     }
   }
 };

--- a/src/rt/test/func/finalisers/finalisers.cc
+++ b/src/rt/test/func/finalisers/finalisers.cc
@@ -32,12 +32,21 @@ class C2 : public V<C2<region_type>, region_type>
 {
 public:
   C2<region_type>* f1 = nullptr;
-  bool finalised = false;
+  enum State
+  {
+    LIVE,
+    FINALISED,
+    DESTRUCTED
+  };
+
+  State state;
+
+  C2() : state(LIVE) {}
 
   void trace(ObjectStack* st) const
   {
-    // Tracing should never happen after finalisation
-    check(!finalised);
+    // Tracing should never happen after destruction
+    check(state == LIVE || state == FINALISED);
 
     if (f1 != nullptr)
       st->push(f1);
@@ -48,11 +57,16 @@ public:
     trace(st);
   }
 
+  void finaliser()
+  {
+    check(state == LIVE);
+    state = FINALISED;
+  }
+
   ~C2()
   {
-    // Don't double deallocate.
-    check(!finalised);
-    finalised = true;
+    check(state == FINALISED);
+    state = DESTRUCTED;
   }
 };
 
@@ -65,7 +79,7 @@ public:
     live_count++;
   }
 
-  ~F1()
+  void finaliser()
   {
     live_count--;
     logger::cout() << "Finalised" << std::endl;
@@ -89,7 +103,7 @@ public:
     live_count++;
   }
 
-  ~F2()
+  void finaliser()
   {
     live_count--;
     logger::cout() << "Finalised: " << id << std::endl;

--- a/src/rt/test/func/finalisers/finalisers.cc
+++ b/src/rt/test/func/finalisers/finalisers.cc
@@ -24,7 +24,7 @@ struct C1 : public V<C1<region_type>, region_type>
       st->push(f2);
   }
 
-  // trace_possibly_iso means this object might need finalisation!
+  // Omit trace_possibly_iso as it would make this object non-trivial.
 };
 
 template<RegionType region_type>

--- a/src/rt/test/func/memory/memory.h
+++ b/src/rt/test/func/memory/memory.h
@@ -24,7 +24,7 @@ struct C1 : public V<C1<region_type>, region_type>
       st->push(f2);
   }
 
-  // trace_possibly_iso would mean this object might need finalisation!
+  // Omit trace_possibly_iso as it would make this object non-trivial.
 };
 
 template<RegionType region_type>
@@ -107,7 +107,7 @@ struct C3 : public V<C3<region_type>, region_type>
       st->push(f2);
   }
 
-  // trace_possibly_iso would mean this object might need finalisation!
+  // Omit trace_possibly_iso as it would make this object non-trivial.
 };
 
 template<RegionType region_type>

--- a/testsuite/features/run-pass/finalisers-extract.verona
+++ b/testsuite/features/run-pass/finalisers-extract.verona
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// This test demostrates the "extract and return in finalisers" pattern.
+// A Handle owns a Value object. When the Handle goes out of scope and its
+// finaliser runs, the Value is returned to a global Pool using a when block.
+
+class Value {
+  _id: U64 & imm;
+
+  create(id: U64 & imm): Value & iso {
+    var result = new Value;
+    result._id = id;
+    result
+  }
+}
+
+class Pool {
+  value: Value & iso;
+
+  create(value: Value & iso): cown[Pool] & imm {
+    var pool = new Pool;
+    pool.value = value;
+    cown.create(pool)
+  }
+  
+  push(self: mut, value: Value & iso) {
+    self.value = value;
+  }
+}
+
+class Handle {
+  pool: cown[Pool] & imm;
+  value: Value & iso;
+
+  create(pool: cown[Pool] & imm, value: Value & iso): Handle & iso {
+    var handle = new Handle;
+    handle.pool = pool;
+    handle.value = value;
+    handle
+  }
+
+  final(self: mut) {
+    var value = (self.value = Value.create(0));
+    when (var p = self.pool) {
+      Builtin.print1("Returning: {:#}\n", mut-view value);
+      p.push(value);
+    }
+  }
+}
+
+class Main {
+  drop[T](x: T) { }
+  main() {
+    var pool = Pool.create(Value.create(5));
+
+    when (pool) {
+      Builtin.print1("Initial: {:#}\n", pool.value);
+    };
+
+    // The handle is dropped when the block ends and is returned to the pool
+    { Handle.create(pool, Value.create(12)); };
+
+    when (pool) {
+      Builtin.print1("Final: {:#}\n", pool.value);
+    };
+
+    // CHECK-L: Initial: Value { 5 }
+    // CHECK-L: Returning: Value { 12 }
+    // CHECK-L: Final: Value { 12 }
+  }
+}
+


### PR DESCRIPTION
This adds a desctructor to every object. The destructor runs just before an object is deallocated. The VM uses this destructor to deallocate the array of fields, allowing us to move the "find iso fields" phase to after the finaliser has run.

Fixes #62.

