### PR TITLE
Dynamically sized objects

### DIFF
--- a/src/compiler/codegen/builtins.cc
+++ b/src/compiler/codegen/builtins.cc
@@ -31,6 +31,8 @@ namespace verona::compiler
         return builtin_freeze();
       else if (method == "trace")
         return builtin_trace_region();
+      else if (method == "error")
+        return builtin_error();
     }
     else if (entity == "U64")
     {
@@ -133,6 +135,17 @@ namespace verona::compiler
     gen_.opcode(Opcode::Clear);
     gen_.reg(Register(1));
     gen_.opcode(Opcode::Return);
+  }
+
+  void BuiltinGenerator::builtin_error()
+  {
+    assert(abi_.arguments == 2);
+    assert(abi_.returns == 1);
+
+    gen_.opcode(Opcode::Error);
+    gen_.reg(Register(1));
+
+    // This opcode aborts the VM and never returns.
   }
 
   void BuiltinGenerator::builtin_binop(bytecode::BinaryOperator op)

--- a/src/compiler/codegen/builtins.cc
+++ b/src/compiler/codegen/builtins.cc
@@ -76,6 +76,21 @@ namespace verona::compiler
       else if (method == "_fulfill_sleeping")
         return builtin_cown_fulfill_sleeping();
     }
+    else if (entity == "Pointer")
+    {
+      if (method == "allocate")
+        return builtin_pointer_allocate();
+      else if (method == "free")
+        return builtin_pointer_free();
+      else if (method == "get")
+        return builtin_pointer_get();
+      else if (method == "set")
+        return builtin_pointer_set();
+      else if (method == "swap")
+        return builtin_pointer_swap();
+      else if (method == "move")
+        return builtin_pointer_move();
+    }
     fmt::print(stderr, "Invalid builtin {}.{}\n", entity, method);
     abort();
   }
@@ -205,6 +220,117 @@ namespace verona::compiler
     gen_.reg(Register(0));
     gen_.opcode(Opcode::Clear);
     gen_.reg(Register(1));
+    gen_.opcode(Opcode::Return);
+  }
+
+  void BuiltinGenerator::builtin_pointer_allocate()
+  {
+    assert(abi_.arguments == 2);
+    assert(abi_.returns == 1);
+    gen_.opcode(Opcode::PointerAllocate);
+    gen_.reg(Register(0));
+    gen_.reg(Register(1));
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(1));
+    gen_.opcode(Opcode::Return);
+  }
+
+  void BuiltinGenerator::builtin_pointer_free()
+  {
+    assert(abi_.arguments == 3);
+    assert(abi_.returns == 1);
+    gen_.opcode(Opcode::PointerFree);
+    gen_.reg(Register(1));
+    gen_.reg(Register(2));
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(2));
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(1));
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(0));
+    gen_.opcode(Opcode::Return);
+  }
+
+  void BuiltinGenerator::builtin_pointer_get()
+  {
+    assert(abi_.arguments == 4);
+    assert(abi_.returns == 1);
+    gen_.opcode(Opcode::PointerGet);
+    gen_.reg(Register(0));
+    gen_.reg(Register(1));
+    gen_.reg(Register(2));
+    gen_.reg(Register(3));
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(3));
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(2));
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(1));
+    gen_.opcode(Opcode::Return);
+  }
+
+  void BuiltinGenerator::builtin_pointer_set()
+  {
+    assert(abi_.arguments == 5);
+    assert(abi_.returns == 1);
+    gen_.opcode(Opcode::PointerSet);
+    gen_.reg(Register(1));
+    gen_.reg(Register(2));
+    gen_.reg(Register(3));
+    gen_.reg(Register(4));
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(4));
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(3));
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(2));
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(1));
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(0));
+    gen_.opcode(Opcode::Return);
+  }
+
+  void BuiltinGenerator::builtin_pointer_swap()
+  {
+    assert(abi_.arguments == 5);
+    assert(abi_.returns == 1);
+    gen_.opcode(Opcode::PointerSwap);
+    gen_.reg(Register(0));
+    gen_.reg(Register(1));
+    gen_.reg(Register(2));
+    gen_.reg(Register(3));
+    gen_.reg(Register(4));
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(4));
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(3));
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(2));
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(1));
+    gen_.opcode(Opcode::Return);
+  }
+
+  void BuiltinGenerator::builtin_pointer_move()
+  {
+    assert(abi_.arguments == 5);
+    assert(abi_.returns == 1);
+    gen_.opcode(Opcode::PointerMove);
+    gen_.reg(Register(1));
+    gen_.reg(Register(2));
+    gen_.reg(Register(3));
+    gen_.reg(Register(4));
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(4));
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(3));
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(2));
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(1));
+    gen_.opcode(Opcode::Clear);
+    gen_.reg(Register(0));
     gen_.opcode(Opcode::Return);
   }
 }

--- a/src/compiler/codegen/builtins.h
+++ b/src/compiler/codegen/builtins.h
@@ -26,6 +26,8 @@ namespace verona::compiler
     void builtin_freeze();
     void builtin_trace_region();
     void builtin_binop(bytecode::BinaryOperator op);
+    void builtin_error();
+
     void builtin_cown_create();
     void builtin_cown_create_sleeping();
     void builtin_cown_fulfill_sleeping();

--- a/src/compiler/codegen/builtins.h
+++ b/src/compiler/codegen/builtins.h
@@ -31,5 +31,12 @@ namespace verona::compiler
     void builtin_cown_create();
     void builtin_cown_create_sleeping();
     void builtin_cown_fulfill_sleeping();
+
+    void builtin_pointer_allocate();
+    void builtin_pointer_free();
+    void builtin_pointer_get();
+    void builtin_pointer_set();
+    void builtin_pointer_swap();
+    void builtin_pointer_move();
   };
 }

--- a/src/compiler/codegen/generator.cc
+++ b/src/compiler/codegen/generator.cc
@@ -93,19 +93,6 @@ namespace verona::compiler
     u8(frame_size, child_callspace - reg.index);
   }
 
-  template<typename T>
-  void Generator::write(std::common_type_t<T> value)
-  {
-    static_assert(std::is_integral_v<T>);
-
-    size_t offset = code_.size();
-    code_.reserve(offset + sizeof(T));
-    for (size_t i = 0; i < sizeof(T) * 8; i += 8)
-    {
-      code_.push_back((value >> i) & 0xff);
-    }
-  }
-
   void Generator::finish()
   {
     for (const auto& rel : relocations_)

--- a/src/compiler/codegen/selector.cc
+++ b/src/compiler/codegen/selector.cc
@@ -23,4 +23,14 @@ namespace verona::compiler
   {
     return selectors_.at(selector);
   }
+
+  std::optional<bytecode::SelectorIdx>
+  SelectorTable::try_get(const Selector& selector) const
+  {
+    auto it = selectors_.find(selector);
+    if (it != selectors_.end())
+      return it->second;
+    else
+      return std::nullopt;
+  }
 }

--- a/src/compiler/codegen/selector.h
+++ b/src/compiler/codegen/selector.h
@@ -53,7 +53,10 @@ namespace verona::compiler
   {
   public:
     static SelectorTable build(const Reachability& reachability);
+
     bytecode::SelectorIdx get(const Selector& selector) const;
+    std::optional<bytecode::SelectorIdx>
+    try_get(const Selector& selector) const;
 
   private:
     SelectorTable() {}

--- a/src/interpreter/bytecode.h
+++ b/src/interpreter/bytecode.h
@@ -151,6 +151,7 @@ namespace verona::bytecode
     Call, // selector(u32), callspace(u8)
     Clear, // dst(u8)
     Copy, // dst(u8), src(u8)
+    Error, // reason(u8)
     FulfillSleepingCown, // cown(u8), val(u8)
     Freeze, // dst(u8), src(u8)
     Int64, // dst(u8), immediate(u64)
@@ -237,6 +238,13 @@ namespace verona::bytecode
   {
     using Operands = OpcodeOperands<Register, Register>;
     constexpr static std::string_view format = "COPY {}, {}";
+  };
+
+  template<>
+  struct OpcodeSpec<Opcode::Error>
+  {
+    using Operands = OpcodeOperands<Register>;
+    constexpr static std::string_view format = "ERROR {}";
   };
 
   template<>

--- a/src/interpreter/bytecode.h
+++ b/src/interpreter/bytecode.h
@@ -18,8 +18,12 @@
  * - 32-bit descriptor index of Main class
  * - 32-bit selector index of main method
  * - 32-bit descriptor index of U64 class (optional)
+ * - 32-bit selector index of the `_data` field (optional)
+ * - 32-bit selector index of the `_size` field (optional)
+ * - 32-bit selector index of the `_capacity` field (optional)
  *
  * Descriptor:
+ * - 8-bit descriptor kind
  * - 16-bit name length, followed by the name bytes
  * - 32-bit size of the fields vtable
  * - 32-bit number of fields
@@ -123,6 +127,9 @@ namespace verona::bytecode
   static constexpr DescriptorIdx INVALID_DESCRIPTOR =
     std::numeric_limits<DescriptorIdx>::max();
 
+  static constexpr DescriptorIdx INVALID_SELECTOR =
+    std::numeric_limits<SelectorIdx>::max();
+
   struct FunctionHeader
   {
     std::string_view name;
@@ -203,6 +210,26 @@ namespace verona::bytecode
     Or,
 
     maximum_value = Or,
+  };
+
+  enum class DescriptorKind : uint8_t
+  {
+    // Intended for values that are not managed by the runtime, eg. U64 or
+    // Pointer. The descriptor is just used for method dispatch.
+    Primitive,
+
+    // Not really used for much yet, eventually might add pattern matching.
+    Interface,
+
+    // The VM provides trace/finalise/destructor functions which traverse all
+    // fields.
+    Class,
+
+    // The provided trace/finalise/destructor methods also manage the contents
+    // of the array, by accessing the _data/_size/_capacity fields.
+    Array,
+
+    maximum_value = Array,
   };
 
   template<typename... Args>

--- a/src/interpreter/bytecode.h
+++ b/src/interpreter/bytecode.h
@@ -168,6 +168,12 @@ namespace verona::bytecode
     NewCown, // dst(u8), descriptor(u8), src(u8)
     NewRegion, // dst(u8), descriptor(u8)
     NewSleepingCown, // dst(u8), descriptor(u8)
+    PointerAllocate, // dst(u8), size(u8)
+    PointerFree, // ptr(u8), size(u8)
+    PointerGet, // dst(u8), parent(u8), ptr(u8), index(u8)
+    PointerSet, // parent(u8), ptr(u8), index(u8), value(u8)
+    PointerSwap, // dst(u8), parent(u8), ptr(u8), index(u8), value(u8)
+    PointerMove, // parent(u8), from(u8), to(u8), size(u8)
     Print, // format(u8), argc(u8), args(u8)...
     Return,
     Store, // dst(u8), base(u8), selector(u32), src(u8)
@@ -343,6 +349,49 @@ namespace verona::bytecode
   {
     using Operands = OpcodeOperands<Register, Register>;
     constexpr static std::string_view format = "NEW_SLEEPING_COWN {} {}";
+  };
+
+  template<>
+  struct OpcodeSpec<Opcode::PointerAllocate>
+  {
+    using Operands = OpcodeOperands<Register, Register>;
+    constexpr static std::string_view format = "PTR ALLOCATE {} {}";
+  };
+
+  template<>
+  struct OpcodeSpec<Opcode::PointerFree>
+  {
+    using Operands = OpcodeOperands<Register, Register>;
+    constexpr static std::string_view format = "PTR FREE {} {}";
+  };
+
+  template<>
+  struct OpcodeSpec<Opcode::PointerGet>
+  {
+    using Operands = OpcodeOperands<Register, Register, Register, Register>;
+    constexpr static std::string_view format = "PTR GET {} {} {} {}";
+  };
+
+  template<>
+  struct OpcodeSpec<Opcode::PointerSet>
+  {
+    using Operands = OpcodeOperands<Register, Register, Register, Register>;
+    constexpr static std::string_view format = "PTR SET {} {} {} {}";
+  };
+
+  template<>
+  struct OpcodeSpec<Opcode::PointerSwap>
+  {
+    using Operands =
+      OpcodeOperands<Register, Register, Register, Register, Register>;
+    constexpr static std::string_view format = "PTR SWAP {} {} {} {} {}";
+  };
+
+  template<>
+  struct OpcodeSpec<Opcode::PointerMove>
+  {
+    using Operands = OpcodeOperands<Register, Register, Register, Register>;
+    constexpr static std::string_view format = "PTR MOVE {} {} {} {}";
   };
 
   template<>

--- a/src/interpreter/code.h
+++ b/src/interpreter/code.h
@@ -13,6 +13,7 @@ namespace verona::interpreter
 {
   using bytecode::CodePtr;
   using bytecode::DescriptorIdx;
+  using bytecode::DescriptorKind;
   using bytecode::FunctionHeader;
   using bytecode::Opcode;
   using bytecode::SelectorIdx;
@@ -27,6 +28,9 @@ namespace verona::interpreter
     const VMDescriptor* main;
     SelectorIdx main_selector;
     const VMDescriptor* u64;
+    SelectorIdx data_field_selector;
+    SelectorIdx size_field_selector;
+    SelectorIdx capacity_field_selector;
   };
 
   class Code
@@ -151,6 +155,8 @@ namespace verona::interpreter
       special_descriptors_.main_selector = load<SelectorIdx>(ip);
       special_descriptors_.u64 =
         get_optional_descriptor(load<DescriptorIdx>(ip));
+      special_descriptors_.data_field_selector = load<SelectorIdx>(ip);
+      special_descriptors_.size_field_selector = load<SelectorIdx>(ip);
     }
 
     const std::vector<std::unique_ptr<const VMDescriptor>>& descriptors()
@@ -205,6 +211,7 @@ namespace verona::interpreter
 
     std::unique_ptr<VMDescriptor> load_descriptor(size_t& ip)
     {
+      DescriptorKind kind = load<DescriptorKind>(ip);
       std::string_view name = str(ip);
       uint32_t method_slots = u32(ip);
       uint32_t method_count = u32(ip);
@@ -213,7 +220,7 @@ namespace verona::interpreter
       uint32_t finaliser_ip = u32(ip);
 
       auto descriptor = std::make_unique<VMDescriptor>(
-        name, method_slots, field_slots, field_count, finaliser_ip);
+        kind, name, method_slots, field_slots, field_count, finaliser_ip);
 
       for (uint32_t i = 0; i < method_count; i++)
       {

--- a/src/interpreter/format.h
+++ b/src/interpreter/format.h
@@ -102,6 +102,9 @@ private:
       case Value::DESCRIPTOR:
         return fmt::format_to(it, "descriptor({})", inner.descriptor->name);
 
+      case Value::POINTER:
+        return fmt::format_to(it, "pointer({})", fmt::ptr(inner.pointer));
+
         EXHAUSTIVE_SWITCH;
     }
   }
@@ -161,6 +164,8 @@ struct fmt::formatter<verona::interpreter::Value::Tag>
         return fmt::format_to(ctx.out(), "DESCRIPTOR");
       case Tag::STRING:
         return fmt::format_to(ctx.out(), "STRING");
+      case Tag::POINTER:
+        return fmt::format_to(ctx.out(), "POINTER");
 
         EXHAUSTIVE_SWITCH
     }

--- a/src/interpreter/object.cc
+++ b/src/interpreter/object.cc
@@ -9,6 +9,7 @@
 namespace verona::interpreter
 {
   VMDescriptor::VMDescriptor(
+    DescriptorKind kind,
     std::string_view name,
     size_t method_slots,
     size_t field_slots,
@@ -20,20 +21,46 @@ namespace verona::interpreter
     field_count(field_count),
     finaliser_ip(finaliser_ip)
   {
-    rt::Descriptor::size = sizeof(VMObject);
-    rt::Descriptor::trace = VMObject::trace_fn;
+    switch (kind)
+    {
+      case DescriptorKind::Class:
+        rt::Descriptor::size = sizeof(VMObject);
+        rt::Descriptor::trace = VMObject::trace_fn;
 
-    // Try to be on the trivial ring as much as possible. This requires the
-    // following three methods to be null.
-    //
-    // If there are no fields, then VMObject's destructor is a no-op and we can
-    // skip it. In that case, there are also obviously no iso fields.
-    rt::Descriptor::destructor =
-      field_count > 0 ? VMObject::destructor_fn : nullptr;
-    rt::Descriptor::trace_possibly_iso =
-      field_count > 0 ? VMObject::trace_fn : nullptr;
-    rt::Descriptor::finaliser =
-      finaliser_ip > 0 ? VMObject::finaliser_fn : nullptr;
+        // Try to be on the trivial ring as much as possible. This requires the
+        // following three methods to be null.
+        //
+        // If there are no fields, then VMObject's destructor is a no-op and we
+        // can skip it. In that case, there are also obviously no iso fields.
+        rt::Descriptor::destructor =
+          field_count > 0 ? VMObject::destructor_fn : nullptr;
+        rt::Descriptor::trace_possibly_iso =
+          field_count > 0 ? VMObject::trace_fn : nullptr;
+        rt::Descriptor::finaliser =
+          finaliser_ip > 0 ? VMObject::finaliser_fn : nullptr;
+        break;
+
+      case DescriptorKind::Array:
+        rt::Descriptor::size = sizeof(VMObject);
+        rt::Descriptor::trace = VMObject::array_trace_fn;
+        rt::Descriptor::destructor = VMObject::array_destructor_fn;
+        rt::Descriptor::trace_possibly_iso = VMObject::array_trace_fn;
+        rt::Descriptor::finaliser =
+          finaliser_ip > 0 ? VMObject::finaliser_fn : nullptr;
+        break;
+
+      case DescriptorKind::Interface:
+        // We never allocate an object with an interface descriptor, so we
+        // there's no need to setup anything.
+        break;
+
+      case DescriptorKind::Primitive:
+        // Primitives are not managed by the runtime, so they don't need any of
+        // the `rt` fields.
+        //
+        // The descriptor's main purpose is to provide method dispatch.
+        break;
+    }
   }
 
   VMObject::VMObject(VMObject* region) : parent_(region)
@@ -78,5 +105,22 @@ namespace verona::interpreter
   {
     VMObject* object = static_cast<VMObject*>(base_object);
     (object)->~VMObject();
+  }
+
+  void VMObject::array_trace_fn(
+    const rt::Object* base_object, rt::ObjectStack* stack)
+  {
+    const VMObject* object = static_cast<const VMObject*>(base_object);
+    VM::local_vm->trace_array_data(object, stack);
+
+    trace_fn(object, stack);
+  }
+
+  void VMObject::array_destructor_fn(rt::Object* base_object)
+  {
+    VMObject* object = static_cast<VMObject*>(base_object);
+    VM::local_vm->dealloc_array_data(object);
+
+    destructor_fn(object);
   }
 }

--- a/src/interpreter/object.h
+++ b/src/interpreter/object.h
@@ -12,6 +12,7 @@ namespace verona::interpreter
   struct VMDescriptor : public rt::Descriptor
   {
     VMDescriptor(
+      bytecode::DescriptorKind kind,
       std::string_view name,
       size_t method_slots,
       size_t field_slots,
@@ -46,6 +47,10 @@ namespace verona::interpreter
     static void trace_fn(const rt::Object* base_object, rt::ObjectStack* stack);
     static void finaliser_fn(rt::Object* base_object);
     static void destructor_fn(rt::Object* base_object);
+
+    static void
+    array_trace_fn(const rt::Object* base_object, rt::ObjectStack* stack);
+    static void array_destructor_fn(rt::Object* base_object);
 
   private:
     VMObject* parent_;

--- a/src/interpreter/value.cc
+++ b/src/interpreter/value.cc
@@ -208,6 +208,11 @@ namespace verona::interpreter
     return inner.object;
   }
 
+  bool FieldValue::is_initialized() const
+  {
+    return tag == Value::UNINIT;
+  }
+
   Value FieldValue::read(Value::Tag parent)
   {
     assert(

--- a/src/interpreter/value.h
+++ b/src/interpreter/value.h
@@ -12,6 +12,7 @@ namespace verona::interpreter
   struct VMDescriptor;
   struct VMObject;
   struct VMCown;
+  struct FieldValue;
 
   /**
    * Tagged Verona value, which handles ownership of objects and reference
@@ -39,6 +40,7 @@ namespace verona::interpreter
       COWN,
       COWN_UNOWNED,
 
+      POINTER,
       STRING,
     };
 
@@ -50,6 +52,7 @@ namespace verona::interpreter
       const VMDescriptor* descriptor;
       uint64_t u64;
       std::string* string_ptr;
+      FieldValue* pointer;
 
       std::string& string()
       {
@@ -78,6 +81,8 @@ namespace verona::interpreter
     static Value imm(VMObject* object);
     // Takes ownership of the reference count.
     static Value cown(VMCown* cown);
+
+    static Value pointer(FieldValue* ptr);
 
     static Value descriptor(const VMDescriptor* descriptor);
 
@@ -155,6 +160,7 @@ namespace verona::interpreter
     static constexpr Tag DESCRIPTOR = Tag::DESCRIPTOR;
     static constexpr Tag COWN = Tag::COWN;
     static constexpr Tag COWN_UNOWNED = Tag::COWN_UNOWNED;
+    static constexpr Tag POINTER = Tag::POINTER;
     static constexpr Tag STRING = Tag::STRING;
   };
 

--- a/src/interpreter/value.h
+++ b/src/interpreter/value.h
@@ -176,6 +176,8 @@ namespace verona::interpreter
     FieldValue() : tag(Value::UNINIT) {}
     ~FieldValue();
 
+    bool is_initialized() const;
+
     /**
      * Get the contents of the FieldValue.
      *

--- a/src/interpreter/vm.cc
+++ b/src/interpreter/vm.cc
@@ -289,6 +289,11 @@ namespace verona::interpreter
     return std::move(src);
   }
 
+  void VM::opcode_error(std::string_view reason)
+  {
+    fatal("{}", reason);
+  }
+
   Value VM::opcode_int64(uint64_t imm)
   {
     return Value::u64(imm);
@@ -572,6 +577,7 @@ namespace verona::interpreter
       OP(Clear, opcode_clear);
       OP(Copy, opcode_copy);
       OP(FulfillSleepingCown, opcode_fulfill_sleeping_cown);
+      OP(Error, opcode_error);
       OP(Freeze, opcode_freeze);
       OP(Int64, opcode_int64);
       OP(Jump, opcode_jump);

--- a/src/interpreter/vm.h
+++ b/src/interpreter/vm.h
@@ -51,6 +51,16 @@ namespace verona::interpreter
      **/
     static void execute_finaliser(VMObject* object);
 
+    /**
+     * Clear the contents of an Array object and deallocate its allocated memory.
+     */
+    void dealloc_array_data(const VMObject* object);
+
+    /**
+     * Trace through every element of an Array object.
+     */
+    void trace_array_data(const VMObject* object, rt::ObjectStack* stack);
+
   private:
     Value
     opcode_binop(bytecode::BinaryOperator op, uint64_t left, uint64_t right);
@@ -134,6 +144,19 @@ namespace verona::interpreter
 
     const VMDescriptor* find_dispatch_descriptor(Register receiver) const;
 
+    struct ArrayFields
+    {
+      FieldValue* data;
+      size_t size;
+      size_t capacity;
+    };
+
+    /**
+     * Load the fields of an Array object, using the selectors from the
+     * SpecialDescriptors table.
+     */
+    ArrayFields load_array_fields(const VMObject* object) const;
+
     template<typename... Args>
     void trace(std::string_view fmt, Args&&... args) const
     {
@@ -154,8 +177,14 @@ namespace verona::interpreter
       abort();
     }
 
-    void check_type(const Value& value, Value::Tag expected);
-    void check_type(const Value& value, std::vector<Value::Tag> expected);
+    template<typename... Args>
+    void check(bool condition, std::string_view fmt, Args&&... args) const
+    {
+      if (!condition)
+        fatal(fmt, std::forward<Args>(args)...);
+    }
+    void check_type(const Value& value, Value::Tag expected) const;
+    void check_type(const Value& value, std::vector<Value::Tag> expected) const;
 
     const Code& code_;
     rt::Alloc* alloc_;

--- a/src/interpreter/vm.h
+++ b/src/interpreter/vm.h
@@ -83,6 +83,17 @@ namespace verona::interpreter
     opcode_when(CodePtr selector, uint8_t cown_count, uint8_t capture_count);
     void opcode_unreachable();
 
+    Value opcode_pointer_allocate(uint64_t size);
+    void opcode_pointer_free(const Value& parent, uint64_t size);
+    Value
+    opcode_pointer_get(const Value& parent, const Value& ptr, uint64_t index);
+    void opcode_pointer_set(
+      const Value& parent, const Value& ptr, uint64_t index, Value value);
+    Value opcode_pointer_swap(
+      const Value& parent, const Value& ptr, uint64_t index, Value value);
+    void opcode_pointer_move(
+      const Value& parent, const Value& src, const Value& dst, uint64_t size);
+
     /**
      * Switches on the opcode value and invokes the appropriate handler.
      */

--- a/src/interpreter/vm.h
+++ b/src/interpreter/vm.h
@@ -58,6 +58,7 @@ namespace verona::interpreter
     void call(size_t addr, uint8_t callspace);
     Value opcode_clear();
     Value opcode_copy(Value src);
+    void opcode_error(std::string_view reason);
     void opcode_fulfill_sleeping_cown(const Value& cown, Value result);
     Value opcode_freeze(Value src);
     Value opcode_int64(uint64_t imm);

--- a/src/stdlib/builtin.verona
+++ b/src/stdlib/builtin.verona
@@ -26,6 +26,9 @@ class Builtin {
   // TODO: invalidate other references into this region
   // TODO: needs expanding as we add other region allocation strategies
   builtin trace(x : mut);
+
+  // Print the given message and abort execution.
+  builtin error[T](reason: String): T;
 }
 
 /**

--- a/src/stdlib/builtin.verona
+++ b/src/stdlib/builtin.verona
@@ -112,3 +112,66 @@ primitive U64 {
   builtin and(self: imm, other: U64 & imm): U64 & imm;
   builtin or(self: imm, other: U64 & imm): U64 & imm;
 }
+
+/**
+ * Manually managed array of values.
+ *
+ * This API is unsafe, and should only be used to implement Array.
+ *
+ * The elements stored through the pointer are not traced automatically. They
+ * should instead be traced through some other mean. For example, the trace
+ * function of Array is special cased to cover its backing array.
+ */
+primitive Pointer[T] {
+  /**
+   * Allocate a block of memory.
+   *
+   * The size is specified in number of elements, not in bytes.
+   */
+  builtin allocate(size: U64 & imm): Pointer[T] & imm;
+
+  /**
+   * Free a block of memory.
+   *
+   * The size argument must match the size that was used during allocation.
+   * All elements in the allocation must be uninitialized.
+   */
+  builtin free(ptr: Pointer[T] & imm, size: U64);
+
+  /**
+   * Get the element at the given index.
+   *
+   * The parent argument is used to apply region information and viewpoint
+   * adaptation.
+   */
+  builtin get(parent: (mut | imm), ptr: Pointer[T] & imm, index: U64 & imm): T
+    where return in parent;
+
+  /**
+   * Set the value at a given index. That location must be uninitialized prior
+   * to calling this function. If it is initialized, then the swap method should
+   * be used instead to ensure the old value is collected correctly.
+   *
+   * The parent argument is used to apply region information and to access the
+   * remembered set in case a reference counted value is written.
+   */
+  builtin set(parent: mut, ptr: Pointer[T] & imm, index: U64 & imm, value: T)
+    where value in parent;
+
+  /**
+   * Replace the value at a given index.
+   *
+   * The parent argument is used to apply region information and to access the
+   * remembered set in case a reference counted value is written.
+   */
+  builtin swap(parent: mut, ptr: Pointer[T] & imm, index: U64 & imm, value: T): T
+    where value in parent, return from parent;
+
+  /**
+   * Move a set of values from one allocation to another. The memory locations
+   * in the destination array must be uninitialized. The locations in the source
+   * array will be uninitialized after this method is called.
+   */
+  builtin move(parent: mut, src: Pointer[T] & imm, dst: Pointer[T] & imm, size: U64 & imm);
+}
+

--- a/src/stdlib/builtin.verona
+++ b/src/stdlib/builtin.verona
@@ -175,3 +175,106 @@ primitive Pointer[T] {
   builtin move(parent: mut, src: Pointer[T] & imm, dst: Pointer[T] & imm, size: U64 & imm);
 }
 
+/**
+ * Dynamically resizable array.
+ *
+ * Codegen and the VM have special support for this class. The trace function
+ * will traverse the first _size elements of the _data field. The class'
+ * destructor clears the data and frees the underlying memory allocation.
+ */
+class Array[T] {
+  _data: Pointer[T] & imm;
+  _size: U64 & imm;
+  _capacity: U64 & imm;
+
+  create(): Array[T] & iso
+  {
+    var this = new Array;
+    this._data = Pointer.allocate(0);
+    this._size = 0;
+    this._capacity = 0;
+    this
+  }
+
+  push_back(self: mut, value: T)
+    where value in self
+  {
+    if (self._size + 1) > self._capacity
+    {
+      self._grow();
+    };
+
+    Pointer.set(self, self._data, self._size, value);
+    self._size = self._size + 1;
+  }
+
+  _grow(self: mut)
+  {
+    if self._capacity == 0 {
+      Pointer.free(self._data, self._capacity);
+
+      self._capacity = 8;
+      self._data = Pointer.allocate(self._capacity);
+    } else {
+      var ew_capacity = 2 * self._capacity;
+      var ew_data = Pointer.allocate(ew_capacity);
+
+      Pointer.move(self, self._data, ew_data, self._size);
+      Pointer.free(self._data, self._capacity);
+
+      self._capacity = ew_capacity;
+      self._data = ew_data;
+    }
+  }
+
+  apply(self: mut, index: U64 & imm): T
+    where return in self
+  {
+    if index >= self._size
+    {
+      Builtin.error("Out-of-bound access")
+    }
+    else
+    {
+      Pointer.get(self, self._data, index)
+    }
+  }
+
+  update(self: mut, index: U64 & imm, value: T): T
+    where value in self, return from self
+  {
+    if index >= self._size
+    {
+      Builtin.error("Out-of-bound access")
+    }
+    else
+    {
+      Pointer.swap(self, self._data, index, value)
+    }
+  }
+
+  size(self: mut): U64
+  {
+    self._size
+  }
+
+  capacity(self: mut): U64
+  {
+    self._capacity
+  }
+
+  print(self: mut)
+  {
+    var i = 0;
+    Builtin.print("{{");
+    while i < self._size {
+      if i == 0 {
+        Builtin.print1("{}", self.apply(i));
+      } else {
+        Builtin.print1(", {}", self.apply(i));
+      };
+      i = i + 1;
+    };
+    Builtin.print("}}");
+  }
+}

--- a/testsuite/features/run-pass/array.verona
+++ b/testsuite/features/run-pass/array.verona
@@ -1,0 +1,20 @@
+class Main
+{
+  main()
+  {
+    var x = mut-view (Array.create());
+    var i = 1;
+    while i <= 10 {
+      x.push_back(i);
+      i = i + 1;
+    };
+
+    // CHECK-L: size = 10
+    // CHECK-L: capacity = 16
+    // CHECK-L: {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+    Builtin.print1("size = {}\n", x.size());
+    Builtin.print1("capacity = {}\n", x.capacity());
+    x.print();
+  }
+}
+


### PR DESCRIPTION
This PR adds support for dynamically sized arrays, through a Pointer primitive and a wrapper Array class. The codegen and VM have special knowledge of the Array class, as they need to provide a custom trace and destructor function.

The chunk of memory referenced by the Array is uniquely owned by it. Ideally we would be able to have many slices all pointing into the same block, without needing any indirection, but there's a few issues around tracing and GC that prevents that. I'll write it up in some issue later to see if anyone has a solution.