### PR TITLE
Cmake now uses a flag rather than environment variables

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -125,7 +125,7 @@ to provide the other configurations.
 Note: Sometimes `cmake` detects `gcc` instead of `clang`.
 To override this, run `cmake` with environment variables, for example:
 ```
-cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DCMAKE_CC_COMPILER=/usr/bin/clang
+cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DCMAKE_C_COMPILER=/usr/bin/clang
 ```
 This may require you to remove your CMakeCache.txt file from the build
 directory.

--- a/docs/building.md
+++ b/docs/building.md
@@ -125,7 +125,7 @@ to provide the other configurations.
 Note: Sometimes `cmake` detects `gcc` instead of `clang`.
 To override this, run `cmake` with environment variables, for example:
 ```
-CC=clang CXX=clang++ cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug
+cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DCMAKE_CC_COMPILER=/usr/bin/clang
 ```
 This may require you to remove your CMakeCache.txt file from the build
 directory.


### PR DESCRIPTION
Applied the proper cmake flags to set the C and C++ compiler.

```
CC=...
CXX=...
```

These environment variables can have side effects for the rest of the system, it's better to have cmake use it for 1 specific build.

