### PR TITLE
Fix error when compiling RT tests

### DIFF
--- a/src/rt/test/func/cowngc1/cowngc1.cc
+++ b/src/rt/test/func/cowngc1/cowngc1.cc
@@ -81,6 +81,18 @@ struct CCown;
 struct RCown;
 static RCown* rcown_first;
 
+struct CCown : public VCown<CCown>
+{
+  CCown* child;
+  CCown(CCown* child_) : child(child_) {}
+
+  void trace(ObjectStack* fields) const
+  {
+    if (child != nullptr)
+      fields->push(child);
+  }
+};
+
 template<RegionType region_type>
 struct O : public V<O<region_type>, region_type>
 {
@@ -97,18 +109,6 @@ struct O : public V<O<region_type>, region_type>
 };
 using OTrace = O<RegionType::Trace>;
 using OArena = O<RegionType::Arena>;
-
-struct CCown : public VCown<CCown>
-{
-  CCown* child;
-  CCown(CCown* child_) : child(child_) {}
-
-  void trace(ObjectStack* fields) const
-  {
-    if (child != nullptr)
-      fields->push(child);
-  }
-};
 
 struct RCown : public VCown<RCown>
 {

--- a/src/rt/test/func/cowngc4/cowngc4.cc
+++ b/src/rt/test/func/cowngc4/cowngc4.cc
@@ -65,7 +65,18 @@ struct PRNG
   }
 };
 
-struct CCown;
+struct CCown : public VCown<CCown>
+{
+  CCown* child;
+  CCown(CCown* child_) : child(child_) {}
+
+  void trace(ObjectStack* fields) const
+  {
+    if (child != nullptr)
+      fields->push(child);
+  }
+};
+
 template<RegionType region_type>
 struct RCown;
 
@@ -109,18 +120,6 @@ struct O : public V<O<region_type>, region_type>
 
 using OTrace = O<RegionType::Trace>;
 using OArena = O<RegionType::Arena>;
-
-struct CCown : public VCown<CCown>
-{
-  CCown* child;
-  CCown(CCown* child_) : child(child_) {}
-
-  void trace(ObjectStack* fields) const
-  {
-    if (child != nullptr)
-      fields->push(child);
-  }
-};
 
 template<RegionType region_type>
 struct RCown : public VCown<RCown<region_type>>


### PR DESCRIPTION
This PR fixes a compilation error by moving the declaration of `CCown` from cowngc1 and cowngc4 tests before its use as a class derrived from `Object`.