### PR TITLE
Fixed test generation of CI

### DIFF
--- a/src/rt/CMakeLists.txt
+++ b/src/rt/CMakeLists.txt
@@ -149,7 +149,11 @@ if(NOT DEFINED VERONA_RT_ONLY_HEADER_LIBRARY)
   # Try to avoid testing fairness of OS.
   set_tests_properties(func-con-fair_variance PROPERTIES PROCESSORS 7)
 
-  MATH(EXPR CHUNK "500")
+  if (VERONA_CI)
+    MATH(EXPR CHUNK "100")
+  else ()
+    MATH(EXPR CHUNK "500")
+  endif ()
 
   # cowngc{1,4} are basically variations on the same test.
   # The other cowngc tests are more complicated.


### PR DESCRIPTION
The test generation for CI is problematic.  When the CHUNK size was
made larger for the testing it meant the systematic test names no longer
match the regexp for making a smaller set of running tests in CI.

This test reduces the batch size in CI, so the original regexp still
works.