### PR TITLE
Fix potential double collection

### DIFF
--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -763,6 +763,7 @@ namespace verona::rt
                 << "Cown " << c << " not outdated." << std::endl;
           }
         }
+        p = &(c->next);
       }
 
       free_cowns -= count;


### PR DESCRIPTION
Make the ref count the trigger for final collection on a cown.  Leak
detection can trigger the body of the cown to be collected, but
the stub will remain until the weak_count hits 0.  This fixes a bug
where the delayed dec ref lists are ignored by the leak detector. Now
when the leak detector frees an unreachable component, it performs the
decrefs, but does not signal that the stub can be collected until the
ref count reachs zero.

Previously, the thread field was set to zero to indicate the body had
been collected, now we use the bottom bit, so we don't confuse the
unadopted by a scheduler thread state, and the collected state.