### PR TITLE
Initial commit for a cpp-peglib based parser and untyped AST gen

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,3 +11,7 @@
 [submodule "external/fmt"]
 	path = external/fmt
 	url = https://github.com/fmtlib/fmt.git
+[submodule "external/cpp-peglib"]
+	path = external/cpp-peglib
+	url = git@github.com:yhirose/cpp-peglib.git
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,5 +13,5 @@
 	url = https://github.com/fmtlib/fmt.git
 [submodule "external/cpp-peglib"]
 	path = external/cpp-peglib
-	url = git@github.com:yhirose/cpp-peglib.git
+	url = https://github.com/yhirose/cpp-peglib.git
 	branch = master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ enable_testing()
 if(MSVC)
   add_compile_options(/permissive-)
   add_compile_options(/utf-8)
+  add_compile_options(/wd4307)
 endif()
 
 add_subdirectory(external/CLI11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,5 +19,8 @@ add_subdirectory(external/CLI11)
 add_subdirectory(external/fmt)
 add_subdirectory(external/pegmatite)
 
+add_library(cpp-peglib INTERFACE)
+target_include_directories(cpp-peglib INTERFACE external/cpp-peglib)
+
 add_subdirectory(src)
 add_subdirectory(testsuite)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 endif()
 
 
+add_subdirectory(ast)
 add_subdirectory(compiler)
 add_subdirectory(interpreter)
 add_subdirectory(stdlib)

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(Threads REQUIRED)
+
 add_library(verona-ast-lib
   ast.cc
   err.cc
@@ -8,6 +10,7 @@ add_library(verona-ast-lib
 
 target_link_libraries(verona-ast-lib CLI11::CLI11)
 target_link_libraries(verona-ast-lib cpp-peglib)
+target_link_libraries(verona-ast-lib Threads::Threads)
 
 add_executable(verona-ast main.cc cli.cc path.cc)
 target_link_libraries(verona-ast verona-ast-lib)

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_library(verona-ast-lib
+  ast.cc
+  err.cc
+  files.cc
+  parser.cc
+  sym.cc
+  )
+
+target_link_libraries(verona-ast-lib CLI11::CLI11)
+target_link_libraries(verona-ast-lib cpp-peglib)
+
+add_executable(verona-ast main.cc cli.cc path.cc)
+target_link_libraries(verona-ast verona-ast-lib)
+
+install(TARGETS verona-ast RUNTIME DESTINATION .)
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/grammar.peg DESTINATION .)

--- a/src/ast/ast.cc
+++ b/src/ast/ast.cc
@@ -1,0 +1,125 @@
+#include "ast.h"
+
+namespace ast
+{
+  using namespace peg::udl;
+
+  Ast from(const Ast& ast, const char* name, const std::string& token)
+  {
+    return std::make_shared<AstImpl>(
+      ast->path.c_str(),
+      ast->line,
+      ast->column,
+      name,
+      token,
+      ast->position,
+      ast->length);
+  }
+
+  void replace(Ast& prev, Ast next)
+  {
+    auto parent = prev->parent.lock();
+
+    if (parent)
+    {
+      auto find = std::find(parent->nodes.begin(), parent->nodes.end(), prev);
+      assert(find != parent->nodes.end());
+      *find = next;
+      next->parent = parent;
+    }
+
+    prev = next;
+  }
+
+  void remove(Ast ast)
+  {
+    auto parent = ast->parent.lock();
+
+    if (parent)
+    {
+      auto find = std::find(parent->nodes.begin(), parent->nodes.end(), ast);
+      assert(find != parent->nodes.end());
+      parent->nodes.erase(find);
+    }
+  }
+
+  Ast get_closest(Ast ast, Tag tag)
+  {
+    while (ast && (ast->tag != tag))
+      ast = ast->parent.lock();
+
+    return ast;
+  }
+
+  Ast get_scope(Ast ast)
+  {
+    while (ast && !ast->scope)
+      ast = ast->parent.lock();
+
+    return ast;
+  }
+
+  Ast get_expr(Ast ast)
+  {
+    while (ast && (ast->tag != "expr"_) && (ast->tag != "term"_))
+      ast = ast->parent.lock();
+
+    return ast;
+  }
+
+  Ast get_def(Ast ast, Ident id)
+  {
+    auto pos = ast->position;
+
+    while ((ast = get_scope(ast)))
+    {
+      auto scope = ast->scope;
+      auto find = scope->sym.find(id);
+
+      if (find != scope->sym.end())
+      {
+        auto def = find->second.lock();
+
+        if (def->position < pos)
+          return def;
+      }
+
+      ast = ast->parent.lock();
+    }
+
+    return {};
+  }
+
+  Ast get_prev_in_expr(Ast ast)
+  {
+    auto expr = get_expr(ast);
+
+    if (expr)
+    {
+      auto find = std::find(expr->nodes.begin(), expr->nodes.end(), ast);
+      assert(find != expr->nodes.end());
+
+      if (find != expr->nodes.begin())
+        return *(find - 1);
+    }
+
+    return {};
+  }
+
+  Ast get_next_in_expr(Ast ast)
+  {
+    auto expr = get_expr(ast);
+
+    if (expr)
+    {
+      auto find = std::find(expr->nodes.begin(), expr->nodes.end(), ast);
+      assert(find != expr->nodes.end());
+      ++find;
+
+      if (find != expr->nodes.end())
+        return *find;
+    }
+
+    return {};
+  }
+}

--- a/src/ast/ast.cc
+++ b/src/ast/ast.cc
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 #include "ast.h"
 
 namespace ast

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <peglib.h>
+
+namespace ast
+{
+  struct SymbolScope;
+  struct Annotation;
+
+  using Scope = std::shared_ptr<SymbolScope>;
+  using AstImpl = peg::AstBase<Annotation>;
+  using Ast = std::shared_ptr<AstImpl>;
+  using WeakAst = std::weak_ptr<AstImpl>;
+  using Ident = std::string;
+  using Tag = unsigned int;
+
+  struct Annotation
+  {
+    Scope scope;
+  };
+
+  struct SymbolScope
+  {
+    std::map<Ident, WeakAst> sym;
+  };
+
+  Ast from(const Ast& ast, const char* name, const std::string& token);
+  void replace(Ast& prev, Ast next);
+  void remove(Ast ast);
+
+  Ast get_closest(Ast ast, Tag tag);
+  Ast get_scope(Ast ast);
+  Ast get_expr(Ast ast);
+  Ast get_def(Ast ast, Ident id);
+  Ast get_prev_in_expr(Ast ast);
+  Ast get_next_in_expr(Ast ast);
+}

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 #pragma once
 
 #include <peglib.h>

--- a/src/ast/cli.cc
+++ b/src/ast/cli.cc
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 #include "cli.h"
 
 #include "path.h"

--- a/src/ast/cli.cc
+++ b/src/ast/cli.cc
@@ -1,0 +1,32 @@
+#include "cli.h"
+
+#include "path.h"
+
+#include <CLI/CLI.hpp>
+
+namespace cli
+{
+  Opt parse(int argc, char** argv)
+  {
+    CLI::App app{"Verona AST"};
+
+    Opt opt;
+    app.add_flag("-a,--ast", opt.ast, "Emit an abstract syntax tree.");
+    app.add_option("-g,--grammar", opt.grammar, "Grammar to use.");
+    app.add_option("file", opt.filename, "File to compile.")->required();
+
+    try
+    {
+      app.parse(argc, argv);
+    }
+    catch (const CLI::ParseError& e)
+    {
+      exit(app.exit(e));
+    }
+
+    if (opt.grammar.empty())
+      opt.grammar = path::directory(path::executable()).append("/grammar.peg");
+
+    return opt;
+  }
+}

--- a/src/ast/cli.h
+++ b/src/ast/cli.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+
+namespace cli
+{
+  struct Opt
+  {
+    bool ast = false;
+    bool llvm = false;
+    bool exec = false;
+    std::string grammar;
+    std::string filename;
+  };
+
+  Opt parse(int argc, char** argv);
+}

--- a/src/ast/cli.h
+++ b/src/ast/cli.h
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 #pragma once
 
 #include <string>

--- a/src/ast/err.cc
+++ b/src/ast/err.cc
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 #include "err.h"
 
 namespace err

--- a/src/ast/err.cc
+++ b/src/ast/err.cc
@@ -1,0 +1,78 @@
+#include "err.h"
+
+namespace err
+{
+  bool Errors::empty()
+  {
+    return list.size() == 0;
+  }
+
+  Errors& Errors::operator<<(ast::Ast& ast)
+  {
+    if (list.size() == 0)
+    {
+      // Create a group if none exist.
+      list.push_back({});
+    }
+    else if (list.back().size() > 0)
+    {
+      // Finish the previous error in this group.
+      list.back().back().msg = ss.str();
+      ss.str(std::string());
+    }
+
+    list.back().push_back({ast, std::string()});
+    return *this;
+  }
+
+  Errors& Errors::operator<<(const std::string& s)
+  {
+    ss << s;
+    return *this;
+  }
+
+  Errors& Errors::operator<<(std::ostream& (*f)(std::ostream&))
+  {
+    ss << f;
+    return *this;
+  }
+
+  Errors& Errors::operator<<(const err::endtoken&)
+  {
+    // Finish the last error in this group and start a new one.
+    if ((list.size() > 0) && (list.back().size() > 0))
+    {
+      list.back().back().msg = ss.str();
+      ss.str(std::string());
+      list.push_back({});
+    }
+
+    return *this;
+  }
+
+  std::string Errors::to_s() const
+  {
+    std::ostringstream ss;
+    bool first_group = true;
+
+    for (auto& group : list)
+    {
+      if (first_group)
+      {
+        first_group = false;
+      }
+      else if (group.size() > 0)
+      {
+        ss << "---" << std::endl;
+      }
+
+      for (auto& err : group)
+      {
+        ss << err.ast->path << ":" << err.ast->line << ":" << err.ast->column
+           << ": " << err.msg << std::endl;
+      }
+    }
+
+    return ss.str();
+  }
+}

--- a/src/ast/err.h
+++ b/src/ast/err.h
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 #pragma once
 
 #include "ast.h"

--- a/src/ast/err.h
+++ b/src/ast/err.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "ast.h"
+
+#include <sstream>
+#include <vector>
+
+namespace err
+{
+  struct endtoken
+  {};
+
+  struct Error
+  {
+    ast::Ast ast;
+    std::string msg;
+  };
+
+  struct Errors
+  {
+    std::vector<std::vector<Error>> list;
+    std::ostringstream ss;
+
+    bool empty();
+
+    Errors& operator<<(ast::Ast& ast);
+    Errors& operator<<(const std::string& s);
+    Errors& operator<<(std::ostream& (*f)(std::ostream&));
+    Errors& operator<<(const err::endtoken&);
+
+    std::string to_s() const;
+  };
+
+  constexpr endtoken end;
+}

--- a/src/ast/files.cc
+++ b/src/ast/files.cc
@@ -1,0 +1,36 @@
+#include "files.h"
+
+namespace files
+{
+  std::vector<char> slurp(const std::string& file, bool optional)
+  {
+    std::ifstream f(file.c_str(), std::ios::binary | std::ios::ate);
+
+    if (!f)
+    {
+      if (optional)
+      {
+        return {};
+      }
+      else
+      {
+        std::cerr << "Could not open file " << file << std::endl;
+        exit(-1);
+      }
+    }
+
+    auto size = f.tellg();
+    f.seekg(0, std::ios::beg);
+
+    std::vector<char> data(static_cast<std::vector<char>::size_type>(size));
+    f.read(data.data(), size);
+
+    if (!optional && !f)
+    {
+      std::cerr << "Could not read file " << file << std::endl;
+      exit(-1);
+    }
+
+    return data;
+  }
+}

--- a/src/ast/files.cc
+++ b/src/ast/files.cc
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 #include "files.h"
 
 namespace files

--- a/src/ast/files.h
+++ b/src/ast/files.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+namespace files
+{
+  std::vector<char> slurp(const std::string& file, bool optional = false);
+}

--- a/src/ast/files.h
+++ b/src/ast/files.h
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 #pragma once
 
 #include <fstream>

--- a/src/ast/grammar.peg
+++ b/src/ast/grammar.peg
@@ -1,0 +1,99 @@
+# TODO:
+# module typeparams
+# error handling
+# getter, setter, rest/spread
+# value constraints
+
+module <- (typedef / field / function)*
+
+typedef <-
+  category id typeparams oftype constraints ('=' type ';' / typebody)
+category <- <'type' / 'class'>
+typebody <- '{' (typedef / field / function)* '}'
+
+typeparams <- ('[' list(typeparam)? ']')?
+typeparam <- id
+constraints <- constraint*
+constraint <- 'where' id oftype inittype
+
+field <- id oftype initexpr ';'
+
+function <- funcname sig (block / ';')
+funcname <- (id / sym)?
+sig <- typeparams params oftype constraints
+params <- '(' list(param)? ')'
+param <- namedparam / type
+namedparam <- id oftype initexpr
+
+type <- type_one (type_op type_one)*
+type_op <- <'&' / '|'>
+type_one <-
+  type_tuple /
+  type_ref /
+  typebody
+type_tuple <- '(' list(type)? ')'
+type_ref <- (id typeargs?) ('.' id typeargs?)*
+
+typeargs <- '[' list(typearg) ']'
+typearg <- type / expr
+
+oftype <- (':' type)?
+inittype <- ('=' type)?
+initexpr <- ('=' expr)?
+
+seq <- term* expr?
+term <- atom* (blockexpr / ';')
+expr <- blockexpr / atom+ blockexpr?
+
+blockexpr <- block / when / while / match / if / for / typedef
+block <- '{' seq '}'
+when <- 'when' tuple block
+while <- 'while' cond block
+match <- 'match' cond '{' case* '}'
+if <- 'if' cond block else
+for <- 'for' '(' list(expr) 'in' seq ')' block
+
+cond <- '(' seq ')'
+else <- ('else' (if / block))?
+case <- pattern guard block
+pattern <- expr
+guard <- ('if' '(' seq ')')?
+
+atom <-
+  break / continue / return / yield / let / new / lambda /
+  hex / binary / float / int / string /
+  id / sym / tuple / typeargs
+
+break <- 'break'
+continue <- 'continue'
+return <- 'return'
+yield <- 'yield'
+let <- 'let' (id / '(' list(id)? ')') oftype
+new <- 'new' type? typebody?
+lambda <- sig block
+tuple <- '(' list(expr)? ')'
+
+keyword <-
+  'type' / 'class' / 'where' /
+  'if' / 'else' / 'while' / 'for' / 'in' / 'match' / 'when' /
+  'break' / 'continue' / 'return' / 'yield' /
+  'let' / 'new'
+
+id <- <!keyword %word>
+sym <- <[!-'*+\x2D./:<-@\\^|~]+> # Reserved: , _ () [] {} ` ;
+
+float <- <digits '.' digits ([eE][-+]? digits)?>
+int <- <digits>
+digits <- [0-9][_0-9]*
+hex <- <'0x' [_a-fA-F]*>
+binary <- <'0b' [_01]*>
+string <- '`' ('(' <((!'(' !')' .) / substring)*> ')' / <%word>)
+substring <- '(' ('\\)' / (!'(' !')' .) / substring)* ')'
+
+list(x) <- x (',' x)*
+
+blank <- [ \t\r\n]+
+linecomment <- '//' (![\r\n] .)*
+nestedcomment <- '/*' ((!'/*' !'*/' .) / nestedcomment)* '*/'
+%whitespace <- (blank / linecomment / nestedcomment)*
+%word <- [_a-zA-Z][_a-zA-Z0-9']*

--- a/src/ast/main.cc
+++ b/src/ast/main.cc
@@ -1,0 +1,40 @@
+#include "cli.h"
+#include "files.h"
+#include "parser.h"
+#include "sym.h"
+
+// #include "llvm/ExecutionEngine/ExecutionEngine.h"
+// #include "llvm/ExecutionEngine/GenericValue.h"
+// #include "llvm/ExecutionEngine/MCJIT.h"
+// #include <llvm/IR/IRBuilder.h>
+// #include <llvm/IR/ValueSymbolTable.h>
+// #include <llvm/IR/Verifier.h>
+// #include <llvm/Support/TargetSelect.h>
+
+int main(int argc, char** argv)
+{
+  auto opt = cli::parse(argc, argv);
+  auto parser = parser::create(opt.grammar);
+  auto ast = parser::parse(parser, opt.filename);
+
+  if (!ast)
+    return -1;
+
+  err::Errors err;
+  sym::build(ast, err);
+
+  if (!err.empty())
+  {
+    std::cout << err.to_s() << std::endl;
+    return -1;
+  }
+
+  // import
+  // typecheck
+  // codegen
+
+  if (opt.ast)
+    std::cout << peg::ast_to_s(ast) << std::endl;
+
+  return 0;
+}

--- a/src/ast/main.cc
+++ b/src/ast/main.cc
@@ -3,14 +3,6 @@
 #include "parser.h"
 #include "sym.h"
 
-// #include "llvm/ExecutionEngine/ExecutionEngine.h"
-// #include "llvm/ExecutionEngine/GenericValue.h"
-// #include "llvm/ExecutionEngine/MCJIT.h"
-// #include <llvm/IR/IRBuilder.h>
-// #include <llvm/IR/ValueSymbolTable.h>
-// #include <llvm/IR/Verifier.h>
-// #include <llvm/Support/TargetSelect.h>
-
 int main(int argc, char** argv)
 {
   auto opt = cli::parse(argc, argv);

--- a/src/ast/main.cc
+++ b/src/ast/main.cc
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 #include "cli.h"
 #include "files.h"
 #include "parser.h"

--- a/src/ast/parser.cc
+++ b/src/ast/parser.cc
@@ -1,0 +1,24 @@
+#include "parser.h"
+
+#include "files.h"
+
+namespace parser
+{
+  std::string format_error_message(
+    const std::string& path, size_t ln, size_t col, const std::string& msg)
+  {
+    std::stringstream ss;
+    ss << path.c_str() << ":" << ln << ":" << col << ": " << msg << std::endl;
+    return ss.str();
+  }
+
+  peg::parser create(const std::string& file)
+  {
+    return create(files::slurp(file), file);
+  }
+
+  ast::Ast parse(peg::parser& parser, const std::string& file)
+  {
+    return parse(parser, files::slurp(file), file);
+  }
+}

--- a/src/ast/parser.cc
+++ b/src/ast/parser.cc
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 #include "parser.h"
 
 #include "files.h"

--- a/src/ast/parser.h
+++ b/src/ast/parser.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "ast.h"
+
+namespace parser
+{
+  std::string format_error_message(
+    const std::string& path, size_t ln, size_t col, const std::string& msg);
+  peg::parser create(const std::string& file);
+  ast::Ast parse(peg::parser& parser, const std::string& file);
+
+  template<typename T>
+  peg::parser create(const T& grammar, const std::string& file)
+  {
+    peg::parser parser;
+
+    parser.log = [&](size_t ln, size_t col, const std::string& msg) {
+      std::cerr << format_error_message(file, ln, col, msg) << std::endl;
+    };
+
+    if (!parser.load_grammar(grammar.data(), grammar.size()))
+      exit(-1);
+
+    parser.enable_packrat_parsing();
+    parser.enable_ast<ast::AstImpl>();
+    return parser;
+  }
+
+  template<typename T>
+  ast::Ast parse(peg::parser& parser, const T& src, const std::string& file)
+  {
+    ast::Ast ast;
+
+    parser.log = [&](size_t ln, size_t col, const std::string& msg) {
+      std::cerr << format_error_message(file, ln, col, msg) << std::endl;
+    };
+
+    if (!parser.parse_n(src.data(), src.size(), ast, file.c_str()))
+      return nullptr;
+
+    return ast;
+  }
+}

--- a/src/ast/parser.h
+++ b/src/ast/parser.h
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 #pragma once
 
 #include "ast.h"

--- a/src/ast/path.cc
+++ b/src/ast/path.cc
@@ -7,6 +7,11 @@
 #  include <stdlib.h>
 #elif defined(__APPLE__)
 #  include <sys/syslimits.h>
+#  include <mach-o/dyld.h>
+#elif defined(_WIN32)
+#  define WIN32_LEAN_AND_MEAN
+#  define NOMINMAX
+#  include <windows.h>
 #endif
 
 namespace path

--- a/src/ast/path.cc
+++ b/src/ast/path.cc
@@ -1,0 +1,34 @@
+#include "path.h"
+
+#if defined(__linux__)
+#  include <limits.h>
+#  include <stdlib.h>
+#endif
+
+namespace path
+{
+  std::string executable()
+  {
+#if defined(__linux__)
+    constexpr auto link = "/proc/self/exe";
+    char buffer[PATH_MAX];
+    return realpath(link, buffer);
+#else
+#  error "path::executable not supported on this target."
+#endif
+  }
+
+  std::string directory(const std::string& path)
+  {
+#if defined(__linux__)
+    size_t pos = path.rfind("/");
+
+    if ((pos == std::string::npos) || (pos >= (path.size() - 1)))
+      return path;
+
+    return path.substr(0, pos);
+#else
+#  error "path::directory not supported on this target."
+#endif
+  }
+}

--- a/src/ast/path.cc
+++ b/src/ast/path.cc
@@ -1,8 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 #include "path.h"
 
 #if defined(__linux__)
 #  include <limits.h>
 #  include <stdlib.h>
+#elif defined(__APPLE__)
+#  include <sys/syslimits.h>
 #endif
 
 namespace path

--- a/src/ast/path.cc
+++ b/src/ast/path.cc
@@ -6,8 +6,8 @@
 #  include <limits.h>
 #  include <stdlib.h>
 #elif defined(__APPLE__)
-#  include <sys/syslimits.h>
 #  include <mach-o/dyld.h>
+#  include <sys/syslimits.h>
 #elif defined(_WIN32)
 #  define WIN32_LEAN_AND_MEAN
 #  define NOMINMAX

--- a/src/ast/path.cc
+++ b/src/ast/path.cc
@@ -13,6 +13,10 @@ namespace path
     constexpr auto link = "/proc/self/exe";
     char buffer[PATH_MAX];
     return realpath(link, buffer);
+#elif defined(_WIN32)
+    char p[MAX_PATH];
+    GetModuleFileName(NULL, p, MAX_PATH);
+    return std::string(p);
 #else
 #  error "path::executable not supported on this target."
 #endif
@@ -20,15 +24,21 @@ namespace path
 
   std::string directory(const std::string& path)
   {
+    constexpr auto delim =
 #if defined(__linux__)
-    size_t pos = path.rfind("/");
+      "/"
+#elif defined(_WIN32)
+      "\\"
+#else
+#  error "path::directory not supported on this target."
+#endif
+      ;
+
+    size_t pos = path.rfind(delim);
 
     if ((pos == std::string::npos) || (pos >= (path.size() - 1)))
       return path;
 
     return path.substr(0, pos);
-#else
-#  error "path::directory not supported on this target."
-#endif
   }
 }

--- a/src/ast/path.h
+++ b/src/ast/path.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <string>
+
+namespace path
+{
+  std::string executable();
+  std::string directory(const std::string& path);
+}

--- a/src/ast/path.h
+++ b/src/ast/path.h
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 #pragma once
 
 #include <string>

--- a/src/ast/sym.cc
+++ b/src/ast/sym.cc
@@ -1,0 +1,271 @@
+#include "sym.h"
+
+using namespace peg::udl;
+
+namespace
+{
+  void add_scope(ast::Ast& ast)
+  {
+    ast->scope = std::make_shared<ast::SymbolScope>();
+  }
+
+  void add_symbol(ast::Ident id, ast::Ast& ast, err::Errors& err)
+  {
+    auto enclosing = ast::get_scope(ast);
+    auto scope = enclosing->scope;
+    auto find = scope->sym.find(id);
+
+    if (find != scope->sym.end())
+    {
+      auto prev = find->second.lock();
+      err << ast << id << " is already defined." << prev
+          << "Previous definition of " << id << " is here." << err::end;
+    }
+
+    scope->sym.emplace(id, ast);
+  }
+
+  void set_fixity(ast::Ast& ast)
+  {
+    auto prev = ast::get_prev_in_expr(ast);
+
+    if (!prev || (prev->tag == "infix"_))
+    {
+      // If it's the first atom, or it's after an infix, it's a prefix operator.
+      ast::replace(ast, ast::from(ast, "prefix", ast->token));
+    }
+    else
+    {
+      // If it's after anything else, it's an infix operator.
+      ast::replace(ast, ast::from(ast, "infix", ast->token));
+    }
+  }
+
+  template<typename T>
+  void for_each(ast::Ast ast, err::Errors& err, T f)
+  {
+    auto size = ast->nodes.size();
+
+    for (decltype(size) i = 0; i < size; i++)
+    {
+      auto node = ast->nodes[i];
+      f(node, err);
+
+      // Back up if we remove nodes. Only remove earlier siblings.
+      if (ast->nodes.size() < size)
+      {
+        auto diff = size - ast->nodes.size();
+        i -= diff;
+        size = ast->nodes.size();
+      }
+    }
+  }
+
+  void elide_node(ast::Ast& ast, err::Errors& err)
+  {
+    assert(ast->nodes.size() == 1);
+    auto child = ast->nodes[0];
+    ast::replace(ast, child);
+    sym::build(ast, err);
+  }
+
+  void only_atom(ast::Ast& ast, err::Errors& err)
+  {
+    if (ast::get_expr(ast)->nodes.size() > 1)
+    {
+      err << ast << ast->name << " must be the only element of an expression."
+          << err::end;
+    }
+  }
+
+  void first_atom(ast::Ast& ast, err::Errors& err)
+  {
+    if (ast::get_expr(ast)->nodes[0] != ast)
+    {
+      err << ast << ast->name << " must be the first element of an expression."
+          << err::end;
+    }
+  }
+
+  void not_in_pattern(ast::Ast& ast, err::Errors& err)
+  {
+    if (ast::get_closest(ast, "pattern"_))
+      err << ast << ast->token << " cannot appear in a pattern." << err::end;
+  }
+
+  void last_in_block(ast::Ast& ast, err::Errors& err)
+  {
+    auto block = ast::get_closest(ast, "block"_);
+
+    if (block)
+    {
+      auto seq = block->nodes[0];
+      auto expr = seq->nodes.back();
+
+      if (expr == ast::get_expr(ast))
+        return;
+    }
+
+    err << ast << ast->token << " must be the last expression in a block."
+        << err::end;
+  }
+}
+
+namespace sym
+{
+  void build(ast::Ast& ast, err::Errors& err)
+  {
+    switch (ast->tag)
+    {
+      case "module"_:
+      case "typebody"_:
+      case "lambda"_:
+      {
+        add_scope(ast);
+        break;
+      }
+
+      case "typedef"_:
+      {
+        add_symbol(ast->nodes[1]->token, ast, err);
+        add_scope(ast);
+        not_in_pattern(ast, err);
+        break;
+      }
+
+      case "typeparam"_:
+      {
+        add_symbol(ast->nodes[0]->token, ast, err);
+        break;
+      }
+
+      case "field"_:
+      {
+        add_symbol(ast->nodes[0]->token, ast, err);
+        break;
+      }
+
+      case "function"_:
+      {
+        // A missing function name is sugar for "apply"
+        if (ast->nodes[0]->nodes.size() == 0)
+        {
+          ast->nodes[0]->nodes.push_back(
+            ast::from(ast->nodes[0], "id", "apply"));
+        }
+
+        auto node = ast->nodes[0]->nodes[0];
+        add_symbol(node->token, ast, err);
+        add_scope(ast);
+        break;
+      }
+
+      case "namedparam"_:
+      {
+        add_symbol(ast->nodes[0]->token, ast, err);
+        break;
+      }
+
+      case "blockexpr"_:
+      {
+        elide_node(ast, err);
+        return;
+      }
+
+      case "block"_:
+      case "when"_:
+      case "while"_:
+      case "match"_:
+      case "case"_:
+      case "if"_:
+      case "for"_:
+      {
+        add_scope(ast);
+        not_in_pattern(ast, err);
+        break;
+      }
+
+      case "atom"_:
+      {
+        auto node = ast->nodes[0];
+
+        if (node->tag == "id"_)
+          ast::replace(node, ast::from(node, "ref", node->token));
+
+        elide_node(ast, err);
+        return;
+      }
+
+      case "break"_:
+      case "continue"_:
+      {
+        only_atom(ast, err);
+        not_in_pattern(ast, err);
+        last_in_block(ast, err);
+        break;
+      }
+
+      case "return"_:
+      case "yield"_:
+      {
+        first_atom(ast, err);
+        not_in_pattern(ast, err);
+        last_in_block(ast, err);
+        break;
+      }
+
+      case "let"_:
+      {
+        first_atom(ast, err);
+
+        for_each(ast, err, [](auto& node, auto& err) {
+          if (node->tag == "id"_)
+          {
+            ast::replace(node, ast::from(node, "local", node->token));
+            add_symbol(node->token, node, err);
+          }
+        });
+        break;
+      }
+
+      case "ref"_:
+      {
+        auto def = ast::get_def(ast, ast->token);
+
+        if (!def || ((def->tag != "local"_) && (def->tag != "namedparam"_)))
+          set_fixity(ast);
+        break;
+      }
+
+      case "sym"_:
+      {
+        if (ast->token == ".")
+        {
+          auto next = ast::get_next_in_expr(ast);
+
+          if (next && (next->tag == "atom"_))
+          {
+            auto lookup = next->nodes[0];
+
+            if ((lookup->tag == "id"_) || (lookup->tag == "sym"_))
+            {
+              ast::replace(next, ast::from(lookup, "lookup", lookup->token));
+              ast::remove(ast);
+              break;
+            }
+          }
+
+          err << ast << "lookup must be followed by a symbol or an identifier."
+              << err::end;
+        }
+        else
+        {
+          set_fixity(ast);
+        }
+        break;
+      }
+    }
+
+    for_each(ast, err, build);
+  }
+}

--- a/src/ast/sym.cc
+++ b/src/ast/sym.cc
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 #include "sym.h"
 
 using namespace peg::udl;

--- a/src/ast/sym.h
+++ b/src/ast/sym.h
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 #pragma once
 
 #include "ast.h"

--- a/src/ast/sym.h
+++ b/src/ast/sym.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "ast.h"
+#include "err.h"
+
+namespace sym
+{
+  void build(ast::Ast& ast, err::Errors& err);
+}


### PR DESCRIPTION
This uses cpp-peglib to generate a packrat PEG for a grammar defined
in a text file, and then does some very basic AST manipulation. It
sets up scopes and symbol tables, and does a bit of fixity analysis.
The intention is to use this for a very slim parser front-end that
goes to MLIR before any serious heavy lifting is done. No tests are
included in the initial commit, as the grammar.peg is preliminary.Z