### PR TITLE
VS 2019 fixes

### DIFF
--- a/src/interpreter/object.cc
+++ b/src/interpreter/object.cc
@@ -36,7 +36,8 @@ namespace verona::interpreter
       finaliser_ip > 0 ? VMObject::finaliser_fn : nullptr;
   }
 
-  VMObject::VMObject(VMObject* region) : parent_(region)
+  VMObject::VMObject(VMObject* region, const VMDescriptor* desc)
+  : Object(desc), parent_(region)
   {
     if (descriptor()->field_count > 0)
       fields = std::make_unique<FieldValue[]>(descriptor()->field_count);

--- a/src/interpreter/object.h
+++ b/src/interpreter/object.h
@@ -32,7 +32,7 @@ namespace verona::interpreter
      *
      * If the object is in a new region, nullptr should be passed instead.
      */
-    explicit VMObject(VMObject* region);
+    explicit VMObject(VMObject* region, const VMDescriptor* desc);
 
     std::unique_ptr<FieldValue[]> fields;
 

--- a/src/interpreter/vm.cc
+++ b/src/interpreter/vm.cc
@@ -380,7 +380,7 @@ namespace verona::interpreter
 
     VMObject* region = parent->object->region();
     rt::Object* object = rt::Region::alloc(alloc_, region, descriptor);
-    return Value::mut(new (object) VMObject(region));
+    return Value::mut(new (object) VMObject(region, descriptor));
   }
 
   Value VM::opcode_new_region(const VMDescriptor* descriptor)
@@ -388,7 +388,7 @@ namespace verona::interpreter
     // TODO(region): For now, the only kind of region we can create is a trace
     // region. Later, we might need a new bytecode?
     rt::Object* object = rt::RegionTrace::create(alloc_, descriptor);
-    return Value::iso(new (object) VMObject(nullptr));
+    return Value::iso(new (object) VMObject(nullptr, descriptor));
   }
 
   Value VM::opcode_new_cown(const VMDescriptor* descriptor, Value src)

--- a/src/rt/cpp/vobject.h
+++ b/src/rt/cpp/vobject.h
@@ -115,14 +115,15 @@ namespace verona::rt
     }
 
   public:
+    V() : Base(desc()) {}
+
     void* operator new(size_t)
     {
       if constexpr (std::is_same_v<Base, Object>)
         return RegionClass::template create<sizeof(T)>(
           ThreadAlloc::get(), desc());
       else
-        return Cown::alloc<sizeof(T)>(
-          ThreadAlloc::get(), desc(), get_alloc_epoch());
+        return ThreadAlloc::get()->alloc<sizeof(T)>();
     }
 
     void* operator new(size_t, Alloc* alloc)
@@ -130,7 +131,7 @@ namespace verona::rt
       if constexpr (std::is_same_v<Base, Object>)
         return RegionClass::template create<sizeof(T)>(alloc, desc());
       else
-        return Cown::alloc<sizeof(T)>(alloc, desc(), get_alloc_epoch());
+        return ThreadAlloc::get()->alloc<sizeof(T)>();
     }
 
     void* operator new(size_t, Object* region)
@@ -139,8 +140,7 @@ namespace verona::rt
         return RegionClass::template alloc<sizeof(T)>(
           ThreadAlloc::get(), region, desc());
       else
-        return Cown::alloc<sizeof(T)>(
-          ThreadAlloc::get(), desc(), get_alloc_epoch());
+        return ThreadAlloc::get()->alloc<sizeof(T)>();
     }
 
     void* operator new(size_t, Alloc* alloc, Object* region)
@@ -148,7 +148,7 @@ namespace verona::rt
       if constexpr (std::is_same_v<Base, Object>)
         return RegionClass::template alloc<sizeof(T)>(alloc, region, desc());
       else
-        return Cown::alloc<sizeof(T)>(alloc, desc(), get_alloc_epoch());
+        return ThreadAlloc::get()->alloc<sizeof(T)>();
     }
 
     void operator delete(void*)

--- a/src/rt/object/object.h
+++ b/src/rt/object/object.h
@@ -205,7 +205,7 @@ namespace verona::rt
     Object(const Object&) = delete;
     Object& operator=(const Object&) = delete;
 
-    Object() = default;
+    Object(const Descriptor* desc) : descriptor(desc) {}
 
     inline const Descriptor* get_descriptor() const
     {

--- a/src/rt/region/externalreference.h
+++ b/src/rt/region/externalreference.h
@@ -51,7 +51,8 @@ namespace verona::rt
         return i->second.get_wref();
       }
 
-      ExternalRef(ExternalReferenceTable* ert_, Object* o_) : ert{ert_}, o{o_}
+      ExternalRef(ExternalReferenceTable* ert_, Object* o_)
+      : Object(desc()), ert{ert_}, o{o_}
       {
         set_descriptor(desc());
         make_scc();

--- a/src/rt/region/region_arena.h
+++ b/src/rt/region/region_arena.h
@@ -233,7 +233,10 @@ namespace verona::rt
     Object* last_large;
 
     RegionArena()
-    : first_arena(nullptr), last_arena(nullptr), last_large(nullptr)
+    : RegionBase(desc()),
+      first_arena(nullptr),
+      last_arena(nullptr),
+      last_large(nullptr)
     {
       set_descriptor(desc());
       init_next(this);

--- a/src/rt/region/region_base.h
+++ b/src/rt/region/region_base.h
@@ -43,6 +43,8 @@ namespace verona::rt
       AllObjects,
     };
 
+    RegionBase(const Descriptor* desc) : Object(desc) {}
+
   private:
     inline void dealloc(Alloc* alloc)
     {

--- a/src/rt/region/region_trace.h
+++ b/src/rt/region/region_trace.h
@@ -68,7 +68,8 @@ namespace verona::rt
     // Compact representation of previous memory used as a sizeclass.
     snmalloc::sizeclass_t previous_memory_used = 0;
 
-    explicit RegionTrace(Object* o) : next_not_root(this), last_not_root(this)
+    explicit RegionTrace(Object* o)
+    : RegionBase(desc()), next_not_root(this), last_not_root(this)
     {
       set_descriptor(desc());
       init_next(o);

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -42,6 +42,11 @@ namespace verona::rt
       YesTryFast
     };
 
+    Cown(const Descriptor* desc) : Object(desc)
+    {
+      this->init(ThreadAlloc::get(), desc, Scheduler::alloc_epoch());
+    }
+
   private:
     friend class DLList<Cown>;
     friend class MultiMessage;


### PR DESCRIPTION
The anonymous union types in Verona and snmalloc were not compiling on VS2019 due to a lack of default constructor. I could not find a way to add a default constructor to an anonymous union. This addresses those issues by making the unions types have default constructors.