### PR TITLE
Made Verona CI build output stack traces on crashs

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -45,10 +45,10 @@ jobs:
     displayName: 'Install Build Dependencies'
 
   - task: CMake@1
-    displayName: 'CMake .. -GNinja -DCMAKE_BUILD_TYPE=$(BuildType) -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_COMPILER=$(CXX) -DCMAKE_CXX_FLAGS=$(CXXFLAGS) -DUSE_ASAN=$(Asan) -DVERONA_CI_BUILD=On -DRT_TESTS=On'
+    displayName: 'CMake .. -GNinja -DCMAKE_BUILD_TYPE=$(BuildType) -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_COMPILER=$(CXX) -DCMAKE_CXX_FLAGS=$(CXXFLAGS) -DUSE_ASAN=$(Asan) -DVERONA_CI_BUILD=On -DSNMALLOC_CI_BUILD=On -DRT_TESTS=On'
     inputs:
       cmakeArgs: |
-        .. -GNinja -DCMAKE_BUILD_TYPE=$(BuildType) -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_COMPILER=$(CXX) -DCMAKE_CXX_FLAGS=$(CXXFLAGS) -DUSE_ASAN=$(Asan) -DVERONA_CI_BUILD=On -DRT_TESTS=On
+        .. -GNinja -DCMAKE_BUILD_TYPE=$(BuildType) -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_COMPILER=$(CXX) -DCMAKE_CXX_FLAGS=$(CXXFLAGS) -DUSE_ASAN=$(Asan) -DVERONA_CI_BUILD=On -DSNMALLOC_CI_BUILD=On -DRT_TESTS=On
 
   - script: |
       ninja -j4 install
@@ -91,9 +91,9 @@ jobs:
       pip install OutputCheck
 
   - task: CMake@1
-    displayName: 'CMake .. -G"Visual Studio 15 2017 Win64" -DVERONA_CI_BUILD=On -DRT_TESTS=On'
+    displayName: 'CMake .. -G"Visual Studio 15 2017 Win64" -DVERONA_CI_BUILD=On -DSNMALLOC_CI_BUILD=On -DRT_TESTS=On'
     inputs:
-      cmakeArgs: '.. -G"Visual Studio 15 2017 Win64" -DVERONA_CI_BUILD=On -DRT_TESTS=On'
+      cmakeArgs: '.. -G"Visual Studio 15 2017 Win64" -DVERONA_CI_BUILD=On -DSNMALLOC_CI_BUILD=On -DRT_TESTS=On'
 
   - script: |
       dir /s /b
@@ -143,7 +143,7 @@ jobs:
   - task: CMake@1
     displayName: 'CMake .. -DCMAKE_BUILD_TYPE=$(BuildType) -DVERONA_CI_BUILD=On -DRT_TESTS=On'
     inputs:
-      cmakeArgs: '.. -DCMAKE_BUILD_TYPE=$(BuildType) -DVERONA_CI_BUILD=On -DRT_TESTS=On'
+      cmakeArgs: '.. -DCMAKE_BUILD_TYPE=$(BuildType) -DVERONA_CI_BUILD=On -DSNMALLOC_CI_BUILD=On -DRT_TESTS=On'
 
   - script: |
       make -j 4 install

--- a/src/compiler/main.cc
+++ b/src/compiler/main.cc
@@ -16,6 +16,7 @@
 #include "fs.h"
 #include "interpreter/interpreter.h"
 #include "interpreter/options.h"
+#include "test/setup.h"
 
 #include <CLI/CLI.hpp>
 #include <cstring>
@@ -206,6 +207,7 @@ namespace verona::compiler
   int main(int argc, const char** argv)
   {
     enable_colour_console();
+    setup();
 
     Options options;
 

--- a/src/interpreter/main.cc
+++ b/src/interpreter/main.cc
@@ -3,6 +3,8 @@
 #include "interpreter/code.h"
 #include "interpreter/interpreter.h"
 #include "interpreter/options.h"
+#include "test/setup.h"
+#include "ds/console.h"
 
 #include <CLI/CLI.hpp>
 #include <verona.h>
@@ -19,6 +21,9 @@ struct Options : public verona::interpreter::InterpreterOptions
 
 int main(int argc, const char** argv)
 {
+  enable_colour_console();
+  setup();
+
   Options options;
 
   CLI::App app{"Verona Bytecode Interpreter"};

--- a/testsuite/common.cmake
+++ b/testsuite/common.cmake
@@ -57,6 +57,8 @@ function(CheckStatus)
 
   if(NOT ${code} EQUAL ${CHECK_STATUS_EXPECTED_STATUS})
     message(FATAL_ERROR " \"${cmd_str}\" exited with error code ${code}, expected ${CHECK_STATUS_EXPECTED_STATUS}")
+  else()
+    message(STATUS "Executing \"${cmd_str}\" completed!")
   endif()
 endfunction()
 


### PR DESCRIPTION
This makes the veronac and interpreter output exceptions
and not produce a dialog box on Windows for debugging
when inside a CI build.