### PR TITLE
Sched fixup

### DIFF
--- a/src/rt/sched/epoch.h
+++ b/src/rt/sched/epoch.h
@@ -110,7 +110,7 @@ namespace verona::rt
 
     void add_to_dec_list(Alloc* alloc, Object* p)
     {
-      auto node = (DecNode*)alloc->alloc(sizeof(DecNode));
+      auto node = (DecNode*)alloc->alloc<sizeof(DecNode)>();
       node->o = p;
       dec_list.enqueue((InnerNode*)node);
       (*get_to_dec(2))++;
@@ -181,7 +181,7 @@ namespace verona::rt
         {
           auto dn = (DecNode*)dec_list.dequeue();
           auto o = dn->o;
-          alloc->dealloc(dn);
+          alloc->dealloc<sizeof(DecNode)>(dn);
           Immutable::release(alloc, o);
         }
 

--- a/src/rt/sched/multimessage.h
+++ b/src/rt/sched/multimessage.h
@@ -37,7 +37,7 @@ namespace verona::rt
     static MultiMessage*
     make(Alloc* alloc, EpochMark epoch, MultiMessageBody* body)
     {
-      auto msg = (MultiMessage*)alloc->alloc(sizeof(MultiMessage));
+      auto msg = (MultiMessage*)alloc->alloc<sizeof(MultiMessage)>();
       msg->body = body;
       msg->set_epoch(epoch);
       return msg;

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -123,7 +123,7 @@ namespace verona::rt
         scheduled_unscanned_cown = true;
       }
       assert(!a->queue.is_sleeping());
-      q.push(alloc, a);
+      q.enqueue(alloc, a);
 
       // Put the token back if it has been stolen.  This will help
       // free up more work for other threads to steal.
@@ -139,7 +139,7 @@ namespace verona::rt
       // asynchronous I/O.
       Systematic::cout() << "LIFO Scheduled Cown: " << a << std::endl;
 
-      q.push_back(ThreadAlloc::get(), a);
+      q.enqueue_front(ThreadAlloc::get(), a);
       stats.lifo();
 
       if (Scheduler::get().unpause())
@@ -217,7 +217,7 @@ namespace verona::rt
 
         if (cown == nullptr)
         {
-          cown = q.pop(alloc);
+          cown = q.dequeue(alloc);
           if (cown != nullptr)
             Systematic::cout() << "Popped cown:" << cown << std::endl;
         }
@@ -274,7 +274,7 @@ namespace verona::rt
             // otherwise run this cown again. Don't push to the queue
             // immediately to avoid another thread stealing our only cown.
 
-            T* n = q.pop(alloc);
+            T* n = q.dequeue(alloc);
 
             if (n != nullptr)
             {
@@ -351,7 +351,7 @@ namespace verona::rt
       // Try to steal from the victim thread.
       if (victim != this)
       {
-        cown = victim->q.pop(alloc);
+        cown = victim->q.dequeue(alloc);
 
         if (cown != nullptr)
         {
@@ -415,7 +415,7 @@ namespace verona::rt
         ld_protocol();
 
         // Check if some other thread has pushed work on our queue.
-        cown = q.pop(alloc);
+        cown = q.dequeue(alloc);
 
         if (cown != nullptr)
           return cown;
@@ -423,7 +423,7 @@ namespace verona::rt
         // Try to steal from the victim thread.
         if (victim != this)
         {
-          cown = victim->q.pop(alloc);
+          cown = victim->q.dequeue(alloc);
 
           if (cown != nullptr)
           {
@@ -686,7 +686,7 @@ namespace verona::rt
     {
       // Must set the flag before pushing due to work stealing.
       assert(!debug_is_token_consumed());
-      q.push(alloc, (T*)((uintptr_t)get_token_cown() | 1));
+      q.enqueue(alloc, (T*)((uintptr_t)get_token_cown() | 1));
     }
 
     void enter_scan()


### PR DESCRIPTION
This PR fixes the documentation and naming of the spmcq implementation to be more consistent with the mpscq. Statically known alloc and dealloc sizes are also passed to snmalloc for `MultiMessage` and epoch `DecNode`.