### PR TITLE
Refactor hashmap

### DIFF
--- a/src/rt/ds/hashmap.h
+++ b/src/rt/ds/hashmap.h
@@ -20,6 +20,28 @@ namespace verona::rt
    *
    * The key must be Object*, because the low bits are used to encode marking
    * status (MARK) and distance-to-initial-bucket (DIB).
+   *
+   * Static callbacks may be supplied as the second template parameter as
+   * follows:
+   *   ```cpp
+   *   struct MyMapCallbacks
+   *   {
+   *     static void on_insert(Entry& e)
+   *     {
+   *       // called every time an entry is inserted into the map
+   *       // i.e. when `insert` returns true.
+   *     }
+   *
+   *     static void on_erase(Entry& e)
+   *     {
+   *       // called every time an entry is deleted from the map
+   *     }
+   *   };
+   *
+   *   using MyMap = PtrKeyHashMap<std::pair<Object*, uint8_t>, MyMapCallbacks>;
+   *   ```
+   *   Note that all callbacks will have the low bits of the Entry key unmarked
+   *   so that it may be used as expected.
    */
   template<typename Entry, typename CB = DefaultMapCallbacks<Entry>>
   class PtrKeyHashMap

--- a/src/rt/ds/hashmap.h
+++ b/src/rt/ds/hashmap.h
@@ -160,7 +160,7 @@ namespace verona::rt
       return dib;
     }
 
-    inline void set_entry(size_t index, Entry& entry, size_t dib)
+    inline void set_entry(size_t index, Entry entry, size_t dib)
     {
       // When entry is passed in, it may or may not have a mark bit, but it
       // must have no dib. If the DIB is greater than the maximum DIB, encode
@@ -313,7 +313,7 @@ namespace verona::rt
     }
 
     // Returns true if newly added, false if previously present.
-    bool insert(Alloc* alloc, Entry& entry, size_t& location)
+    bool insert(Alloc* alloc, Entry entry, size_t& location)
     {
       const auto& orig_key = key_of(entry);
       assert(orig_key == unmark_key(orig_key));
@@ -337,8 +337,8 @@ namespace verona::rt
             location = index;
 
           // This index is empty, insert here.
-          set_entry(index, entry, dib_entry);
           CB::on_insert(entry);
+          set_entry(index, std::move(entry), dib_entry);
 
           count++;
           grow(alloc);
@@ -369,7 +369,7 @@ namespace verona::rt
           // The DIB of the entry to insert is greater than the DIB of the
           // entry at this index. Insert o here, and continue looking for
           // somewhere to insert other.
-          set_entry(index, entry, dib_entry);
+          set_entry(index, std::move(entry), dib_entry);
 
           key_of(tmp) = (uintptr_t)get_pointer(key_of(tmp));
           entry = std::move(tmp);
@@ -385,15 +385,15 @@ namespace verona::rt
       return false;
     }
 
-    bool insert(Alloc* alloc, Entry& entry)
+    bool insert(Alloc* alloc, Entry entry)
     {
       size_t dummy;
-      return insert(alloc, entry, dummy);
+      return insert(alloc, std::move(entry), dummy);
     }
 
-    void insert_unique(Alloc* alloc, Entry& entry)
+    void insert_unique(Alloc* alloc, Entry entry)
     {
-      auto unique = insert(alloc, entry);
+      auto unique = insert(alloc, std::move(entry));
       assert(unique);
       UNUSED(unique);
     }

--- a/src/rt/ds/hashmap.h
+++ b/src/rt/ds/hashmap.h
@@ -2,6 +2,9 @@
 // Licensed under the MIT License.
 #pragma once
 
+#include "../object/object.h"
+#include "mem/allocconfig.h"
+
 namespace verona::rt
 {
   /**
@@ -12,7 +15,7 @@ namespace verona::rt
    * bits (normally zero due pointer alignment) are used to encode marking
    * status (MARK) and distance-to-initial-bucket (DIB).
    */
-  template<typename Entry, size_t& key_of(Entry*)>
+  template<typename Entry, uintptr_t& key_of(Entry&)>
   class PtrKeyHashMap
   {
   private:
@@ -25,8 +28,9 @@ namespace verona::rt
 
     static constexpr uint8_t INITIAL_SIZE_BITS = 3;
     static constexpr uint8_t MARK = 1 << (MIN_ALLOC_BITS - 1);
-    static constexpr uint8_t DIB_MAX = MARK - 1;
-    static constexpr size_t POINTER_MASK = ~(((size_t)1 << MIN_ALLOC_BITS) - 1);
+    static constexpr size_t DIB_MAX = MARK - 1;
+    static constexpr uintptr_t POINTER_MASK =
+      ~(((uintptr_t)1 << MIN_ALLOC_BITS) - 1);
 
     // Both the Object and hashmap implementations steal some of the bottom
     // bits of an Object* pointer. The number of bits used may not be the
@@ -39,7 +43,7 @@ namespace verona::rt
     {
       // The Object* returned will retain its RememberedSet mark bit, but not
       // its dib.
-      return (Object*)(p & ~(size_t)DIB_MAX);
+      return (Object*)(p & ~DIB_MAX);
     }
 
     void grow(Alloc* alloc)
@@ -65,13 +69,13 @@ namespace verona::rt
       {
         for (size_t index = 0; index < old_size; index++)
         {
-          auto entry = &old_set[index];
+          auto& entry = old_set[index];
           auto& key = key_of(entry);
           if (key != 0)
           {
-            key = (size_t)get_unmarked_pointer(key);
+            key = (uintptr_t)get_unmarked_pointer(key);
             size_t dummy;
-            insert(alloc, *entry, dummy);
+            insert(alloc, entry, dummy);
           }
         }
 
@@ -98,18 +102,18 @@ namespace verona::rt
       {
         for (size_t index = 0; index < old_size; index++)
         {
-          auto entry = &old_set[index];
+          auto& entry = old_set[index];
           auto& key = key_of(entry);
 
           if ((key & MARK) != 0)
           {
-            key = (size_t)get_unmarked_pointer(key);
+            key = (uintptr_t)get_unmarked_pointer(key);
             size_t dummy;
-            insert(alloc, *entry, dummy);
+            insert(alloc, entry, dummy);
           }
           else if (key != 0)
           {
-            entry->~Entry();
+            entry.~Entry();
           }
         }
 
@@ -117,7 +121,7 @@ namespace verona::rt
       }
     }
 
-    inline size_t get_dib(size_t size, size_t index, size_t key)
+    inline size_t get_dib(size_t size, size_t index, uintptr_t key)
     {
       size_t dib = key & DIB_MAX;
 
@@ -140,7 +144,7 @@ namespace verona::rt
       // must have no dib. If the DIB is greater than the maximum DIB, encode
       // it as the maximum DIB. We will recalculate the real DIB when we
       // fetch it.
-      auto& key = key_of(&entry);
+      auto& key = key_of(entry);
       key = key | (dib < DIB_MAX ? dib : DIB_MAX);
       set[index] = std::move(entry);
     }
@@ -183,7 +187,7 @@ namespace verona::rt
           i++;
           if (i == size)
             break;
-          if (key_of(&map->set[i]) != 0)
+          if (key_of(map->set[i]) != 0)
             break;
         }
 
@@ -213,7 +217,7 @@ namespace verona::rt
       return new (r) PtrKeyHashMap();
     }
 
-    static Object* get_unmarked_pointer(size_t p)
+    static Object* get_unmarked_pointer(uintptr_t p)
     {
       assert(p != 0);
       // The Object* returned has no mark bits or dib.
@@ -227,7 +231,7 @@ namespace verona::rt
       {
         return i;
       }
-      if (key_of(&set[0]) != 0)
+      if (key_of(set[0]) != 0)
       {
         return i;
       }
@@ -237,18 +241,14 @@ namespace verona::rt
 
     Iterator end()
     {
-      if (count == 0)
-      {
-        return {this, 0};
-      }
-      size_t size = get_size();
-      return {this, size};
+      size_t c = (count == 0) ? 0 : get_size();
+      return Iterator(this, c);
     }
 
     void mark_slot(size_t index, size_t& marked)
     {
       assert(index < get_size());
-      auto& key = key_of(&set[index]);
+      auto& key = key_of(set[index]);
       assert(key != 0);
 
       if ((key & MARK) == 0)
@@ -269,7 +269,7 @@ namespace verona::rt
           for (size_t i = 0; i < size; ++i)
           {
             auto& e = set[i];
-            if (key_of(&e) != 0)
+            if (key_of(e) != 0)
             {
               e.~Entry();
             }
@@ -282,8 +282,8 @@ namespace verona::rt
     // Returns true if newly added, false if previously present.
     bool insert(Alloc* alloc, Entry& entry, size_t& location)
     {
-      auto orig_key = key_of(&entry);
-      assert(orig_key == (size_t)get_unmarked_pointer(orig_key));
+      auto orig_key = key_of(entry);
+      assert(orig_key == (uintptr_t)get_unmarked_pointer(orig_key));
 
       if (size_bits == 0)
         grow(alloc);
@@ -295,12 +295,12 @@ namespace verona::rt
 
       for (size_t i = 0; i <= mask; i++)
       {
-        auto other = &set[index];
-        auto other_key = key_of(other);
+        auto& other = set[index];
+        auto& other_key = key_of(other);
 
         if (other_key == 0)
         {
-          if (key_of(&entry) == orig_key)
+          if (key_of(entry) == orig_key)
             location = index;
 
           // This index is empty, insert here.
@@ -318,8 +318,8 @@ namespace verona::rt
           // This entry is already present. This should only happen for the
           // original o, not for any swapped pointer.
           if (
-            (key_of(&entry) == orig_key) &&
-            (key_of(&entry) == (size_t)get_unmarked_pointer(other_key)))
+            (key_of(entry) == orig_key) &&
+            (key_of(entry) == (uintptr_t)get_unmarked_pointer(other_key)))
           {
             location = index;
             return false;
@@ -327,9 +327,9 @@ namespace verona::rt
         }
         else if (dib_entry > dib_other)
         {
-          auto tmp = std::move(*other);
+          auto tmp = std::move(other);
 
-          if (key_of(&entry) == orig_key)
+          if (key_of(entry) == orig_key)
             location = index;
 
           // The DIB of the entry to insert is greater than the DIB of the
@@ -337,7 +337,7 @@ namespace verona::rt
           // somewhere to insert other.
           set_entry(index, entry, dib_entry);
 
-          key_of(&tmp) = (size_t)get_pointer(key_of(&tmp));
+          key_of(tmp) = (uintptr_t)get_pointer(key_of(tmp));
           entry = std::move(tmp);
           dib_entry = dib_other;
         }
@@ -385,7 +385,7 @@ namespace verona::rt
 
       for (size_t index = 0; index < size; index++)
       {
-        auto entry = &set[index];
+        auto& entry = set[index];
         auto& key = key_of(entry);
 
         if (key == 0)
@@ -402,27 +402,27 @@ namespace verona::rt
         }
         else if ((key & MARK) != 0)
         {
-          key = (size_t)get_unmarked_pointer(key);
+          key = (uintptr_t)get_unmarked_pointer(key);
           size_t dib = get_dib(size, index, key);
 
           if (dib == 0)
           {
-            set[index] = std::move(*entry);
+            set[index] = std::move(entry);
             empty_dib = 0;
             fill_dib = 0;
           }
           else if (empty_dib == 0)
           {
-            set_entry(index, *entry, dib);
+            set_entry(index, entry, dib);
             empty_dib = 0;
             fill_dib = 0;
           }
           else
           {
             set_entry(
-              index - empty_dib + fill_dib, *entry, dib - empty_dib + fill_dib);
+              index - empty_dib + fill_dib, entry, dib - empty_dib + fill_dib);
 
-            key_of(&set[index]) = 0;
+            key_of(set[index]) = 0;
             empty_dib++;
             fill_dib++;
           }
@@ -431,7 +431,7 @@ namespace verona::rt
         {
           set[index].~Entry();
 
-          key_of(&set[index]) = 0;
+          key_of(set[index]) = 0;
 
           if (fill_dib > 0)
           {
@@ -451,21 +451,21 @@ namespace verona::rt
 
         for (size_t index = 0; index < size; index++)
         {
-          auto entry = &set[index];
+          auto& entry = set[index];
           auto& key = key_of(entry);
 
           size_t dib = get_dib(size, index, key);
 
           if (dib > 0)
           {
-            key = (size_t)get_unmarked_pointer(key);
+            key = (uintptr_t)get_unmarked_pointer(key);
 
             set_entry(
               (index - empty_dib + fill_dib + size) & mask,
-              *entry,
+              entry,
               dib - empty_dib + fill_dib);
 
-            key_of(&set[index]) = 0;
+            key_of(set[index]) = 0;
             empty_dib++;
             fill_dib++;
           }
@@ -482,37 +482,36 @@ namespace verona::rt
       sweep_set(alloc, 0);
     }
 
-    Iterator find(size_t orig_key)
+    Iterator find(const Object* key)
     {
       if (count == 0)
       {
         return end();
       }
 
-      assert(orig_key == (size_t)get_unmarked_pointer(orig_key));
+      assert(key == get_unmarked_pointer((uintptr_t)key));
 
-      size_t size = get_size();
-      size_t mask = size - 1;
-      size_t index = verona::rt::bits::hash((void*)orig_key) & mask;
-      size_t dib_entry = 0;
+      auto size = get_size();
+      auto mask = (uintptr_t)size - 1;
+      auto index = verona::rt::bits::hash((void*)key) & mask;
+      uintptr_t dib_entry = 0;
 
       for (size_t i = 0; i <= mask; i++)
       {
-        auto other = &set[index];
-        auto key = key_of(other);
-
-        if (key == 0)
+        auto& k = key_of(set[index]);
+        if (k == 0)
         {
           return end();
         }
 
-        size_t dib_other = get_dib(size, index, key);
+        auto dib_other = get_dib(size, index, k);
 
         if (dib_entry == dib_other)
         {
           // This entry is already present. This should only happen for the
           // original o, not for any swapped pointer.
-          if ((key == orig_key) && (key == (size_t)get_unmarked_pointer(key)))
+          if (
+            (k == (uintptr_t)key) && (k == (uintptr_t)get_unmarked_pointer(k)))
           {
             return {this, index};
           }
@@ -531,13 +530,13 @@ namespace verona::rt
       return end();
     }
 
-    void erase(void* p)
+    void erase(const Object* p)
     {
       if (count == 0)
       {
         return;
       }
-      auto i = find((size_t)p);
+      auto i = find(p);
       if (i == end())
       {
         return;
@@ -549,9 +548,9 @@ namespace verona::rt
       i->~Entry();
       auto next_index = (cur_index + 1) & mask;
 
-      size_t key = 0;
+      uintptr_t key = 0;
       size_t dib = 0;
-      while ((key = key_of(&set[next_index])) != 0 &&
+      while ((key = key_of(set[next_index])) != 0 &&
              (dib = get_dib(size, next_index, key)) != 0)
       {
         set_entry(cur_index, set[next_index], dib - 1);
@@ -560,7 +559,7 @@ namespace verona::rt
         next_index = (next_index + 1) & mask;
       }
 
-      key_of(&set[cur_index]) = 0;
+      key_of(set[cur_index]) = 0;
       count--;
     }
   };

--- a/src/rt/ds/hashmap.h
+++ b/src/rt/ds/hashmap.h
@@ -95,12 +95,10 @@ namespace verona::rt
         for (size_t index = 0; index < old_size; index++)
         {
           auto& entry = old_set[index];
-          auto& key = key_of(entry);
+          const auto key = unmark_key(key_of(entry));
           if (key != 0)
           {
-            key = unmark_key(key);
-            size_t dummy;
-            insert(alloc, entry, dummy);
+            insert(alloc, entry);
           }
         }
 
@@ -133,8 +131,7 @@ namespace verona::rt
           if ((key & MARK) != 0)
           {
             key = unmark_key(key);
-            size_t dummy;
-            insert(alloc, entry, dummy);
+            insert(alloc, entry);
           }
           else if (key != 0)
           {
@@ -388,10 +385,15 @@ namespace verona::rt
       return false;
     }
 
-    void insert_unique(Alloc* alloc, Entry& entry)
+    bool insert(Alloc* alloc, Entry& entry)
     {
       size_t dummy;
-      auto unique = insert(alloc, entry, dummy);
+      return insert(alloc, entry, dummy);
+    }
+
+    void insert_unique(Alloc* alloc, Entry& entry)
+    {
+      auto unique = insert(alloc, entry);
       assert(unique);
       UNUSED(unique);
     }

--- a/src/rt/object/object.h
+++ b/src/rt/object/object.h
@@ -300,7 +300,7 @@ namespace verona::rt
     friend class RegionArena;
     friend class RememberedSet;
     friend class ExternalReferenceTable;
-    template<typename Entry, size_t& key_of(Entry*)>
+    template<typename Entry, uintptr_t& key_of(Entry&)>
     friend class PtrKeyHashMap;
     friend class Message;
     friend class LocalEpoch;

--- a/src/rt/object/object.h
+++ b/src/rt/object/object.h
@@ -300,7 +300,7 @@ namespace verona::rt
     friend class RegionArena;
     friend class RememberedSet;
     friend class ExternalReferenceTable;
-    template<typename Entry, uintptr_t& key_of(Entry&)>
+    template<typename Entry, typename CB>
     friend class PtrKeyHashMap;
     friend class Message;
     friend class LocalEpoch;

--- a/src/rt/region/externalreference.h
+++ b/src/rt/region/externalreference.h
@@ -59,9 +59,9 @@ namespace verona::rt
         set_descriptor(desc());
         make_scc();
 
-        auto pair = std::make_pair(o, this);
         ert.load(std::memory_order_relaxed)
-          ->external_map->insert_unique(ThreadAlloc::get(), pair);
+          ->external_map->insert_unique(
+            ThreadAlloc::get(), std::make_pair(o, this));
 
         o->set_has_ext_ref();
       }
@@ -154,8 +154,8 @@ namespace verona::rt
       {
         assert(e.second->o);
         e.second->ert.store(this, std::memory_order_relaxed);
-        auto pair = std::make_pair(e.first, std::move(e.second));
-        external_map->insert_unique(alloc, pair);
+        external_map->insert_unique(
+          alloc, std::make_pair(e.first, std::move(e.second)));
       }
     }
 

--- a/src/rt/region/externalreference.h
+++ b/src/rt/region/externalreference.h
@@ -59,7 +59,7 @@ namespace verona::rt
         set_descriptor(desc());
         make_scc();
 
-        auto pair = std::make_pair((uintptr_t)o, this);
+        auto pair = std::make_pair(o, this);
         ert.load(std::memory_order_relaxed)
           ->external_map->insert_unique(ThreadAlloc::get(), pair);
 
@@ -109,12 +109,12 @@ namespace verona::rt
 
     struct MapCallbacks
     {
-      static void on_insert(std::pair<size_t, ExternalRef*>& e)
+      static void on_insert(std::pair<Object*, ExternalRef*>& e)
       {
         e.second->incref();
       }
 
-      static void on_erase(std::pair<size_t, ExternalRef*>& e)
+      static void on_erase(std::pair<Object*, ExternalRef*>& e)
       {
         if (e.second)
         {
@@ -132,7 +132,7 @@ namespace verona::rt
     // contribute to objects RC; when an object is collected, its corresponding
     // entry in the map (if any) is removed as well.
     using ExternalMap =
-      PtrKeyHashMap<std::pair<uintptr_t, ExternalRef*>, MapCallbacks>;
+      PtrKeyHashMap<std::pair<Object*, ExternalRef*>, MapCallbacks>;
 
     ExternalMap* external_map;
 

--- a/src/rt/region/externalreference.h
+++ b/src/rt/region/externalreference.h
@@ -49,8 +49,8 @@ namespace verona::rt
       {
         auto i = ert->external_map->find(o);
         assert(i != ert->external_map->end());
-        assert(i->second);
-        return i->second;
+        assert(i.value());
+        return i.value();
       }
 
       ExternalRef(ExternalReferenceTable* ert_, Object* o_)
@@ -150,12 +150,11 @@ namespace verona::rt
 
     void merge(Alloc* alloc, ExternalReferenceTable* that)
     {
-      for (auto& e : *that->external_map)
+      for (auto e : *that->external_map)
       {
         assert(e.second->o);
         e.second->ert.store(this, std::memory_order_relaxed);
-        external_map->insert_unique(
-          alloc, std::make_pair(e.first, std::move(e.second)));
+        external_map->insert_unique(alloc, std::move(e));
       }
     }
 

--- a/src/rt/region/externalreference.h
+++ b/src/rt/region/externalreference.h
@@ -109,11 +109,6 @@ namespace verona::rt
 
     struct MapCallbacks
     {
-      static uintptr_t& key_of(std::pair<size_t, ExternalRef*>& e)
-      {
-        return e.first;
-      }
-
       static void on_insert(std::pair<size_t, ExternalRef*>& e)
       {
         e.second->incref();

--- a/src/rt/region/rememberedset.h
+++ b/src/rt/region/rememberedset.h
@@ -26,8 +26,7 @@ namespace verona::rt
       static void on_erase(Object*& e)
       {
         if (e != nullptr)
-          RememberedSet::release_internal(
-            ThreadAlloc::get(), HashSet::unmark_pointer(e));
+          RememberedSet::release_internal(ThreadAlloc::get(), e);
       }
     };
 
@@ -48,15 +47,13 @@ namespace verona::rt
 
     void merge(Alloc* alloc, RememberedSet* that)
     {
-      for (auto*& e : *that->hash_set)
+      for (auto* e : *that->hash_set)
       {
-        Object* q = HashSet::unmark_pointer(e);
-
         // If q is already present in this, decref, otherwise insert.
         // No need to call release, as the rc will not drop to zero.
-        if (!hash_set->insert(alloc, q))
+        if (!hash_set->insert(alloc, e))
         {
-          q->decref();
+          e->decref();
         }
       }
     }

--- a/src/rt/region/rememberedset.h
+++ b/src/rt/region/rememberedset.h
@@ -19,55 +19,29 @@ namespace verona::rt
     friend class RegionArena;
 
   private:
-    // It's not allowed to pass lambda as template argument (until c++20);
-    // using static function as a workaround for HashSet and ExternalMap.
-
-    struct HashSetEntry
+    struct SetCallbacks
     {
-      Object* o;
-
-      explicit HashSetEntry(Object* o_) : o{o_}
+      static uintptr_t& key_of(Object*& e)
       {
-        assert(o_);
+        return (uintptr_t&)e;
       }
 
-      HashSetEntry(const HashSetEntry&) = delete;
-
-      HashSetEntry& operator=(const HashSetEntry&) = delete;
-
-      HashSetEntry(HashSetEntry&& other) noexcept : o{other.o}
+      static void on_insert(Object*& e)
       {
-        if (this != &other)
-        {
-          other.o = nullptr;
-        }
+        assert(e != nullptr);
       }
 
-      HashSetEntry& operator=(HashSetEntry&& other) noexcept
+      static void on_erase(Object*& e)
       {
-        if (this != &other)
+        if (e != nullptr)
         {
-          o = other.o;
-          other.o = nullptr;
-        }
-        return *this;
-      }
-
-      ~HashSetEntry()
-      {
-        if (o != nullptr)
-        {
-          o = HashSet::get_unmarked_pointer((uintptr_t)o);
-          RememberedSet::release_internal(ThreadAlloc::get(), o);
+          e = HashSet::get_unmarked_pointer((uintptr_t)e);
+          RememberedSet::release_internal(ThreadAlloc::get(), e);
         }
       }
     };
 
-    static uintptr_t& hash_set_key_of(HashSetEntry& e)
-    {
-      return (uintptr_t&)e.o;
-    }
-    using HashSet = PtrKeyHashMap<HashSetEntry, hash_set_key_of>;
+    using HashSet = PtrKeyHashMap<Object*, SetCallbacks>;
     HashSet* hash_set;
 
   public:
@@ -86,19 +60,15 @@ namespace verona::rt
     {
       for (auto& e : *that->hash_set)
       {
-        Object* q = HashSet::get_unmarked_pointer((uintptr_t)e.o);
+        Object* q = HashSet::get_unmarked_pointer((uintptr_t)e);
         size_t dummy;
 
-        HashSetEntry entry{q};
         // If q is already present in this, decref, otherwise insert.
         // No need to call release, as the rc will not drop to zero.
-        if (!hash_set->insert(alloc, entry, dummy))
+        if (!hash_set->insert(alloc, q, dummy))
         {
           q->decref();
         }
-
-        // If we don't null this out, the destructor will release q.
-        entry.o = nullptr;
       }
     }
 
@@ -110,10 +80,8 @@ namespace verona::rt
 
       size_t dummy;
 
-      HashSetEntry entry{o};
-      if (hash_set->insert(alloc, entry, dummy))
+      if (hash_set->insert(alloc, o, dummy))
       {
-        assert(entry.o == nullptr);
         // If the caller is not transfering ownership of a refcount, i.e., the
         // object is being added to the region but not dropped from somewhere,
         // we need to incref it.
@@ -122,7 +90,6 @@ namespace verona::rt
       }
       else
       {
-        entry.o = nullptr;
         // If the caller is transfering ownership of a refcount, i.e., the
         // object is being moved from somewhere to this region, but the object
         // is already here, we need to decref it.
@@ -137,17 +104,8 @@ namespace verona::rt
       assert(o->debug_is_rc() || o->debug_is_cown());
 
       size_t index = 0;
-
-      HashSetEntry entry{o};
-      if (hash_set->insert(alloc, entry, index))
-      {
-        assert(entry.o == nullptr);
+      if (hash_set->insert(alloc, o, index))
         o->incref();
-      }
-      else
-      {
-        entry.o = nullptr;
-      }
 
       hash_set->mark_slot(index, marked);
     }

--- a/src/rt/region/rememberedset.h
+++ b/src/rt/region/rememberedset.h
@@ -90,7 +90,7 @@ namespace verona::rt
 
       size_t index = 0;
       if (hash_set->insert(alloc, o, index))
-        HashSet::unmark_pointer(o)->incref();
+        o->incref();
 
       hash_set->mark_slot(index, marked);
     }

--- a/src/rt/region/rememberedset.h
+++ b/src/rt/region/rememberedset.h
@@ -90,7 +90,7 @@ namespace verona::rt
 
       size_t index = 0;
       if (hash_set->insert(alloc, o, index))
-        o->incref();
+        HashSet::unmark_pointer(o)->incref();
 
       hash_set->mark_slot(index, marked);
     }

--- a/src/rt/region/rememberedset.h
+++ b/src/rt/region/rememberedset.h
@@ -51,11 +51,10 @@ namespace verona::rt
       for (auto*& e : *that->hash_set)
       {
         Object* q = HashSet::unmark_pointer(e);
-        size_t dummy;
 
         // If q is already present in this, decref, otherwise insert.
         // No need to call release, as the rc will not drop to zero.
-        if (!hash_set->insert(alloc, q, dummy))
+        if (!hash_set->insert(alloc, q))
         {
           q->decref();
         }
@@ -68,15 +67,13 @@ namespace verona::rt
       // If o is not present, add it and o->incref().
       assert(o->debug_is_rc() || o->debug_is_cown());
 
-      size_t dummy;
-
       // If the caller is not transfering ownership of a refcount, i.e., the
       // object is being added to the region but not dropped from somewhere,
       // we need to incref it.
       if constexpr (transfer == NoTransfer)
         o->incref();
 
-      if (!hash_set->insert(alloc, o, dummy))
+      if (!hash_set->insert(alloc, o))
       {
         // If the caller is transfering ownership of a refcount, i.e., the
         // object is being moved from somewhere to this region, but the object

--- a/src/rt/region/rememberedset.h
+++ b/src/rt/region/rememberedset.h
@@ -21,14 +21,10 @@ namespace verona::rt
   private:
     struct SetCallbacks
     {
-      static uintptr_t& key_of(Object*& e)
-      {
-        return (uintptr_t&)e;
-      }
-
       static void on_insert(Object*& e)
       {
         assert(e != nullptr);
+        UNUSED(e);
       }
 
       static void on_erase(Object*& e)

--- a/src/rt/region/rememberedset.h
+++ b/src/rt/region/rememberedset.h
@@ -57,15 +57,15 @@ namespace verona::rt
       {
         if (o != nullptr)
         {
-          o = HashSet::get_unmarked_pointer((size_t)o);
+          o = HashSet::get_unmarked_pointer((uintptr_t)o);
           RememberedSet::release_internal(ThreadAlloc::get(), o);
         }
       }
     };
 
-    static size_t& hash_set_key_of(HashSetEntry* e)
+    static uintptr_t& hash_set_key_of(HashSetEntry& e)
     {
-      return (size_t&)e->o;
+      return (uintptr_t&)e.o;
     }
     using HashSet = PtrKeyHashMap<HashSetEntry, hash_set_key_of>;
     HashSet* hash_set;
@@ -86,7 +86,7 @@ namespace verona::rt
     {
       for (auto& e : *that->hash_set)
       {
-        Object* q = HashSet::get_unmarked_pointer((size_t)e.o);
+        Object* q = HashSet::get_unmarked_pointer((uintptr_t)e.o);
         size_t dummy;
 
         HashSetEntry entry{q};

--- a/src/rt/region/rememberedset.h
+++ b/src/rt/region/rememberedset.h
@@ -30,10 +30,8 @@ namespace verona::rt
       static void on_erase(Object*& e)
       {
         if (e != nullptr)
-        {
-          e = HashSet::get_unmarked_pointer((uintptr_t)e);
-          RememberedSet::release_internal(ThreadAlloc::get(), e);
-        }
+          RememberedSet::release_internal(
+            ThreadAlloc::get(), HashSet::unmark_pointer(e));
       }
     };
 
@@ -56,7 +54,7 @@ namespace verona::rt
     {
       for (auto& e : *that->hash_set)
       {
-        Object* q = HashSet::get_unmarked_pointer((uintptr_t)e);
+        Object* q = HashSet::unmark_pointer(e);
         size_t dummy;
 
         // If q is already present in this, decref, otherwise insert.


### PR DESCRIPTION
This PR makes several fixes and simplifications to the user interface of the Robin Hood hash map:
- Use `uintptr_t` instead of `size_t` when messing with `Object*` key bits
- Replace entry wrapper classes and `key_of` with a single set of defaulted static callbacks
- Enforce strict entry types
- Hide manipulation of `Object*` key bits from the user
- Add overload for insert without the need to create a dummy index