### PR TITLE
Resolved an issue where in the future cv qualifiers could be ignored

### DIFF
--- a/src/compiler/main.cc
+++ b/src/compiler/main.cc
@@ -123,7 +123,7 @@ namespace verona::compiler
         auto directory = input_file.remove_filename();
         if (directory.empty())
           directory = ".";
-        auto new_input_file = directory.string() + "/" + (std::string)*include;
+        auto new_input_file = directory.string() + "/" + static_cast<std::string>(*include);
         work_list.push(new_input_file);
       }
 


### PR DESCRIPTION
There was a c-style cast in the main.cc file which, in the future, could possibly discard const qualifiers.

Future proofing :)