### PR TITLE
Fix compilation error with clang 10

### DIFF
--- a/src/interpreter/bytecode.h
+++ b/src/interpreter/bytecode.h
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <cstdlib>
+#include <limits>
 #include <ostream>
 #include <string_view>
 


### PR DESCRIPTION
Missing include <limits> generated the error:
```
../src/./interpreter/bytecode.h:124:10:
  error: no member named 'numeric_limits' in namespace 'std'
    std::numeric_limits<DescriptorIdx>::max();
```