### PR TITLE
Parse more common string representation

### DIFF
--- a/src/ast/grammar.peg
+++ b/src/ast/grammar.peg
@@ -87,8 +87,8 @@ int <- <digits>
 digits <- [0-9][_0-9]*
 hex <- <'0x' [_a-fA-F]*>
 binary <- <'0b' [_01]*>
-string <- '`' ('(' <((!'(' !')' .) / substring)*> ')' / <%word>)
-substring <- '(' ('\\)' / (!'(' !')' .) / substring)* ')'
+string <- '"' (!'"' (escaped / .))* '"'
+escaped <- '\\' ('\\' / '"' / [bfnrt])
 
 list(x) <- x (',' x)*
 


### PR DESCRIPTION
Change string syntax from `` `(...)`` to `"..."`, including common escape
sequences.