### PR TITLE
Make the VM stricter about field writes

### DIFF
--- a/src/interpreter/vm.cc
+++ b/src/interpreter/vm.cc
@@ -509,11 +509,16 @@ namespace verona::interpreter
   void VM::opcode_store(
     Register dst, const Value& base, SelectorIdx selector, Value src)
   {
-    check_type(base, {Value::Tag::ISO, Value::Tag::MUT, Value::Tag::IMM});
+    check_type(base, {Value::Tag::ISO, Value::Tag::MUT});
 
     VMObject* object = base->object;
     const VMDescriptor* desc = object->descriptor();
     size_t index = desc->fields[selector];
+
+    if (src.tag == Value::Tag::MUT && object->region() != src->object->region())
+    {
+      fatal("Writing reference to incorrect region");
+    }
 
     Value old_value =
       object->fields[index].exchange(alloc_, object->region(), std::move(src));


### PR DESCRIPTION
The STORE opcode is never valid on an IMM reference, so we can
disallow that. Additionally when writing a MUT value, the regions of
the two objects must match.

In practice the first check should never fail as the compiler will
disallow this statically. The second can happen as the compiler
doesn't enforce region equality yet, so it's nice to have a dynamic
check.