### PR TITLE
Only build and test runtime if changed

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -2,8 +2,23 @@ resources:
 - repo: self
 
 jobs:
+- job: HasRuntimeChanged
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+  - script: |
+      echo "Determine if runtime changed."
+      git diff --quiet origin/master -- src/rt || echo "##vso[task.setvariable variable=testRuntime;isOutput=true]On" #set variable to testRuntime to On
+      git diff --quiet origin/master -- src/rt && echo "##vso[task.setvariable variable=testRuntime;isOutput=true]Off" #set variable to testRuntime to Off
+      git diff --quiet origin/master -- src/rt && echo "Runtime unchanged!"
+      git diff --quiet origin/master -- src/rt || echo "Runtime changed!"
+    displayName: Check for runtime changes.
+    name: setVarStep
 - job: 
   displayName: Linux
+  dependsOn: HasRuntimeChanged
+  variables: 
+    RTTests: $[ dependencies.HasRuntimeChanged.outputs['setVarStep.testRuntime'] ]
   pool:
     vmImage: 'ubuntu-16.04'
   strategy:
@@ -42,13 +57,14 @@ jobs:
       sudo apt-get install -y ninja-build
 
       sudo pip install wheel OutputCheck
+      echo RTTESTS=$(RTTests)
     displayName: 'Install Build Dependencies'
 
   - task: CMake@1
-    displayName: 'CMake .. -GNinja -DCMAKE_BUILD_TYPE=$(BuildType) -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_COMPILER=$(CXX) -DCMAKE_CXX_FLAGS=$(CXXFLAGS) -DUSE_ASAN=$(Asan) -DVERONA_CI_BUILD=On -DSNMALLOC_CI_BUILD=On -DRT_TESTS=On'
+    displayName: 'CMake .. -GNinja -DCMAKE_BUILD_TYPE=$(BuildType) -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_COMPILER=$(CXX) -DCMAKE_CXX_FLAGS=$(CXXFLAGS) -DUSE_ASAN=$(Asan) -DVERONA_CI_BUILD=On -DSNMALLOC_CI_BUILD=On -DRT_TESTS=$(RTTests)'
     inputs:
       cmakeArgs: |
-        .. -GNinja -DCMAKE_BUILD_TYPE=$(BuildType) -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_COMPILER=$(CXX) -DCMAKE_CXX_FLAGS=$(CXXFLAGS) -DUSE_ASAN=$(Asan) -DVERONA_CI_BUILD=On -DSNMALLOC_CI_BUILD=On -DRT_TESTS=On
+        .. -GNinja -DCMAKE_BUILD_TYPE=$(BuildType) -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_COMPILER=$(CXX) -DCMAKE_CXX_FLAGS=$(CXXFLAGS) -DUSE_ASAN=$(Asan) -DVERONA_CI_BUILD=On -DSNMALLOC_CI_BUILD=On -DRT_TESTS=$(RTTests)
 
   - script: |
       set -eo pipefail
@@ -62,21 +78,16 @@ jobs:
       export ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer
       export ASAN_OPTIONS="alloc_dealloc_mismatch=0 symbolize=1"
       ctest -j 4 -E "([1-9][0-9]00|[4-9]00)" --timeout 400 --output-on-failure
-    workingDirectory: build/src/rt
+    workingDirectory: build
     failOnStderr: true
-    displayName: Runtime test suite
-
-  - script: |
-      set -eo pipefail
-      export ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer
-      export ASAN_OPTIONS="alloc_dealloc_mismatch=0 symbolize=1"
-      ctest -j 4 --timeout 400 --output-on-failure
-    workingDirectory: build/testsuite
-    failOnStderr: true
-    displayName: Language test suite
+    displayName: Tests
 
 - job: 
   displayName: Windows
+  dependsOn: HasRuntimeChanged
+  variables: 
+    RTTests: $[ dependencies.HasRuntimeChanged.outputs['setVarStep.testRuntime'] ]
+
   pool:
     vmImage: 'vs2017-win2016'
   strategy:
@@ -92,11 +103,11 @@ jobs:
 
   - script:
       pip install OutputCheck
-
-  - task: CMake@1
-    displayName: 'CMake .. -G"Visual Studio 15 2017 Win64" -DVERONA_CI_BUILD=On -DSNMALLOC_CI_BUILD=On -DRT_TESTS=On'
-    inputs:
-      cmakeArgs: '.. -G"Visual Studio 15 2017 Win64" -DVERONA_CI_BUILD=On -DSNMALLOC_CI_BUILD=On -DRT_TESTS=On'
+      
+  - script: |
+      mkdir build
+      cd build
+      cmake .. -G"Visual Studio 15 2017 Win64" -DVERONA_CI_BUILD=On -DSNMALLOC_CI_BUILD=On -DRT_TESTS=$(RTTests)
 
   - task: MSBuild@1
     displayName: 'Build solution build/verona-lang.sln'
@@ -106,15 +117,9 @@ jobs:
 
   - script: |
       ctest -j 4 -E "([1-9][0-9]00|[4-9]00)" --timeout 400 --output-on-failure --interactive-debug-mode 0 -C $(BuildType)
-    workingDirectory: build/src/rt
+    workingDirectory: build/
     failOnStderr: true
-    displayName: Runtime test suite
-
-  - script: |
-      ctest -j 4 --timeout 400 --output-on-failure --interactive-debug-mode 0 -C $(BuildType)
-    workingDirectory: build/testsuite
-    failOnStderr: true
-    displayName: Language test suite
+    displayName: Tests
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
@@ -123,6 +128,10 @@ jobs:
 
 - job: 
   displayName: macOS
+  dependsOn: HasRuntimeChanged
+  variables: 
+    RTTests: $[ dependencies.HasRuntimeChanged.outputs['setVarStep.testRuntime'] ]
+
   pool:
     vmImage: 'macOS-10.14'
   strategy:
@@ -142,9 +151,9 @@ jobs:
     displayName:  Dependencies
 
   - task: CMake@1
-    displayName: 'CMake .. -DCMAKE_BUILD_TYPE=$(BuildType) -DVERONA_CI_BUILD=On -DRT_TESTS=On'
+    displayName: 'CMake .. -DCMAKE_BUILD_TYPE=$(BuildType) -DVERONA_CI_BUILD=On -DRT_TESTS=$(RTTests)'
     inputs:
-      cmakeArgs: '.. -DCMAKE_BUILD_TYPE=$(BuildType) -DVERONA_CI_BUILD=On -DSNMALLOC_CI_BUILD=On -DRT_TESTS=On'
+      cmakeArgs: '.. -DCMAKE_BUILD_TYPE=$(BuildType) -DVERONA_CI_BUILD=On -DSNMALLOC_CI_BUILD=On -DRT_TESTS=$(RTTests)'
 
   - script: |
       set -eo pipefail
@@ -157,16 +166,9 @@ jobs:
   - script: |
       set -eo pipefail
       ctest -j 4 -E "([1-9][0-9]00|[4-9]00)" --timeout 400 --output-on-failure
-    workingDirectory: build/src/rt
+    workingDirectory: build/
     failOnStderr: true
-    displayName: Runtime test suite
-
-  - script: |
-      set -eo pipefail
-      ctest -j 4 --timeout 400 --output-on-failure
-    workingDirectory: build/testsuite
-    failOnStderr: true
-    displayName: Language test suite
+    displayName: Tests suite
 
 - job: 
   displayName: Format

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -60,7 +60,6 @@ jobs:
       sudo apt-get install -y ninja-build
 
       sudo pip install wheel OutputCheck
-      echo RTTESTS=$(RTTests)
     displayName: 'Install Build Dependencies'
 
   - task: CMake@1

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -8,10 +8,13 @@ jobs:
   steps:
   - script: |
       echo "Determine if runtime changed."
-      git diff --quiet origin/master -- src/rt || echo "##vso[task.setvariable variable=testRuntime;isOutput=true]On" #set variable to testRuntime to On
-      git diff --quiet origin/master -- src/rt && echo "##vso[task.setvariable variable=testRuntime;isOutput=true]Off" #set variable to testRuntime to Off
-      git diff --quiet origin/master -- src/rt && echo "Runtime unchanged!"
-      git diff --quiet origin/master -- src/rt || echo "Runtime changed!"
+      if git diff --quiet origin/master -- src/rt; then
+        echo "Runtime unchanged!"
+        echo "##vso[task.setvariable variable=testRuntime;isOutput=true]Off" #set variable to testRuntime to Off
+      else
+        echo "Runtime changed!"
+        echo "##vso[task.setvariable variable=testRuntime;isOutput=true]On" #set variable to testRuntime to On
+      fi
     displayName: Check for runtime changes.
     name: setVarStep
 - job: 


### PR DESCRIPTION
The runtime systematic testing can be slow, and there are a lot of
language changes that do not need to retest the runtime. This changed
detects if anything has changed in the runtime, and if it has not
changed, then it does not rebuild or run the tests.