### PR TITLE
Remove uninitialized field from rt test harness

### DIFF
--- a/src/rt/test/func/cowngc1/cowngc1.cc
+++ b/src/rt/test/func/cowngc1/cowngc1.cc
@@ -376,7 +376,7 @@ void test_cown_gc_before_sched()
 int main(int argc, char** argv)
 {
   SystematicTestHarness harness(argc, argv);
-  PRNG rand(harness.seed);
+  PRNG rand(harness.seed_lower);
 
   size_t ring = harness.opt.is<size_t>("--ring", 10);
   uint64_t forward = harness.opt.is<uint64_t>("--forward", 10);

--- a/src/rt/test/func/cowngc4/cowngc4.cc
+++ b/src/rt/test/func/cowngc4/cowngc4.cc
@@ -376,7 +376,7 @@ void test_cown_gc(uint64_t forward_count, size_t ring_size, PRNG* rand)
 int main(int argc, char** argv)
 {
   SystematicTestHarness harness(argc, argv);
-  PRNG rand(harness.seed);
+  PRNG rand(harness.seed_lower);
 
   size_t ring = harness.opt.is<size_t>("--ring", 10);
   uint64_t forward = harness.opt.is<uint64_t>("--forward", 10);

--- a/src/rt/test/func/diningphilosophers/diningphil.cc
+++ b/src/rt/test/func/diningphilosophers/diningphil.cc
@@ -160,7 +160,7 @@ void test_dining(
   }
 
   verona::Scramble scrambler;
-  xoroshiro::p128r32 rand(h->seed);
+  xoroshiro::p128r32 rand(h->seed_lower);
 
   for (size_t i = 0; i < philosophers; i++)
   {

--- a/src/rt/test/func/diningphilosophers/diningphil.cc
+++ b/src/rt/test/func/diningphilosophers/diningphil.cc
@@ -160,7 +160,7 @@ void test_dining(
   }
 
   verona::Scramble scrambler;
-  xoroshiro::p128r32 rand(h->seed_lower);
+  xoroshiro::p128r32 rand(h->current_seed());
 
   for (size_t i = 0; i < philosophers; i++)
   {

--- a/src/rt/test/harness.h
+++ b/src/rt/test/harness.h
@@ -32,7 +32,6 @@ public:
   size_t cores;
   size_t seed_lower;
   size_t seed_upper;
-  size_t seed;
   high_resolution_clock::time_point start;
 
   SystematicTestHarness(int argc, char** argv) : opt(argc, argv)
@@ -81,7 +80,7 @@ public:
     // When not a CI build use the seed the user specified.
     size_t random = 0;
 #endif
-    for (seed = seed_lower + random; seed < seed_upper + random; seed++)
+    for (size_t seed = seed_lower + random; seed < seed_upper + random; seed++)
     {
       std::cout << "Seed: " << seed << std::endl;
 

--- a/src/rt/test/harness.h
+++ b/src/rt/test/harness.h
@@ -25,6 +25,8 @@ extern "C" void dump_flight_recorder()
 
 class SystematicTestHarness
 {
+  size_t seed = 0;
+
 public:
   opt::Opt opt;
 
@@ -80,7 +82,7 @@ public:
     // When not a CI build use the seed the user specified.
     size_t random = 0;
 #endif
-    for (size_t seed = seed_lower + random; seed < seed_upper + random; seed++)
+    for (seed = seed_lower + random; seed < seed_upper + random; seed++)
     {
       std::cout << "Seed: " << seed << std::endl;
 
@@ -111,5 +113,11 @@ public:
                 << duration_cast<seconds>((t1 - start)).count() << " seconds"
                 << std::endl;
     }
+  }
+
+  size_t current_seed()
+  {
+    assert(seed != 0);
+    return seed;
   }
 };


### PR DESCRIPTION
The `seed` field was uninitialized on the construction of `SystematicTestHarness`. This has resulted in the use of uninitialized values for the xoroshiro PRNG in multiple runtime tests.