### PR TITLE
Fix issue #67

### DIFF
--- a/src/compiler/codegen/reachability.cc
+++ b/src/compiler/codegen/reachability.cc
@@ -399,6 +399,9 @@ namespace verona::compiler
         visit_types(ty->elements);
       }
 
+      void visit_variable_renaming_type(const VariableRenamingTypePtr& ty) final
+      {}
+
       void visit_capability(const CapabilityTypePtr& ty) final {}
 
       ReachabilityVisitor* parent;

--- a/testsuite/reachability/compile-pass/visit-variable-renaming-type.verona
+++ b/testsuite/reachability/compile-pass/visit-variable-renaming-type.verona
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+/*
+ * This test checks https://github.com/microsoft/verona/issues/67
+ */
+
+class B {
+  foo(self: mut) {}
+}
+
+class Main {
+  main() {
+    var b = new B;
+    var mutb = mut-view b;
+    while (1) {
+      mutb.foo();
+    };
+  }
+}


### PR DESCRIPTION
Loops introduce variable renamings and their types. The
reachability pass doesn't need to do anything here but
that visitor needs a variable renaming type case.

Fixes #67 