### PR TITLE
Add `ninja check` target to run ctest with deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ add_custom_target(install_for_test
 
 set(CTEST "ctest")
 add_custom_target("check"
-                  COMMAND ${CTEST} ${PARALLEL_ARGS} -C$<CONFIG>
+                  COMMAND ${CTEST} ${PARALLEL_ARGS} -C $<CONFIG>
                   COMMENT "Run ctest tests"
                   USES_TERMINAL COMMAND_EXPAND_LISTS)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,3 +21,21 @@ add_subdirectory(external/pegmatite)
 
 add_subdirectory(src)
 add_subdirectory(testsuite)
+
+# A target to run the ctests
+# TODO: Add run-time libraries, too, and a check-all for both
+include(ProcessorCount)
+ProcessorCount(N)
+if (NOT N EQUAL 0)
+  set(CTEST_ARGS "-j${N}")
+endif()
+set(CTEST "ctest")
+add_custom_target("check"
+                  COMMAND ${CTEST} ${CTEST_ARGS}
+                  COMMENT "Run ctest tests"
+                  USES_TERMINAL)
+
+# FIXME: Why doesn't this work on Windows?
+if (UNIX)
+  add_dependencies("check" "install")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,15 +27,22 @@ add_subdirectory(testsuite)
 include(ProcessorCount)
 ProcessorCount(N)
 if (NOT N EQUAL 0)
-  set(CTEST_ARGS "-j${N}")
+  set(PARALLEL_ARGS --parallel ${N})
 endif()
+
+# The `install` target is not supported by add_dependencies
+# and doesn't work with msbuild.  This adds a custom target that
+# pushes the original target into cmake, so that tests can
+# depend on it.
+add_custom_target(install_for_test
+                  COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} ${PARALLEL_ARGS} --config $<CONFIG> --target install
+                  COMMENT "Installs distribution."
+                  USES_TERMINAL COMMAND_EXPAND_LISTS)
+
 set(CTEST "ctest")
 add_custom_target("check"
-                  COMMAND ${CTEST} ${CTEST_ARGS}
+                  COMMAND ${CTEST} ${PARALLEL_ARGS} -C$<CONFIG>
                   COMMENT "Run ctest tests"
-                  USES_TERMINAL)
+                  USES_TERMINAL COMMAND_EXPAND_LISTS)
 
-# FIXME: Why doesn't this work on Windows?
-if (UNIX)
-  add_dependencies("check" "install")
-endif()
+add_dependencies("check" "install_for_test")

--- a/docs/building.md
+++ b/docs/building.md
@@ -165,7 +165,15 @@ Note that the test suite requires Python 3 to be installed. If your cmake versio
 
 The test suite can be run from the `build` or `build_ninja` directories:
 ```
-ctest
+ninja check
+```
+
+On Windows, you need to run `ctest` directly.
+
+These tests are driven by `ctest`. To run specific tests or with different
+configurations, run:
+```
+ctest <args>
 ```
 
 On Windows, you will need to pass the option `-C <config>` where `<config>` is

--- a/docs/building.md
+++ b/docs/building.md
@@ -168,19 +168,11 @@ The test suite can be run from the `build` or `build_ninja` directories:
 ninja check
 ```
 
-On Windows, you need to run `ctest` directly.
-
-These tests are driven by `ctest`. To run specific tests or with different
-configurations, run:
+On Windows, this can be achieved with:
 ```
-ctest <args>
+cmake --build . --target check --config <config>
 ```
-
-On Windows, you will need to pass the option `-C <config>` where `<config>` is
-the build type, e.g. Debug.
-
-Use the options `-j N` to run `N` jobs in parallel, and `-R <regex>` to run
-tests that match the regular expression `<regex>`.
+Where `<config>` is the build type, e.g. Debug.
 
 ## Building the runtime tests
 


### PR DESCRIPTION
Just running `ctest` can silently crash if the user hasn't also ran
`ninja install`, which is confusing. This commit adds a new `check`
target that not only makes the dependency clear, but also defaults the
test to run on the maximum number of cores available.

Fixes #114