### PR TITLE
Recusive deallocation tests and fixes

### DIFF
--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -1164,7 +1164,7 @@ namespace verona::rt
       yield();
       weak_release(alloc);
 
-      // Collect recursively reachable cowns 
+      // Collect recursively reachable cowns
       while (!current.empty())
       {
         auto a = (Cown*)current.pop();

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -1146,18 +1146,18 @@ namespace verona::rt
      **/
     void queue_collect(Alloc* alloc)
     {
-      thread_local ObjectStack* queue = nullptr;
+      thread_local ObjectStack* work_list = nullptr;
 
       // If there is a already a queue, use it
-      if (queue != nullptr)
+      if (work_list != nullptr)
       {
-        queue->push(this);
+        work_list->push(this);
         return;
       }
 
       // Make queue for recursive deallocations.
       ObjectStack current(alloc);
-      queue = &current;
+      work_list = &current;
 
       // Collect the current cown
       collect(alloc);
@@ -1172,7 +1172,7 @@ namespace verona::rt
         yield();
         a->weak_release(alloc);
       }
-      queue = nullptr;
+      work_list = nullptr;
     }
 
     void collect(Alloc* alloc)

--- a/src/rt/test/func/cownchain/cownchain.cc
+++ b/src/rt/test/func/cownchain/cownchain.cc
@@ -1,0 +1,63 @@
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#include <test/harness.h>
+#include <test/xoroshiro.h>
+/**
+ * This example is design to test a long chain of cowns being collected.
+ **/
+
+struct ChainCown;
+
+struct LinkObject : public V<LinkObject>
+{
+  ChainCown* next;
+
+  LinkObject(ChainCown* next) : next(next) {}
+
+  void trace(ObjectStack& fields) const;
+};
+
+struct ChainCown : public VCown<ChainCown>
+{
+  LinkObject* next;
+
+  ChainCown(LinkObject* next) : next(next) {}
+
+  static ChainCown* make_chain(Alloc* alloc, size_t length)
+  {
+    ChainCown* hd = nullptr;
+    for (; length > 0; length --)
+    {
+      auto next = new (alloc) LinkObject(hd);
+      if (hd != nullptr)
+        RegionTrace::insert<TransferOwnership::YesTransfer>(alloc, next, hd);
+      hd = new (alloc) ChainCown(next);
+    }
+    return hd;
+  }
+
+  void trace(ObjectStack& fields) const
+  {
+    if (next != nullptr)
+    {
+      fields.push(next);
+    }
+  }
+};
+
+void LinkObject::trace(ObjectStack& fields) const
+{
+  if (next != nullptr)
+  {
+    fields.push(next);
+  }
+}
+
+int main(int, char**)
+{
+  auto alloc = ThreadAlloc::get();
+  auto a = ChainCown::make_chain(alloc, 100000);
+  Cown::release(alloc, a);
+  snmalloc::current_alloc_pool()->debug_check_empty();
+}

--- a/src/rt/test/func/cownchain/cownchain.cc
+++ b/src/rt/test/func/cownchain/cownchain.cc
@@ -27,7 +27,7 @@ struct ChainCown : public VCown<ChainCown>
   static ChainCown* make_chain(Alloc* alloc, size_t length)
   {
     ChainCown* hd = nullptr;
-    for (; length > 0; length --)
+    for (; length > 0; length--)
     {
       auto next = new (alloc) LinkObject(hd);
       if (hd != nullptr)

--- a/src/rt/test/func/cownchain/cownchain.cc
+++ b/src/rt/test/func/cownchain/cownchain.cc
@@ -1,6 +1,6 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
 #include <test/harness.h>
 #include <test/xoroshiro.h>
 /**

--- a/src/rt/test/func/memory/memory.h
+++ b/src/rt/test/func/memory/memory.h
@@ -105,14 +105,6 @@ struct C3 : public V<C3<region_type>, region_type>
     if (f2 != nullptr)
       st.push(f2);
   }
-
-  void finaliser(Object* region, ObjectStack& sub_regions)
-  {
-    Object::add_sub_region(f1, region, sub_regions);
-    Object::add_sub_region(f2, region, sub_regions);
-    Object::add_sub_region(c1, region, sub_regions);
-    Object::add_sub_region(c2, region, sub_regions);
-  }
 };
 
 template<RegionType region_type>

--- a/src/rt/test/func/memory/memory.h
+++ b/src/rt/test/func/memory/memory.h
@@ -105,6 +105,14 @@ struct C3 : public V<C3<region_type>, region_type>
     if (f2 != nullptr)
       st.push(f2);
   }
+
+  void finaliser(Object* region, ObjectStack& sub_regions)
+  {
+    Object::add_sub_region(f1, region, sub_regions);
+    Object::add_sub_region(f2, region, sub_regions);
+    Object::add_sub_region(c1, region, sub_regions);
+    Object::add_sub_region(c2, region, sub_regions);
+  }
 };
 
 template<RegionType region_type>

--- a/src/rt/test/func/memory/memory_subregion.h
+++ b/src/rt/test/func/memory/memory_subregion.h
@@ -319,18 +319,18 @@ namespace memory_subregion
   template<RegionType region_type>
   void test_subregion_deep()
   {
-    using C = C3<region_type>;
+    using F = F3<region_type>;
 
     auto* alloc = ThreadAlloc::get();
 
     // Create the first region, with some unreachable objects.
-    auto* r1 = new (alloc) C;
+    auto* r1 = new (alloc) F;
     auto curr = r1;
     std::cout << "Build long region chain." << std::endl;
     for (size_t i = 0; i < 1 << 20; i++)
     {
-      auto n = new (alloc) C;
-      curr->c1 = n;
+      auto n = new (alloc) F;
+      curr->f1 = n;
       curr = n;
     }
     std::cout << "Dealloc long region chain." << std::endl;

--- a/src/rt/test/func/memory/memory_subregion.h
+++ b/src/rt/test/func/memory/memory_subregion.h
@@ -340,7 +340,6 @@ namespace memory_subregion
     std::cout << "Dealloced long region chain." << std::endl;
   }
 
-
   void run_test()
   {
     test_subregion_singleton<RegionType::Trace>();

--- a/src/rt/test/func/memory/memory_subregion.h
+++ b/src/rt/test/func/memory/memory_subregion.h
@@ -316,6 +316,31 @@ namespace memory_subregion
     snmalloc::current_alloc_pool()->debug_check_empty();
   }
 
+  template<RegionType region_type>
+  void test_subregion_deep()
+  {
+    using C = C3<region_type>;
+
+    auto* alloc = ThreadAlloc::get();
+
+    // Create the first region, with some unreachable objects.
+    auto* r1 = new (alloc) C;
+    auto curr = r1;
+    std::cout << "Build long region chain." << std::endl;
+    for (size_t i = 0; i < 1 << 20; i++)
+    {
+      auto n = new (alloc) C;
+      curr->c1 = n;
+      curr = n;
+    }
+    std::cout << "Dealloc long region chain." << std::endl;
+
+    Region::release(alloc, r1);
+    snmalloc::current_alloc_pool()->debug_check_empty();
+    std::cout << "Dealloced long region chain." << std::endl;
+  }
+
+
   void run_test()
   {
     test_subregion_singleton<RegionType::Trace>();
@@ -328,6 +353,8 @@ namespace memory_subregion
 
     test_subregion_swap_root<RegionType::Trace>();
     test_subregion_swap_root<RegionType::Arena>();
+
+    test_subregion_deep<RegionType::Trace>();
 
     test_subregion_merge<RegionType::Trace>();
     test_subregion_merge<RegionType::Arena>();


### PR DESCRIPTION
Recursively deallocating structures if implemented incorrectly can cause a stack overflow.  This PR adds twos test
* Deeply nested region test - very long chain of traceable regions
* Deeply nested cown test - very long chain of cowns going via a region at each level

The PR also fixes the deeply nested cowns code to queue recursive calls to avoid stack overflow.
