### PR TITLE
String literals

### DIFF
--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -4,7 +4,9 @@ add_library(verona-ast-lib
   ast.cc
   err.cc
   files.cc
+  lit.cc
   parser.cc
+  prec.cc
   sym.cc
   )
 

--- a/src/ast/ast.cc
+++ b/src/ast/ast.cc
@@ -90,6 +90,13 @@ namespace ast
     replace(ast, next);
   }
 
+  void elide(Ast& ast)
+  {
+    assert(ast->nodes.size() == 1);
+    auto child = ast->nodes.front();
+    ast::replace(ast, child);
+  }
+
   Ast get_closest(Ast ast, Tag tag)
   {
     while (ast && (ast->tag != tag))

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -32,6 +32,7 @@ namespace ast
   void replace(Ast& prev, Ast next);
   void remove(Ast ast);
   void rename(Ast& ast, const char* name);
+  void elide(Ast& ast);
 
   Ast get_closest(Ast ast, Tag tag);
   Ast get_scope(Ast ast);
@@ -39,4 +40,17 @@ namespace ast
   Ast get_def(Ast ast, Ident id);
   Ast get_prev_in_expr(Ast ast);
   Ast get_next_in_expr(Ast ast);
+
+  template<typename E, typename T>
+  void for_each(Ast ast, E& err, T f)
+  {
+    if (!ast)
+      return;
+
+    for (decltype(ast->nodes.size()) i = 0; i < ast->nodes.size(); i++)
+    {
+      auto node = ast->nodes[i];
+      f(node, err);
+    }
+  }
 }

--- a/src/ast/grammar.peg
+++ b/src/ast/grammar.peg
@@ -61,7 +61,7 @@ guard <- ('if' '(' seq ')')?
 
 atom <-
   break / continue / return / yield / let / new / lambda /
-  hex / binary / float / int / string /
+  hex / binary / float / int / interp_string / string /
   id / sym / tuple / typeargs
 
 break <- 'break'
@@ -80,16 +80,20 @@ keyword <-
   'let' / 'new'
 
 id <- <!keyword %word>
-sym <- <[!-'*+\x2D./:<-@\\^|~]+> # Reserved: , _ () [] {} ` ;
+sym <- <[!#-'*+\x2D./:<-@\\^`|~]+> # Reserved: , _ " () [] {} ;
 
 float <- <digits '.' digits ([eE][-+]? digits)?>
 int <- <digits>
 digits <- [0-9][_0-9]*
 hex <- <'0x' [_0-9a-fA-F]*>
 binary <- <'0b' [_01]*>
-string <- '`' (<%word> / '(' <string_inner> ')')
-string_inner <- <(string_escape / (!'`(' !')' .) / string)*>
-string_escape <- '\\' ('`' / ')')
+
+string <- ["] <('\\"' / !'"' .)*> '"'
+interp_string <- ["][{] (unquote / quote)* '}"'
+unquote <- [$] !keyword %word / '${' expr [}]
+quote <- <(nested_string / !unquote !'}"' .)+>
+nested_string <- '"{' nested_quote* '}"'
+nested_quote <- <(nested_string / !'}"' .)+>
 
 list(x) <- x (',' x)*
 

--- a/src/ast/lit.cc
+++ b/src/ast/lit.cc
@@ -1,0 +1,363 @@
+#include "lit.h"
+
+using namespace peg::udl;
+
+namespace
+{
+  size_t nextline(const std::string& s, size_t pos = 0)
+  {
+    auto n = s.find("\n", pos);
+
+    if (n != std::string::npos)
+      n++;
+
+    return n;
+  }
+
+  bool has_cr(const std::string& s, size_t pos)
+  {
+    return (pos < s.size()) && (pos > 0) && (s[pos - 1] == '\r');
+  }
+
+  void remove_leading_blank_line(ast::Ast& ast)
+  {
+    if (ast->nodes.empty())
+      return;
+
+    auto node = ast->nodes.front();
+
+    if (node->tag != "quote"_)
+      return;
+
+    auto& text = node->token;
+    auto pos = text.find_first_not_of(" \f\r\t\v");
+
+    if ((pos != std::string::npos) && (text[pos] == '\n'))
+    {
+      auto next = text.find_first_not_of(" \f\r\t\v", pos + 1);
+
+      if (next == std::string::npos)
+      {
+        ast::remove(node);
+      }
+      else
+      {
+        auto trim = text.substr(pos + 1);
+        auto quote = ast::token(node, "quote", trim);
+        ast::replace(node, quote);
+      }
+    }
+  }
+
+  void remove_trailing_blank_line(ast::Ast& ast)
+  {
+    if (ast->nodes.empty())
+      return;
+
+    auto node = ast->nodes.back();
+
+    if (node->tag != "quote"_)
+      return;
+
+    auto& text = node->token;
+    auto pos = text.find_last_not_of(" \f\r\t\v");
+
+    if ((pos != std::string::npos) && (text[pos] == '\n'))
+    {
+      // Handle \r\n pairs.
+      if (has_cr(text, pos))
+        pos--;
+
+      if (pos == 0)
+      {
+        ast::remove(node);
+      }
+      else
+      {
+        auto trim = text.substr(0, pos);
+        auto quote = ast::token(node, "quote", trim);
+        ast::replace(node, quote);
+      }
+    }
+  }
+
+  size_t calc_indent(ast::Ast& ast)
+  {
+    if (ast->nodes.empty())
+      return 0;
+
+    // If the first node is not a quote, there is no indentation.
+    if (ast->nodes.front()->tag != "quote"_)
+      return 0;
+
+    size_t indent = std::numeric_limits<size_t>::max();
+
+    for (size_t i = 0; i < ast->nodes.size(); i++)
+    {
+      auto node = ast->nodes[i];
+
+      // Only examine quote nodes. Unquote nodes may evaluate to whitespace, but
+      // this is dynamic and not handled.
+      if (node->tag != "quote"_)
+        continue;
+
+      // Start from the first character only on the first node. Otherwise start
+      // from right after the first newline. This is because the previous node
+      // is an unquote, and anything up to the first newline is trailing
+      // whitespace, not leading whitespace.
+      auto& text = node->token;
+      size_t prev = (i > 0) ? nextline(text) : 0;
+
+      while (prev != std::string::npos)
+      {
+        // Find the first non-whitespace character.
+        auto pos = text.find_first_not_of(" \f\r\t\v", prev);
+        size_t len = std::numeric_limits<size_t>::max();
+
+        if (pos == std::string::npos)
+        {
+          // If this is not the last node, then the next node is an unquote.
+          // That means this blank entry is leading whitespace. Otherwise, it is
+          // an entirely blank line at the end of the string.
+          if (i < (ast->nodes.size() - 1))
+            len = text.size() - prev;
+        }
+        else if (text[pos] != '\n')
+        {
+          // Don't do this if we found a newline, as then it is a blank line
+          // that is ignored for indent purposes.
+          len = pos - prev;
+        }
+
+        if (len < indent)
+          indent = len;
+
+        // Find the beginning of the next line.
+        prev = nextline(text, pos);
+      }
+    }
+
+    // If all lines were blank, there is no indent.
+    if (indent == std::numeric_limits<size_t>::max())
+      return 0;
+
+    return indent;
+  }
+
+  void trim_indent(ast::Ast& ast, size_t indent)
+  {
+    if (indent == 0)
+      return;
+
+    for (size_t i = 0; i < ast->nodes.size(); i++)
+    {
+      auto node = ast->nodes[i];
+
+      if (node->tag != "quote"_)
+        continue;
+
+      // Start from the first character only on the first node. Otherwise
+      // start from right after the first newline, since the previous node was
+      // an unquote and anything up to the first newline is trailing text, not
+      // leading text.
+      auto& text = node->token;
+      size_t prev = (i > 0) ? nextline(text) : 0;
+      std::string s(text.substr(0, prev));
+
+      while (prev != std::string::npos)
+      {
+        auto end = nextline(text, prev);
+        auto start = prev + indent;
+        auto nl = has_cr(s, end - 1) ? 2 : 1;
+
+        // Handle blank lines shorter than the indent.
+        if ((end - nl) <= start)
+          start = end - nl;
+
+        auto len = end - start;
+
+        if (start < text.size())
+          s.append(text.substr(start, len));
+
+        prev = end;
+      }
+
+      auto quote = ast::token(node, "quote", s);
+      ast::replace(node, quote);
+    }
+  }
+}
+
+namespace lit
+{
+  size_t hex(const std::string& src, size_t& i, size_t len)
+  {
+    size_t r = 0;
+
+    for (size_t count = 0; count < len; count++)
+    {
+      if (i >= (src.size() - 1))
+        return r;
+
+      auto c = src[i + 1];
+
+      if ((c >= '0') && (c <= '9'))
+        c = c - '0';
+      else if ((c >= 'A') && (c <= 'F'))
+        c = c - 'A' + 10;
+      else if ((c >= 'a') && (c <= 'f'))
+        c = c - 'a' + 10;
+      else
+        return r;
+
+      i++;
+      r = (r << 4) + c;
+    }
+
+    return r;
+  }
+
+  std::string utf8(uint32_t v)
+  {
+    std::string s;
+
+    if (v <= 0x7f)
+    {
+      s.push_back(v & 0x7f);
+    }
+    else if (v <= 0x7FF)
+    {
+      s.push_back(0xc0 | ((v >> 6) & 0xff));
+      s.push_back(0x80 | (v & 0x3f));
+    }
+    else if (v <= 0xffff)
+    {
+      s.push_back(0xe0 | ((v >> 12) & 0xff));
+      s.push_back(0x80 | ((v >> 6) & 0x3f));
+      s.push_back(0x80 | (v & 0x3f));
+    }
+    else if (v < 0x10ffff)
+    {
+      s.push_back(0xf0 | ((v >> 18) & 0xff));
+      s.push_back(0x80 | ((v >> 12) & 0x3f));
+      s.push_back(0x80 | ((v >> 6) & 0x3f));
+      s.push_back(0x80 | (v & 0x3f));
+    }
+
+    return s;
+  }
+
+  std::string escape(const std::string& src)
+  {
+    std::string dst;
+
+    for (size_t i = 0; i < src.size(); i++)
+    {
+      auto c = src[i];
+
+      if (c != '\\')
+      {
+        dst.push_back(c);
+        continue;
+      }
+
+      auto n = src[++i];
+
+      switch (n)
+      {
+        case 'a':
+        {
+          dst.push_back('\a');
+          break;
+        }
+
+        case 'b':
+        {
+          dst.push_back('\b');
+          break;
+        }
+
+        case 'e':
+        {
+          dst.push_back(0x1b);
+          break;
+        }
+
+        case 'f':
+        {
+          dst.push_back('\f');
+          break;
+        }
+
+        case 'n':
+        {
+          dst.push_back('\n');
+          break;
+        }
+
+        case 'r':
+        {
+          dst.push_back('\r');
+          break;
+        }
+
+        case 't':
+        {
+          dst.push_back('\t');
+          break;
+        }
+
+        case 'v':
+        {
+          dst.push_back('\v');
+          break;
+        }
+
+        case '\\':
+        {
+          dst.push_back('\\');
+          break;
+        }
+
+        case '0':
+        {
+          dst.push_back('\0');
+          break;
+        }
+
+        case 'x':
+        {
+          dst.append(utf8(hex(src, i, 2)));
+          break;
+        }
+
+        case 'u':
+        {
+          dst.append(utf8(hex(src, i, 4)));
+          break;
+        }
+
+        case 'U':
+        {
+          dst.append(utf8(hex(src, i, 6)));
+          break;
+        }
+
+        default:
+        {
+          dst.push_back(n);
+          break;
+        }
+      }
+    }
+
+    return dst;
+  }
+
+  void mangle_indent(ast::Ast& ast)
+  {
+    remove_leading_blank_line(ast);
+    remove_trailing_blank_line(ast);
+    trim_indent(ast, calc_indent(ast));
+  }
+}

--- a/src/ast/lit.cc
+++ b/src/ast/lit.cc
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 #include "lit.h"
 
 using namespace peg::udl;

--- a/src/ast/lit.cc
+++ b/src/ast/lit.cc
@@ -219,7 +219,7 @@ namespace lit
     return r;
   }
 
-  std::string utf8(uint32_t v)
+  std::string utf8(size_t v)
   {
     std::string s;
 

--- a/src/ast/lit.h
+++ b/src/ast/lit.h
@@ -8,6 +8,8 @@ namespace lit
 {
   size_t hex(const std::string& src, size_t& i, size_t len);
   std::string utf8(uint32_t v);
+  std::string crlf2lf(const std::string& src);
+  void crlf2lf(ast::Ast& ast);
   std::string escape(const std::string& src);
   void mangle_indent(ast::Ast& ast);
 }

--- a/src/ast/lit.h
+++ b/src/ast/lit.h
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+#include "ast.h"
+
+namespace lit
+{
+  size_t hex(const std::string& src, size_t& i, size_t len);
+  std::string utf8(uint32_t v);
+  std::string escape(const std::string& src);
+  void mangle_indent(ast::Ast& ast);
+}

--- a/src/ast/main.cc
+++ b/src/ast/main.cc
@@ -9,7 +9,8 @@ int main(int argc, char** argv)
 {
   auto opt = cli::parse(argc, argv);
   auto parser = parser::create(opt.grammar);
-  auto ast = parser::parse(parser, opt.filename);
+  auto src = files::slurp(opt.filename);
+  auto ast = parser::parse(parser, src, opt.filename);
 
   if (!ast)
     return -1;

--- a/src/ast/main.cc
+++ b/src/ast/main.cc
@@ -3,6 +3,7 @@
 #include "cli.h"
 #include "files.h"
 #include "parser.h"
+#include "prec.h"
 #include "sym.h"
 
 int main(int argc, char** argv)
@@ -22,7 +23,7 @@ int main(int argc, char** argv)
     sym::references(ast, err);
 
   if (err.empty())
-    sym::precedence(ast, err);
+    prec::build(ast, err);
 
   if (!err.empty())
   {

--- a/src/ast/prec.cc
+++ b/src/ast/prec.cc
@@ -1,0 +1,394 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include "prec.h"
+
+using namespace peg::udl;
+
+namespace
+{
+  void add_typeargs(ast::Ast& ast, ast::Ast& typeargs)
+  {
+    // Adds a typeargs node to ast and moves to the next node in the expr.
+    // If it isn't a typeargs node, adds an empty typeargs node and does not
+    // advance to the next node in the expr.
+    if (typeargs && (typeargs->tag == "typeargs"_))
+    {
+      auto next = ast::get_next_in_expr(typeargs);
+      ast::remove(typeargs);
+      ast::push_back(ast, typeargs);
+      typeargs = next;
+    }
+    else
+    {
+      auto emptyargs = ast::node(ast, "typeargs");
+      ast::push_back(ast, emptyargs);
+    }
+  }
+
+  void staticcall_rule(ast::Ast& ast, err::Errors& err)
+  {
+    // static-call <-
+    //  typeref typargs? (lookup-typeref typeargs?)*
+    //  (lookup typeargs?)? tuple?
+    // (static-call qualtype function typeargs (args ...))
+    assert(ast->tag == "typeref"_);
+    auto typeref = ast;
+    auto call = ast::node(ast, "static-call");
+    ast::replace(ast, call);
+
+    auto qualtype = ast::node(ast, "qualtype");
+    ast::push_back(qualtype, typeref);
+    ast::push_back(ast, qualtype);
+
+    auto next = ast::get_next_in_expr(ast);
+    add_typeargs(qualtype, next);
+
+    // look for type lookups followed by optional typeargs
+    auto def = ast::get_def(ast, typeref->token);
+    assert(def && (def->tag == "typedef"_));
+
+    while (next)
+    {
+      if (next->tag != "lookup"_)
+        break;
+
+      auto subdef = ast::get_def(def, next->token);
+
+      if (!subdef || (subdef->tag != "typedef"_))
+        break;
+
+      ast::remove(next);
+      ast::rename(next, "typeref");
+      ast::push_back(qualtype, next);
+      next = ast::get_next_in_expr(ast);
+      add_typeargs(qualtype, next);
+      def = subdef;
+    }
+
+    if (next && (next->tag == "lookup"_))
+    {
+      // function call
+      ast::remove(next);
+      ast::rename(next, "function");
+      ast::push_back(call, next);
+      next = ast::get_next_in_expr(ast);
+      add_typeargs(call, next);
+    }
+    else
+    {
+      // create sugar
+      auto create = ast::token(call, "function", "create");
+      ast::push_back(call, create);
+      auto typeargs = ast::node(ast, "typeargs");
+      ast::push_back(call, typeargs);
+    }
+
+    if (next && (next->tag == "tuple"_))
+    {
+      ast::remove(next);
+      ast::rename(next, "args");
+      ast::push_back(call, next);
+    }
+    else
+    {
+      auto args = ast::node(call, "args");
+      ast::push_back(call, args);
+    }
+  }
+
+  void obj_rule(ast::Ast& ast, err::Errors& err)
+  {
+    if (ast && (ast->tag == "typeref"_))
+      staticcall_rule(ast, err);
+  }
+
+  void member_rule(ast::Ast& ast, err::Errors& err)
+  {
+    // member <- obj (lookup / typeargs tuple? / tuple)*
+    // lookup can't distinguish types from fields, so invocation is either
+    // calling a method or calling `apply` on a field.
+    obj_rule(ast, err);
+    auto next = ast::get_next_in_expr(ast);
+
+    while (next)
+    {
+      switch (next->tag)
+      {
+        case "lookup"_:
+        {
+          // (member obj lookup)
+          auto obj = ast;
+          auto member = ast::node(next, "member");
+          ast::replace(ast, member);
+          ast::push_back(ast, obj);
+          ast::remove(next);
+          ast::push_back(ast, next);
+          next = ast::get_next_in_expr(ast);
+          break;
+        }
+
+        case "typeargs"_:
+        {
+          // (invoke obj typeargs args)
+          auto obj = ast;
+          auto invoke = ast::node(next, "invoke");
+          ast::replace(ast, invoke);
+          ast::push_back(ast, obj);
+          ast::remove(next);
+          ast::push_back(ast, next);
+          next = ast::get_next_in_expr(ast);
+
+          if (next && (next->tag == "tuple"_))
+          {
+            ast::remove(next);
+            ast::rename(next, "args");
+            ast::push_back(ast, next);
+          }
+          else
+          {
+            // zero argument invoke
+            auto args = ast::node(ast, "args");
+            ast::push_back(ast, args);
+          }
+          break;
+        }
+
+        case "tuple"_:
+        {
+          // (invoke obj typeargs args)
+          auto obj = ast;
+          auto invoke = ast::node(next, "invoke");
+          ast::replace(ast, invoke);
+          ast::push_back(ast, obj);
+          auto typeargs = ast::node(ast, "typeargs");
+          ast::push_back(ast, typeargs);
+          ast::remove(next);
+          ast::rename(next, "args");
+          ast::push_back(ast, next);
+          break;
+        }
+
+        default:
+          return;
+      }
+    }
+  }
+
+  void prefix_rule(ast::Ast& ast, err::Errors& err)
+  {
+    // (call function typeargs obj (args))
+    if (ast && (ast->tag == "op"_))
+    {
+      auto op = ast;
+      auto call = ast::node(ast, "call");
+      ast::replace(ast, call);
+      ast::rename(op, "function");
+      ast::push_back(ast, op);
+      auto next = ast::get_next_in_expr(ast);
+      add_typeargs(ast, next);
+      prefix_rule(next, err);
+
+      if (!next)
+      {
+        err << ast << "Expected an argument to this prefix function."
+            << err::end;
+        return;
+      }
+
+      ast::remove(next);
+      ast::push_back(ast, next);
+      auto args = ast::node(ast, "args");
+      ast::push_back(ast, args);
+    }
+    else
+    {
+      member_rule(ast, err);
+    }
+  }
+
+  void infix_rule(ast::Ast& ast, err::Errors& err)
+  {
+    // (call function typeargs lhs (args rhs))
+    // Infix operators are left associative.
+    prefix_rule(ast, err);
+    auto next = ast::get_next_in_expr(ast);
+    std::string op;
+
+    while (next)
+    {
+      if (next->tag == "assign"_)
+        return;
+
+      if (next->tag != "op"_)
+      {
+        err << next << "Expected an infix operator here." << err::end;
+        return;
+      }
+
+      if (op.empty())
+      {
+        op = next->token;
+      }
+      else if (op != next->token)
+      {
+        err << next << "Use parentheses to establish precedence between " << op
+            << " and " << next->token << " infix operators." << err::end;
+      }
+
+      auto lhs = ast;
+      auto call = ast::node(ast, "call");
+      ast::replace(ast, call);
+      ast::remove(next);
+      ast::rename(next, "function");
+      ast::push_back(ast, next);
+      next = ast::get_next_in_expr(ast);
+      add_typeargs(ast, next);
+      ast::push_back(ast, lhs);
+      auto args = ast::node(ast, "args");
+      ast::push_back(ast, args);
+
+      if (!next)
+      {
+        err << ast << "Expected an expression after this infix operator."
+            << err::end;
+        return;
+      }
+
+      prefix_rule(next, err);
+
+      if (next)
+      {
+        ast::remove(next);
+        ast::push_back(args, next);
+        next = ast::get_next_in_expr(ast);
+      }
+    }
+  }
+
+  void assign_rule(ast::Ast& ast, err::Errors& err)
+  {
+    // (assign lhs rhs)
+    // Assignment is right associative.
+    infix_rule(ast, err);
+    auto next = ast::get_next_in_expr(ast);
+
+    if (!next)
+      return;
+
+    if (next->tag != "assign"_)
+    {
+      err << next << "Expected an assignment or the end of an expression here."
+          << err::end;
+      return;
+    }
+
+    auto lhs = ast;
+    auto assign = ast::node(ast, "assign");
+    ast::replace(ast, assign);
+    ast::push_back(ast, lhs);
+    ast::remove(next);
+    next = ast::get_next_in_expr(ast);
+    assign_rule(next, err);
+
+    if (!next)
+    {
+      err << ast << "Expected an expression after this assignment." << err::end;
+      return;
+    }
+
+    ast::remove(next);
+    ast::push_back(ast, next);
+  }
+}
+
+namespace prec
+{
+  void build(ast::Ast& ast, err::Errors& err)
+  {
+    // static-call <-
+    //  typeref typargs? (lookup-typeref typeargs?)* (lookup typeargs?)? tuple?
+    // obj <-
+    //  let / localref / tuple / new / lambda / literal / blockexpr /
+    //  static-call
+    // member <- obj (lookup / typeargs tuple? / tuple)*
+    // prefix-call <- (op typeargs? prefix-call) / member
+    // infix-call <- prefix-call (op typeargs? prefix-call)*
+    // assign <- infix-call ('=' assign)?
+    // expr <- break / continue / return assign? / yield assign? / assign
+    switch (ast->tag)
+    {
+      case "expr"_:
+      {
+        if (ast->nodes.empty())
+          return;
+
+        auto expr = ast;
+        ast = ast->nodes.front();
+
+        switch (ast->tag)
+        {
+          case "break"_:
+          case "continue"_:
+            break;
+
+          case "return"_:
+          case "yield"_:
+          {
+            auto control = ast::node(ast, ast->name.c_str());
+            ast::replace(ast, control);
+            auto next = ast::get_next_in_expr(ast);
+            assign_rule(next, err);
+            ast::remove(next);
+            ast::push_back(ast, next);
+            break;
+          }
+
+          default:
+          {
+            assign_rule(ast, err);
+            break;
+          }
+        }
+
+        auto parent = expr->parent.lock();
+
+        if (parent && (parent->tag == "interp_string"_))
+        {
+          // (call (function 'string') (typeargs) obj (args))
+          auto call = ast::node(expr, "call");
+          auto fun = ast::token(expr, "function", "string");
+          ast::push_back(call, fun);
+          auto typeargs = ast::node(expr, "typeargs");
+          ast::push_back(call, typeargs);
+          auto obj = expr->nodes.front();
+          ast::remove(obj);
+          ast::push_back(call, obj);
+          auto args = ast::node(expr, "args");
+          ast::push_back(call, args);
+          ast::push_back(expr, call);
+        }
+
+        if (expr->nodes.size() == 1)
+        {
+          ast::elide(expr);
+          build(expr, err);
+          return;
+        }
+        break;
+      }
+
+      case "tuple"_:
+      {
+        if (ast->nodes.size() == 1)
+        {
+          ast::elide(ast);
+          build(ast, err);
+          return;
+        }
+        break;
+      }
+    }
+
+    ast::for_each(ast, err, build);
+  }
+}

--- a/src/ast/prec.h
+++ b/src/ast/prec.h
@@ -5,8 +5,7 @@
 #include "ast.h"
 #include "err.h"
 
-namespace sym
+namespace prec
 {
-  void scope(ast::Ast& ast, err::Errors& err);
-  void references(ast::Ast& ast, err::Errors& err);
+  void build(ast::Ast& ast, err::Errors& err);
 }

--- a/src/ast/sym.cc
+++ b/src/ast/sym.cc
@@ -294,7 +294,8 @@ namespace sym
 
       case "string"_:
       {
-        auto s = lit::escape(ast->token);
+        auto s = lit::crlf2lf(ast->token);
+        s = lit::escape(s);
         auto e = ast::token(ast, "string", s);
         ast::replace(ast, e);
         break;
@@ -302,6 +303,7 @@ namespace sym
 
       case "interp_string"_:
       {
+        lit::crlf2lf(ast);
         lit::mangle_indent(ast);
         break;
       }

--- a/src/ast/sym.cc
+++ b/src/ast/sym.cc
@@ -199,18 +199,18 @@ namespace
     }
     else if (v <= 0x7FF)
     {
-      s.push_back(0xc0 | (v >> 6));
+      s.push_back(0xc0 | ((v >> 6) & 0xff));
       s.push_back(0x80 | (v & 0x3f));
     }
     else if (v <= 0xffff)
     {
-      s.push_back(0xe0 | (v >> 12));
+      s.push_back(0xe0 | ((v >> 12) & 0xff));
       s.push_back(0x80 | ((v >> 6) & 0x3f));
       s.push_back(0x80 | (v & 0x3f));
     }
     else if (v < 0x10ffff)
     {
-      s.push_back(0xf0 | (v >> 18));
+      s.push_back(0xf0 | ((v >> 18) & 0xff));
       s.push_back(0x80 | ((v >> 12) & 0x3f));
       s.push_back(0x80 | ((v >> 6) & 0x3f));
       s.push_back(0x80 | (v & 0x3f));
@@ -251,7 +251,7 @@ namespace
 
         case 'e':
         {
-          dst.push_back('\e');
+          dst.push_back(0x1b);
           break;
         }
 
@@ -368,7 +368,7 @@ namespace
         if (pos == 0)
         {
           ast::remove(node);
- 
+
           if (ast->nodes.empty())
             return;
         }

--- a/src/ast/sym.cc
+++ b/src/ast/sym.cc
@@ -365,6 +365,10 @@ namespace
 
       if ((pos != std::string::npos) && (node->token[pos] == '\n'))
       {
+        // Handle \r\n pairs.
+        if ((pos > 0) && (node->token[pos] == '\r'))
+          pos--;
+
         if (pos == 0)
         {
           ast::remove(node);

--- a/src/ast/sym.cc
+++ b/src/ast/sym.cc
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 #include "sym.h"
 
+#include "lit.h"
+
 using namespace peg::udl;
 
 namespace
@@ -78,45 +80,6 @@ namespace
     }
   }
 
-  void add_typeargs(ast::Ast& ast, ast::Ast& typeargs)
-  {
-    // Adds a typeargs node to ast and moves to the next node in the expr.
-    // If it isn't a typeargs node, adds an empty typeargs node and does not
-    // advance to the next node in the expr.
-    if (typeargs && (typeargs->tag == "typeargs"_))
-    {
-      auto next = ast::get_next_in_expr(typeargs);
-      ast::remove(typeargs);
-      ast::push_back(ast, typeargs);
-      typeargs = next;
-    }
-    else
-    {
-      auto emptyargs = ast::node(ast, "typeargs");
-      ast::push_back(ast, emptyargs);
-    }
-  }
-
-  template<typename T>
-  void for_each(ast::Ast ast, err::Errors& err, T f)
-  {
-    if (!ast)
-      return;
-
-    for (decltype(ast->nodes.size()) i = 0; i < ast->nodes.size(); i++)
-    {
-      auto node = ast->nodes[i];
-      f(node, err);
-    }
-  }
-
-  void elide(ast::Ast& ast, err::Errors& err)
-  {
-    assert(ast->nodes.size() == 1);
-    auto child = ast->nodes[0];
-    ast::replace(ast, child);
-  }
-
   void only_atom(ast::Ast& ast, err::Errors& err)
   {
     auto expr = ast::get_expr(ast);
@@ -132,7 +95,7 @@ namespace
   {
     auto expr = ast::get_expr(ast);
 
-    if (!expr || (expr->nodes[0] != ast))
+    if (!expr || (expr->nodes.front() != ast))
     {
       err << ast << ast->name << " must be the first element of an expression."
           << err::end;
@@ -151,7 +114,7 @@ namespace
 
     if (block)
     {
-      auto seq = block->nodes[0];
+      auto seq = block->nodes.front();
       auto expr = seq->nodes.back();
 
       if (expr == ast::get_expr(ast))
@@ -160,321 +123,6 @@ namespace
 
     err << ast << ast->token << " must be the last expression in a block."
         << err::end;
-  }
-
-  size_t hex(const std::string& src, size_t& i, size_t len)
-  {
-    size_t r = 0;
-
-    for (size_t count = 0; count < len; count++)
-    {
-      if (i >= (src.size() - 1))
-        return r;
-
-      auto c = src[i + 1];
-
-      if ((c >= '0') && (c <= '9'))
-        c = c - '0';
-      else if ((c >= 'A') && (c <= 'F'))
-        c = c - 'A' + 10;
-      else if ((c >= 'a') && (c <= 'f'))
-        c = c - 'a' + 10;
-      else
-        return r;
-
-      i++;
-      r = (r << 4) + c;
-    }
-
-    return r;
-  }
-
-  std::string utf8(size_t v)
-  {
-    std::string s;
-
-    if (v <= 0x7f)
-    {
-      s.push_back(v & 0x7f);
-    }
-    else if (v <= 0x7FF)
-    {
-      s.push_back(0xc0 | ((v >> 6) & 0xff));
-      s.push_back(0x80 | (v & 0x3f));
-    }
-    else if (v <= 0xffff)
-    {
-      s.push_back(0xe0 | ((v >> 12) & 0xff));
-      s.push_back(0x80 | ((v >> 6) & 0x3f));
-      s.push_back(0x80 | (v & 0x3f));
-    }
-    else if (v < 0x10ffff)
-    {
-      s.push_back(0xf0 | ((v >> 18) & 0xff));
-      s.push_back(0x80 | ((v >> 12) & 0x3f));
-      s.push_back(0x80 | ((v >> 6) & 0x3f));
-      s.push_back(0x80 | (v & 0x3f));
-    }
-
-    return s;
-  }
-
-  std::string escape(const std::string& src)
-  {
-    std::string dst;
-
-    for (size_t i = 0; i < src.size(); i++)
-    {
-      auto c = src[i];
-
-      if (c != '\\')
-      {
-        dst.push_back(c);
-        continue;
-      }
-
-      auto n = src[++i];
-
-      switch (n)
-      {
-        case 'a':
-        {
-          dst.push_back('\a');
-          break;
-        }
-
-        case 'b':
-        {
-          dst.push_back('\b');
-          break;
-        }
-
-        case 'e':
-        {
-          dst.push_back(0x1b);
-          break;
-        }
-
-        case 'f':
-        {
-          dst.push_back('\f');
-          break;
-        }
-
-        case 'n':
-        {
-          dst.push_back('\n');
-          break;
-        }
-
-        case 'r':
-        {
-          dst.push_back('\r');
-          break;
-        }
-
-        case 't':
-        {
-          dst.push_back('\t');
-          break;
-        }
-
-        case 'v':
-        {
-          dst.push_back('\v');
-          break;
-        }
-
-        case '\\':
-        {
-          dst.push_back('\\');
-          break;
-        }
-
-        case '0':
-        {
-          dst.push_back('\0');
-          break;
-        }
-
-        case 'x':
-        {
-          dst.append(utf8(hex(src, i, 2)));
-          break;
-        }
-
-        case 'u':
-        {
-          dst.append(utf8(hex(src, i, 4)));
-          break;
-        }
-
-        case 'U':
-        {
-          dst.append(utf8(hex(src, i, 6)));
-          break;
-        }
-
-        default:
-        {
-          dst.push_back(n);
-          break;
-        }
-      }
-    }
-
-    return dst;
-  }
-
-  void mangle_indent(ast::Ast& ast)
-  {
-    if (ast->nodes.empty())
-      return;
-
-    // Remove a leading blank line if one exists.
-    auto node = ast->nodes.front();
-
-    if (node->tag == "quote"_)
-    {
-      auto pos = node->token.find_first_not_of(" \f\r\t\v");
-
-      if ((pos != std::string::npos) && (node->token[pos] == '\n'))
-      {
-        if (pos == (node->token.size() - 1))
-        {
-          ast::remove(node);
-
-          if (ast->nodes.empty())
-            return;
-        }
-        else
-        {
-          auto trim = node->token.substr(pos + 1);
-          auto quote = ast::token(node, "quote", trim);
-          ast::replace(node, quote);
-        }
-      }
-    }
-
-    // Remove a trailing blank line if one exists.
-    node = ast->nodes.back();
-
-    if (node->tag == "quote"_)
-    {
-      auto pos = node->token.find_last_not_of(" \f\r\t\v");
-
-      if ((pos != std::string::npos) && (node->token[pos] == '\n'))
-      {
-        // Handle \r\n pairs.
-        if ((pos > 0) && (node->token[pos] == '\r'))
-          pos--;
-
-        if (pos == 0)
-        {
-          ast::remove(node);
-
-          if (ast->nodes.empty())
-            return;
-        }
-        else
-        {
-          auto trim = node->token.substr(0, pos);
-          auto quote = ast::token(node, "quote", trim);
-          ast::replace(node, quote);
-        }
-      }
-    }
-
-    // If the first node is not a quote, the string starts with an unquote that
-    // is not indented, so we need no indentation mangling.
-    if (ast->nodes[0]->tag != "quote"_)
-      return;
-
-    // Calculate indentation.
-    size_t indent = std::numeric_limits<size_t>::max();
-
-    for (size_t i = 0; i < ast->nodes.size(); i++)
-    {
-      node = ast->nodes[i];
-
-      if (node->tag != "quote"_)
-        continue;
-
-      // Start from the first character only on the first node. Otherwise start
-      // from right after the first newline.
-      size_t prev = 0;
-
-      if (i > 0)
-      {
-        prev = node->token.find("\n");
-
-        if (prev != std::string::npos)
-          prev++;
-      }
-
-      while (prev != std::string::npos)
-      {
-        auto pos = node->token.find_first_not_of(" \f\r\t\v", prev);
-
-        // Entirely blank lines don't influence indentation.
-        if (pos == std::string::npos)
-          break;
-
-        auto len = pos - prev;
-
-        if (len < indent)
-          indent = len;
-
-        prev = node->token.find("\n", pos);
-
-        if (prev != std::string::npos)
-          prev++;
-      }
-    }
-
-    // Trim indentation.
-    if (indent > 0)
-    {
-      for (size_t i = 0; i < ast->nodes.size(); i++)
-      {
-        node = ast->nodes[i];
-
-        if (node->tag != "quote"_)
-          continue;
-
-        // Start from the first character only on the first node. Otherwise
-        // start from right after the first newline.
-        std::string s;
-        size_t prev = 0;
-
-        if (i > 0)
-        {
-          prev = node->token.find("\n");
-
-          if (prev == std::string::npos)
-            continue;
-
-          prev++;
-          s.append(node->token.substr(0, prev));
-        }
-
-        while (prev != std::string::npos)
-        {
-          auto pos = node->token.find("\n", prev);
-
-          if (pos != std::string::npos)
-            pos++;
-
-          if ((prev + indent) < node->token.size())
-            s.append(node->token.substr(prev + indent, pos - indent));
-
-          prev = pos;
-        }
-
-        auto quote = ast::token(node, "quote", s);
-        ast::replace(node, quote);
-      }
-    }
   }
 }
 
@@ -510,26 +158,26 @@ namespace sym
 
       case "typeparam"_:
       {
-        add_symbol(ast->nodes[0]->token, ast, err);
+        add_symbol(ast->nodes.front()->token, ast, err);
         break;
       }
 
       case "field"_:
       {
-        add_symbol(ast->nodes[0]->token, ast, err);
+        add_symbol(ast->nodes.front()->token, ast, err);
         break;
       }
 
       case "function"_:
       {
         // A missing function name is sugar for "apply"
-        if (ast->nodes[0]->nodes.size() == 0)
+        if (ast->nodes.front()->nodes.size() == 0)
         {
-          ast->nodes[0]->nodes.push_back(
-            ast::token(ast->nodes[0], "id", "apply"));
+          ast->nodes.front()->nodes.push_back(
+            ast::token(ast->nodes.front(), "id", "apply"));
         }
 
-        auto node = ast->nodes[0]->nodes[0];
+        auto node = ast->nodes.front()->nodes.front();
         add_symbol(node->token, ast, err);
         add_scope(ast);
         break;
@@ -537,7 +185,7 @@ namespace sym
 
       case "namedparam"_:
       {
-        add_symbol(ast->nodes[0]->token, ast, err);
+        add_symbol(ast->nodes.front()->token, ast, err);
         break;
       }
 
@@ -550,7 +198,7 @@ namespace sym
 
       case "blockexpr"_:
       {
-        elide(ast, err);
+        ast::elide(ast);
         scope(ast, err);
         return;
       }
@@ -570,7 +218,7 @@ namespace sym
 
       case "atom"_:
       {
-        elide(ast, err);
+        ast::elide(ast);
 
         if (ast->tag == "id"_)
           ast::rename(ast, "ref");
@@ -601,7 +249,7 @@ namespace sym
       {
         first_atom(ast, err);
 
-        for_each(ast, err, [](auto& node, auto& err) {
+        ast::for_each(ast, err, [](auto& node, auto& err) {
           if (node->tag == "id"_)
           {
             ast::rename(node, "local");
@@ -619,7 +267,7 @@ namespace sym
 
           if (next && (next->tag == "atom"_))
           {
-            auto id = next->nodes[0];
+            auto id = next->nodes.front();
 
             if ((id->tag == "id"_) || (id->tag == "sym"_))
             {
@@ -646,7 +294,7 @@ namespace sym
 
       case "string"_:
       {
-        auto s = escape(ast->token);
+        auto s = lit::escape(ast->token);
         auto e = ast::token(ast, "string", s);
         ast::replace(ast, e);
         break;
@@ -654,7 +302,7 @@ namespace sym
 
       case "interp_string"_:
       {
-        mangle_indent(ast);
+        lit::mangle_indent(ast);
         break;
       }
 
@@ -667,9 +315,9 @@ namespace sym
 
       case "unquote"_:
       {
-        if (ast->nodes[0]->tag == "%word"_)
+        if (ast->nodes.front()->tag == "%word"_)
         {
-          auto ref = ast->nodes[0];
+          auto ref = ast->nodes.front();
           auto expr = ast::node(ast, "expr");
           ast::replace(ast, expr);
           ast::rename(ref, "ref");
@@ -677,7 +325,7 @@ namespace sym
         }
         else
         {
-          elide(ast, err);
+          ast::elide(ast);
         }
 
         scope(ast, err);
@@ -685,7 +333,7 @@ namespace sym
       }
     }
 
-    for_each(ast, err, scope);
+    ast::for_each(ast, err, scope);
   }
 
   void references(ast::Ast& ast, err::Errors& err)
@@ -699,370 +347,6 @@ namespace sym
       }
     }
 
-    for_each(ast, err, references);
-  }
-
-  void prec_staticcall(ast::Ast& ast, err::Errors& err)
-  {
-    // static-call <-
-    //  typeref typargs? (lookup-typeref typeargs?)*
-    //  (lookup typeargs?)? tuple?
-    // (static-call qualtype function typeargs (args ...))
-    assert(ast->tag == "typeref"_);
-    auto typeref = ast;
-    auto call = ast::node(ast, "static-call");
-    ast::replace(ast, call);
-
-    auto qualtype = ast::node(ast, "qualtype");
-    ast::push_back(qualtype, typeref);
-    ast::push_back(ast, qualtype);
-
-    auto next = ast::get_next_in_expr(ast);
-    add_typeargs(qualtype, next);
-
-    // look for type lookups followed by optional typeargs
-    auto def = ast::get_def(ast, typeref->token);
-    assert(def && (def->tag == "typedef"_));
-
-    while (next)
-    {
-      if (next->tag != "lookup"_)
-        break;
-
-      auto subdef = ast::get_def(def, next->token);
-
-      if (!subdef || (subdef->tag != "typedef"_))
-        break;
-
-      ast::remove(next);
-      ast::rename(next, "typeref");
-      ast::push_back(qualtype, next);
-      next = ast::get_next_in_expr(ast);
-      add_typeargs(qualtype, next);
-      def = subdef;
-    }
-
-    if (next && (next->tag == "lookup"_))
-    {
-      // function call
-      ast::remove(next);
-      ast::rename(next, "function");
-      ast::push_back(call, next);
-      next = ast::get_next_in_expr(ast);
-      add_typeargs(call, next);
-    }
-    else
-    {
-      // create sugar
-      auto create = ast::token(call, "function", "create");
-      ast::push_back(call, create);
-      auto typeargs = ast::node(ast, "typeargs");
-      ast::push_back(call, typeargs);
-    }
-
-    if (next && (next->tag == "tuple"_))
-    {
-      ast::remove(next);
-      ast::rename(next, "args");
-      ast::push_back(call, next);
-    }
-    else
-    {
-      auto args = ast::node(call, "args");
-      ast::push_back(call, args);
-    }
-  }
-
-  void prec_obj(ast::Ast& ast, err::Errors& err)
-  {
-    if (ast && (ast->tag == "typeref"_))
-      prec_staticcall(ast, err);
-  }
-
-  void prec_member(ast::Ast& ast, err::Errors& err)
-  {
-    // member <- obj (lookup / typeargs tuple? / tuple)*
-    // lookup can't distinguish types from fields, so invocation is either
-    // calling a method or calling `apply` on a field.
-    prec_obj(ast, err);
-    auto next = ast::get_next_in_expr(ast);
-
-    while (next)
-    {
-      switch (next->tag)
-      {
-        case "lookup"_:
-        {
-          // (member obj lookup)
-          auto obj = ast;
-          auto member = ast::node(next, "member");
-          ast::replace(ast, member);
-          ast::push_back(ast, obj);
-          ast::remove(next);
-          ast::push_back(ast, next);
-          next = ast::get_next_in_expr(ast);
-          break;
-        }
-
-        case "typeargs"_:
-        {
-          // (invoke obj typeargs args)
-          auto obj = ast;
-          auto invoke = ast::node(next, "invoke");
-          ast::replace(ast, invoke);
-          ast::push_back(ast, obj);
-          ast::remove(next);
-          ast::push_back(ast, next);
-          next = ast::get_next_in_expr(ast);
-
-          if (next && (next->tag == "tuple"_))
-          {
-            ast::remove(next);
-            ast::rename(next, "args");
-            ast::push_back(ast, next);
-          }
-          else
-          {
-            // zero argument invoke
-            auto args = ast::node(ast, "args");
-            ast::push_back(ast, args);
-          }
-          break;
-        }
-
-        case "tuple"_:
-        {
-          // (invoke obj typeargs args)
-          auto obj = ast;
-          auto invoke = ast::node(next, "invoke");
-          ast::replace(ast, invoke);
-          ast::push_back(ast, obj);
-          auto typeargs = ast::node(ast, "typeargs");
-          ast::push_back(ast, typeargs);
-          ast::remove(next);
-          ast::rename(next, "args");
-          ast::push_back(ast, next);
-          break;
-        }
-
-        default:
-          return;
-      }
-    }
-  }
-
-  void prec_prefix(ast::Ast& ast, err::Errors& err)
-  {
-    // (call function typeargs obj (args))
-    if (ast && (ast->tag == "op"_))
-    {
-      auto op = ast;
-      auto call = ast::node(ast, "call");
-      ast::replace(ast, call);
-      ast::rename(op, "function");
-      ast::push_back(ast, op);
-      auto next = ast::get_next_in_expr(ast);
-      add_typeargs(ast, next);
-      prec_prefix(next, err);
-
-      if (!next)
-      {
-        err << ast << "Expected an argument to this prefix function."
-            << err::end;
-        return;
-      }
-
-      ast::remove(next);
-      ast::push_back(ast, next);
-      auto args = ast::node(ast, "args");
-      ast::push_back(ast, args);
-    }
-    else
-    {
-      prec_member(ast, err);
-    }
-  }
-
-  void prec_infix(ast::Ast& ast, err::Errors& err)
-  {
-    // (call function typeargs lhs (args rhs))
-    // Infix operators are left associative.
-    prec_prefix(ast, err);
-    auto next = ast::get_next_in_expr(ast);
-    std::string op;
-
-    while (next)
-    {
-      if (next->tag == "assign"_)
-        return;
-
-      if (next->tag != "op"_)
-      {
-        err << next << "Expected an infix operator here." << err::end;
-        return;
-      }
-
-      if (op.empty())
-      {
-        op = next->token;
-      }
-      else if (op != next->token)
-      {
-        err << next << "Use parentheses to establish precedence between " << op
-            << " and " << next->token << " infix operators." << err::end;
-      }
-
-      auto lhs = ast;
-      auto call = ast::node(ast, "call");
-      ast::replace(ast, call);
-      ast::remove(next);
-      ast::rename(next, "function");
-      ast::push_back(ast, next);
-      next = ast::get_next_in_expr(ast);
-      add_typeargs(ast, next);
-      ast::push_back(ast, lhs);
-      auto args = ast::node(ast, "args");
-      ast::push_back(ast, args);
-
-      if (!next)
-      {
-        err << ast << "Expected an expression after this infix operator."
-            << err::end;
-        return;
-      }
-
-      prec_prefix(next, err);
-
-      if (next)
-      {
-        ast::remove(next);
-        ast::push_back(args, next);
-        next = ast::get_next_in_expr(ast);
-      }
-    }
-  }
-
-  void prec_assign(ast::Ast& ast, err::Errors& err)
-  {
-    // (assign lhs rhs)
-    // Assignment is right associative.
-    prec_infix(ast, err);
-    auto next = ast::get_next_in_expr(ast);
-
-    if (!next)
-      return;
-
-    if (next->tag != "assign"_)
-    {
-      err << next << "Expected an assignment or the end of an expression here."
-          << err::end;
-      return;
-    }
-
-    auto lhs = ast;
-    auto assign = ast::node(ast, "assign");
-    ast::replace(ast, assign);
-    ast::push_back(ast, lhs);
-    ast::remove(next);
-    next = ast::get_next_in_expr(ast);
-    prec_assign(next, err);
-
-    if (!next)
-    {
-      err << ast << "Expected an expression after this assignment." << err::end;
-      return;
-    }
-
-    ast::remove(next);
-    ast::push_back(ast, next);
-  }
-
-  void precedence(ast::Ast& ast, err::Errors& err)
-  {
-    // static-call <-
-    //  typeref typargs? (lookup-typeref typeargs?)* (lookup typeargs?)? tuple?
-    // obj <-
-    //  let / localref / tuple / new / lambda / literal / blockexpr /
-    //  static-call
-    // member <- obj (lookup / typeargs tuple? / tuple)*
-    // prefix-call <- (op typeargs? prefix-call) / member
-    // infix-call <- prefix-call (op typeargs? prefix-call)*
-    // assign <- infix-call ('=' assign)?
-    // expr <- break / continue / return assign? / yield assign? / assign
-    switch (ast->tag)
-    {
-      case "expr"_:
-      {
-        if (ast->nodes.empty())
-          return;
-
-        auto expr = ast;
-        ast = ast->nodes[0];
-
-        switch (ast->tag)
-        {
-          case "break"_:
-          case "continue"_:
-            break;
-
-          case "return"_:
-          case "yield"_:
-          {
-            auto control = ast::node(ast, ast->name.c_str());
-            ast::replace(ast, control);
-            auto next = ast::get_next_in_expr(ast);
-            prec_assign(next, err);
-            ast::remove(next);
-            ast::push_back(ast, next);
-            break;
-          }
-
-          default:
-          {
-            prec_assign(ast, err);
-            break;
-          }
-        }
-
-        auto parent = expr->parent.lock();
-
-        if (parent && (parent->tag == "interp_string"_))
-        {
-          // (call (function 'string') (typeargs) obj (args))
-          auto call = ast::node(expr, "call");
-          auto fun = ast::token(expr, "function", "string");
-          ast::push_back(call, fun);
-          auto typeargs = ast::node(expr, "typeargs");
-          ast::push_back(call, typeargs);
-          auto obj = expr->nodes[0];
-          ast::remove(obj);
-          ast::push_back(call, obj);
-          auto args = ast::node(expr, "args");
-          ast::push_back(call, args);
-          ast::push_back(expr, call);
-        }
-
-        if (expr->nodes.size() == 1)
-        {
-          elide(expr, err);
-          precedence(expr, err);
-          return;
-        }
-        break;
-      }
-
-      case "tuple"_:
-      {
-        if (ast->nodes.size() == 1)
-        {
-          elide(ast, err);
-          precedence(ast, err);
-          return;
-        }
-        break;
-      }
-    }
-
-    for_each(ast, err, precedence);
+    ast::for_each(ast, err, references);
   }
 }

--- a/testsuite/parse/ast-parse/literal.verona
+++ b/testsuite/parse/ast-parse/literal.verona
@@ -7,11 +7,6 @@ f()
   let int2 = 0xc0_FFeE;
   let int3 = 0b10_10_10;
   let float1 = 27.18e-1;
-  let string1 = `foo;
-  let string2 = `(wat ℵ \n);
-  let string3 = `(foo\nbar\) baz);
-  let string4 = `(foo \`\( \ ( \\ baz);
-  let string5 = `(foo `(bar) `bar baz);
   let precedence1 = 1 + 2 + 3;
   let precedence2 = 1 + (2 + 3);
   let object1 = new { x : U64 = 0; };

--- a/testsuite/parse/ast-parse/literal/ast.txt
+++ b/testsuite/parse/ast-parse/literal/ast.txt
@@ -31,31 +31,6 @@
           - float (27.18e-1)
         + assign
           + let
-            - local (string1)
-            + oftype
-          - string (foo)
-        + assign
-          + let
-            - local (string2)
-            + oftype
-          - string (wat ℵ \n)
-        + assign
-          + let
-            - local (string3)
-            + oftype
-          - string (foo\nbar\) baz)
-        + assign
-          + let
-            - local (string4)
-            + oftype
-          - string (foo \`\( \ ( \\ baz)
-        + assign
-          + let
-            - local (string5)
-            + oftype
-          - string (foo `(bar) `bar baz)
-        + assign
-          + let
             - local (precedence1)
             + oftype
           + call

--- a/testsuite/parse/ast-parse/strings.verona
+++ b/testsuite/parse/ast-parse/strings.verona
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+(x: U64, y: U64)
+{
+  " c-string \" \U01f604 -> 😄 ";
+  // no starting or trailing newline
+  "{
+    no indent $x + ${y} = ${x + y} $1
+      indent 2 spaces "{no interp: $x}"
+  }";
+  // starting and trailing newline
+  "{
+
+    hi
+
+  }";
+  // empty string
+  "{
+  }";
+  // escaping a tab into a delimited string
+  let tab = "\t";
+  "{
+    look, a $tab in my string
+  }"
+}

--- a/testsuite/parse/ast-parse/strings.verona
+++ b/testsuite/parse/ast-parse/strings.verona
@@ -22,5 +22,5 @@
   let tab = "\t";
   "{
     look, a $tab in my string
-  }"
+  }";
 }

--- a/testsuite/parse/ast-parse/strings/ast.txt
+++ b/testsuite/parse/ast-parse/strings/ast.txt
@@ -1,0 +1,76 @@
++ module
+  + function
+    + funcname
+      - id (apply)
+    + sig
+      + typeparams
+      + params
+        + param/0
+          + namedparam
+            - id (x)
+            + oftype
+              + type
+                + type_one/1
+                  + type_ref
+                    - id (U64)
+            + initexpr
+        + param/0
+          + namedparam
+            - id (y)
+            + oftype
+              + type
+                + type_one/1
+                  + type_ref
+                    - id (U64)
+            + initexpr
+      + oftype
+      + constraints
+    + block
+      + seq
+        - string ( c-string " 😄 -> 😄 )
+        + interp_string
+          - string (no indent )
+          + call/0
+            - function (string)
+            + typeargs/0
+            - localref (x)
+            + args/0
+          - string ( + )
+          + call/1
+            - function (string)
+            + typeargs/1
+            - localref (y)
+            + args/1
+          - string ( = )
+          + call/1
+            - function (string)
+            + typeargs/1
+            + call
+              - function (+)
+              + typeargs
+              - localref (x)
+              + args
+                - localref (y)
+            + args/1
+          - string ( $1
+  indent 2 spaces "{no interp: $x}")
+        + interp_string
+          - string (
+    hi
+)
+        + interp_string
+          - string ()
+        + assign
+          + let
+            - local (tab)
+            + oftype
+          - string (	)
+        + interp_string
+          - string (look, a )
+          + call/0
+            - function (string)
+            + typeargs/0
+            - localref (tab)
+            + args/0
+          - string ( in my string)
+

--- a/testsuite/parse/ast-parse/strings/ast.txt
+++ b/testsuite/parse/ast-parse/strings/ast.txt
@@ -56,10 +56,9 @@
   indent 2 spaces "{no interp: $x}")
         + interp_string
           - string (
-    hi
+hi
 )
         + interp_string
-          - string ()
         + assign
           + let
             - local (tab)


### PR DESCRIPTION
This PR changes from `(...) syntax to allow two forms of string
literal:

1. C-style strings, which are "..." delimited, not nested, not
   interpolated, and allow C-style escapes. Unlike C strings, they
   are multiline and allow arbitrary UTF-8 content.
2. Verona strings, which are "{...}" delimited, nested, have no
   escapes at all, and interpolate $id and ${expr} in the outer-
   most nesting. They are also multiline (and do indentation
   mangling), and allow arbitrary UTF-8 content.