### PR TITLE
MLIR prototype

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,3 +20,7 @@
 	url = https://github.com/yhirose/cpp-peglib.git
 	branch = master
 	shallow = true
+[submodule "external/llvm-project"]
+	path = external/llvm-project
+	url = https://github.com/llvm/llvm-project.git
+	shallow = true

--- a/devops/ci.yml
+++ b/devops/ci.yml
@@ -7,9 +7,10 @@ pr:
 - master
 
 jobs:
+############################################## Configure CI Run
 - job: ConfigureCIRun
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   steps:
   - script: |
       echo " - PR Build"
@@ -28,14 +29,25 @@ jobs:
         echo Doc changes only;
         echo "##vso[task.setvariable variable=docOnly;isOutput=true]true" #set variable to testRuntime to On
       fi
+      if [ -z "$(LLVMCommit)" ]; then
+        echo "LLVMCommit empty, picking from submodule"
+        LLVMCommit=$(git submodule status external/llvm-project | grep -o "[0-9a-f]\{11\}" | head -n 1)
+      else
+        LLVMCommit=$(LLVMCommit)
+      fi
+      echo "LLVMCommit: $LLVMCommit"
+      echo "##vso[task.setvariable variable=LLVMCommit;isOutput=true]$LLVMCommit"
     displayName: 'Check for runtime changes'
     name: setVarStep
-- job:
+
+############################################## Linux Builds
+- job: 
   displayName: Linux
   dependsOn: ConfigureCIRun
   condition: eq(dependencies.ConfigureCIRun.outputs['setVarStep.docOnly'], 'false')
   variables:
     RTTests: $[ dependencies.ConfigureCIRun.outputs['setVarStep.testRuntime'] ]
+    LLVMCommit: $[ dependencies.ConfigureCIRun.outputs['setVarStep.LLVMCommit'] ]
   pool:
     vmImage: 'ubuntu-18.04'
   strategy:
@@ -54,7 +66,27 @@ jobs:
         Asan: On
   steps:
   - checkout: self
-    submodules: recursive
+
+  - script: |
+      set -eo pipefail
+      git submodule init
+      git submodule update --depth 1 --recursive
+    displayName: 'Checkout submodules'
+
+  - script:
+      echo "##vso[task.setvariable variable=PKG_NAME]verona-llvm-x86_64-linux-release-$(LLVMCommit)"
+    displayName: 'Set LLVM Package'
+
+  - script: |
+      set -eo pipefail
+      wget -q -O $(PKG_NAME).tar.gz https://verona.blob.core.windows.net/llvmbuild/$(PKG_NAME)
+    displayName: 'Download package'
+
+  - bash: |
+      set -eo pipefail
+      ./utils/llvm/setup-llvm-builddir.sh $(PKG_NAME).tar.gz
+    displayName: 'Setup LLVM Build dir'
+    workingDirectory: '$(Build.SourcesDirectory)'
 
   - script: |
       set -eo pipefail
@@ -83,32 +115,51 @@ jobs:
     workingDirectory: build
     displayName: 'Tests'
 
-- job:
+############################################## Windows Builds
+- job: 
   displayName: Windows
   dependsOn: ConfigureCIRun
   condition: eq(dependencies.ConfigureCIRun.outputs['setVarStep.docOnly'], 'false')
   variables:
     RTTests: $[ dependencies.ConfigureCIRun.outputs['setVarStep.testRuntime'] ]
-
+    LLVMCommit: $[ dependencies.ConfigureCIRun.outputs['setVarStep.LLVMCommit'] ]
   pool:
     vmImage: 'windows-2019'
   strategy:
     matrix:
       Release:
+        CXXFLAGS: '/EHsc /D _SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING=1'
         BuildType: Release
 
   steps:
   - checkout: self
-    submodules: recursive
+
+  - script: |
+      git submodule init
+      git submodule update --depth 1 --recursive
+    displayName: 'Checkout submodules'
 
   - script:
       pip install OutputCheck
     displayName: 'Dependencies'
 
+  - bash:
+      echo "##vso[task.setvariable variable=PKG_NAME]verona-llvm-x86_64-windows-release-$(LLVMCommit)"
+    displayName: 'Set LLVM Package'
+
+  - powershell: |
+      $ProgressPreference = 'SilentlyContinue'; (New-Object Net.WebClient).DownloadFile("https://verona.blob.core.windows.net/llvmbuild/$(PKG_NAME)", "$(PKG_NAME).tar.gz")
+    displayName: 'Download package'
+
+  - bash: |
+      ./utils/llvm/setup-llvm-builddir.sh $(PKG_NAME).tar.gz
+    displayName: 'Setup LLVM Build dir'
+    workingDirectory: '$(Build.SourcesDirectory)'
+
   - script: |
       mkdir build
       cd build
-      cmake .. -G"Visual Studio 16 2019" -DENABLE_ASSERTS=ON -DVERONA_CI_BUILD=On -DSNMALLOC_CI_BUILD=On -DRT_TESTS=$(RTTests)
+      cmake .. -G"Visual Studio 16 2019" -DENABLE_ASSERTS=ON -DVERONA_CI_BUILD=On -DSNMALLOC_CI_BUILD=On -DRT_TESTS=$(RTTests) -DCMAKE_CXX_FLAGS="$(CXXFLAGS)"
     displayName: 'CMake'
 
   - task: MSBuild@1
@@ -119,7 +170,7 @@ jobs:
 
   - script: |
       ctest -j 4 -E "([1-9][0-9]00|[4-9]00)" --timeout 400 --output-on-failure --interactive-debug-mode 0 -C $(BuildType)
-    workingDirectory: build/
+    workingDirectory: build
     displayName: 'Tests'
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
@@ -127,13 +178,14 @@ jobs:
     inputs:
       failOnAlert: true
 
-- job:
-  displayName: macOS
+############################################## MacOS Builds
+- job: 
+  displayName: MacOS
   dependsOn: ConfigureCIRun
   condition: eq(dependencies.ConfigureCIRun.outputs['setVarStep.docOnly'], 'false')
   variables:
     RTTests: $[ dependencies.ConfigureCIRun.outputs['setVarStep.testRuntime'] ]
-
+    LLVMCommit: $[ dependencies.ConfigureCIRun.outputs['setVarStep.LLVMCommit'] ]
   pool:
     vmImage: 'macOS-10.14'
   strategy:
@@ -143,12 +195,32 @@ jobs:
 
   steps:
   - checkout: self
-    submodules: recursive
+
+  - script: |
+      set -eo pipefail
+      git submodule init
+      git submodule update --depth 1 --recursive
+    displayName: 'Checkout submodules'
 
   - script: |
       set -eo pipefail
       sudo pip install wheel OutputCheck
-    displayName:  'Dependencies'
+    displayName: 'Dependencies'
+
+  - script:
+      echo "##vso[task.setvariable variable=PKG_NAME]verona-llvm-x86_64-macos-release-$(LLVMCommit)"
+    displayName: 'Set LLVM Package'
+
+  - script: |
+      set -eo pipefail
+      curl -s --output $(PKG_NAME).tar.gz https://verona.blob.core.windows.net/llvmbuild/$(PKG_NAME)
+    displayName: 'Download package'
+
+  - bash: |
+      set -eo pipefail
+      ./utils/llvm/setup-llvm-builddir.sh $(PKG_NAME).tar.gz
+    displayName: 'Setup LLVM Build dir'
+    workingDirectory: '$(Build.SourcesDirectory)'
 
   - task: CMake@1
     displayName: 'CMake'
@@ -168,28 +240,34 @@ jobs:
     workingDirectory: build/
     displayName: 'Tests'
 
-- job:
+############################################## Clang Format Check
+- job: 
   displayName: Format
   pool:
     vmImage: 'ubuntu-18.04'
   steps:
   - checkout: self
-    submodules: recursive
 
   - script: |
       set -eo pipefail
-      wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+      git submodule init
+      git submodule update --depth 1 --recursive
+    displayName: 'Update submodules'
+
+  - script: |
+      set -eo pipefail
+      wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
       sudo apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main"
       sudo apt-get update
       sudo apt-get install -y clang-format-9 clang-tidy-9
       sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-9 100
-
     displayName: 'Install Clang tools'
 
   - task: CMake@1
     displayName: 'CMake'
     inputs:
-      cmakeArgs: '..'
+      cmakeArgs: |
+        .. -DDISABLE_LLVM_BUILD=ON
 
   - script: |
       set -eo pipefail

--- a/devops/llvm.yml
+++ b/devops/llvm.yml
@@ -44,6 +44,7 @@ jobs:
       set -eo pipefail
       sudo apt-get update
       sudo apt-get install -y clang ninja-build cmake lld
+      curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
     displayName: 'Install Build Dependencies'
 
   - task: CMake@1
@@ -55,28 +56,19 @@ jobs:
   - script: |
       set -eo pipefail
       ninja
-      VERSION=$(./bin/mlir-tblgen --version | grep -o "[0-9]\+\.[0-9]\+\.[0-9]\+" | cut -d "." -f 1,3)
-      echo "##vso[task.setvariable variable=VERSION]$VERSION"
     workingDirectory: build
     displayName: 'Compile LLVM & MLIR'
 
   - script: |
       set -eo pipefail
-      rm -rf /tmp/$PKG_NAME
-      mkdir -p /tmp/$PKG_NAME
-      tar zcf /tmp/$PKG_NAME/$PKG_NAME.tar.gz .
-    displayName: 'Create artifact'
+      rm -f $(PKG_NAME).tar.gz
+      tar zcf $(PKG_NAME).tar.gz build
+    displayName: 'Create package'
 
-  - task: UniversalPackages@0
-    displayName: 'Publishing Package'
-    inputs:
-      command: publish
-      publishDirectory: /tmp/$(PKG_NAME)
-      vstsFeedPublish: Project%20Verona/LLVMBuild
-      vstsFeedPackagePublish: $(PKG_NAME)
-      packagePublishDescription: 'Verona LLVM $(BuildType) Build for Linux at $(GOOD_HASH)'
-      versionOption: custom
-      versionPublish: $(VERSION).$(Build.Buildid)
+  - script: |
+      set -eo pipefail
+      az storage blob upload --container-name llvmbuild --file $(PKG_NAME).tar.gz --name $(PKG_NAME) --connection-string "$(BLOB_CONNECTION_STRING)"
+    displayName: 'Upload package'
 
 ############################################## Windows Builds
 - job:
@@ -94,12 +86,13 @@ jobs:
   variables:
   - name: PKG_NAME
     value: verona-llvm-x86_64-windows-$(BuildName)-$(GOOD_HASH)
-  # TODO: Figure how to set version on Windows
-  - name: VERSION
-    value: 11.0
 
   steps:
   - checkout: llvm
+
+  - powershell: |
+      Invoke-WebRequest -Uri https://aka.ms/installazurecliwindows -OutFile .\AzureCLI.msi; Start-Process msiexec.exe -Wait -ArgumentList '/I AzureCLI.msi /quiet'; rm .\AzureCLI.msi
+    displayName: 'Install Azure CLI'
 
   - powershell: |
       Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
@@ -129,21 +122,13 @@ jobs:
       msbuildArguments: '/m /p:Configuration=$(BuildType)'
 
   - script: |
-      rd /s /q $(PKG_NAME)
-      mkdir $(PKG_NAME)
-      tar.exe -z -c -f $(PKG_NAME)/$(PKG_NAME).tar.gz build
-    displayName: 'Create artifact'
+      rd /s /q $(PKG_NAME).tar.gz
+      tar.exe -z -c -f $(PKG_NAME).tar.gz build
+    displayName: 'Create package'
 
-  - task: UniversalPackages@0
-    displayName: 'Publishing Package'
-    inputs:
-      command: publish
-      publishDirectory: $(PKG_NAME)
-      vstsFeedPublish: Project%20Verona/LLVMBuild
-      vstsFeedPackagePublish: $(PKG_NAME)
-      packagePublishDescription: 'Verona LLVM $(BuildType) Build for Windows at $(GOOD_HASH)'
-      versionOption: custom
-      versionPublish: $(VERSION).$(Build.Buildid)
+  - script: |
+      "C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\wbin\az" storage blob upload --container-name llvmbuild --file $(PKG_NAME).tar.gz --name $(PKG_NAME) --connection-string "$(BLOB_CONNECTION_STRING)"
+    displayName: 'Upload package'
 
 ############################################## MacOS Builds
 - job:
@@ -181,25 +166,16 @@ jobs:
   - script: |
       set -eo pipefail
       make -j 4
-      VERSION=$(./bin/mlir-tblgen --version | grep -o "[0-9]\+\.[0-9]\+\.[0-9]\+" | cut -d "." -f 1,3)
-      echo "##vso[task.setvariable variable=VERSION]$VERSION"
     workingDirectory: build
     displayName: 'Compile LLVM & MLIR'
 
   - script: |
       set -eo pipefail
-      rm -rf /tmp/$PKG_NAME
-      mkdir -p /tmp/$PKG_NAME
-      tar zcf /tmp/$PKG_NAME/$PKG_NAME.tar.gz .
-    displayName: 'Create artifact'
+      rm -f $(PKG_NAME).tar.gz
+      tar zcf $(PKG_NAME).tar.gz build
+    displayName: 'Create package'
 
-  - task: UniversalPackages@0
-    displayName: 'Publishing Package'
-    inputs:
-      command: publish
-      publishDirectory: /tmp/$(PKG_NAME)
-      vstsFeedPublish: Project%20Verona/LLVMBuild
-      vstsFeedPackagePublish: $(PKG_NAME)
-      packagePublishDescription: 'Verona LLVM $(BuildType) Build for MacOS at $(GOOD_HASH)'
-      versionOption: custom
-      versionPublish: $(VERSION).$(Build.Buildid)
+  - script: |
+      set -eo pipefail
+      az storage blob upload --container-name llvmbuild --file $(PKG_NAME).tar.gz --name $(PKG_NAME) --connection-string "$(BLOB_CONNECTION_STRING)"
+    displayName: 'Upload package'

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -14,8 +14,29 @@ schedules:
     - master
 
 jobs:
+############################################## Configure CI Run
+- job: ConfigureCIRun
+  pool:
+    vmImage: 'ubuntu-18.04'
+  steps:
+  - script: |
+      if [ -z "$(LLVMCommit)" ]; then
+        echo "LLVMCommit empty, picking from submodule"
+        LLVMCommit=$(git submodule status external/llvm-project | grep -o "[0-9a-f]\{11\}" | head -n 1)
+      else
+        LLVMCommit=$(LLVMCommit)
+      fi
+      echo "LLVMCommit: $LLVMCommit"
+      echo "##vso[task.setvariable variable=LLVMCommit;isOutput=true]$LLVMCommit"
+    displayName: 'Check for runtime changes'
+    name: setVarStep
+
+############################################## Linux Builds
 - job:
   displayName: Linux
+  dependsOn: ConfigureCIRun
+  variables:
+    LLVMCommit: $[ dependencies.ConfigureCIRun.outputs['setVarStep.LLVMCommit'] ]
   pool:
     vmImage: 'ubuntu-18.04'
   strategy:
@@ -58,7 +79,27 @@ jobs:
         Asan: On
   steps:
   - checkout: self
-    submodules: recursive
+
+  - script: |
+      set -eo pipefail
+      git submodule init
+      git submodule update --depth 1 --recursive
+    displayName: 'Checkout submodules'
+
+  - script:
+      echo "##vso[task.setvariable variable=PKG_NAME]verona-llvm-x86_64-linux-release-$(LLVMCommit)"
+    displayName: 'Set LLVM Package'
+
+  - script: |
+      set -eo pipefail
+      wget -q -O $(PKG_NAME).tar.gz https://verona.blob.core.windows.net/llvmbuild/$(PKG_NAME)
+    displayName: 'Download package'
+
+  - bash: |
+      set -eo pipefail
+      ./utils/llvm/setup-llvm-builddir.sh $(PKG_NAME).tar.gz
+    displayName: 'Setup LLVM Build dir'
+    workingDirectory: '$(Build.SourcesDirectory)'
 
   - script: |
       set -eo pipefail
@@ -87,29 +128,63 @@ jobs:
     workingDirectory: build
     displayName: 'Tests'
 
+############################################## Windows Builds
 - job:
   displayName: Windows
+  dependsOn: ConfigureCIRun
+  variables:
+    LLVMCommit: $[ dependencies.ConfigureCIRun.outputs['setVarStep.LLVMCommit'] ]
   pool:
     vmImage: 'windows-2019'
   strategy:
     matrix:
       RelWithDebInfo:
+        CXXFLAGS: '/EHsc /D _SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING=1'
         BuildType: RelWithDebInfo
       Release:
+        CXXFLAGS: '/EHsc /D _SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING=1'
         BuildType: Release
 
   steps:
   - checkout: self
-    submodules: recursive
+
+  - script: |
+      git submodule init
+      git submodule update --depth 1 --recursive
+    displayName: 'Checkout submodules'
 
   - script:
       pip install OutputCheck
     displayName: 'Dependencies'
 
+  - bash:
+      echo "##vso[task.setvariable variable=PKG_NAME]verona-llvm-x86_64-windows-release-$(LLVMCommit)"
+    displayName: 'Set LLVM Package'
+
+  - powershell: |
+      $ProgressPreference = 'SilentlyContinue'; (New-Object Net.WebClient).DownloadFile("https://verona.blob.core.windows.net/llvmbuild/$(PKG_NAME)", "$(PKG_NAME).tar.gz")
+    displayName: 'Download package'
+
+  - bash: |
+      ./utils/llvm/setup-llvm-builddir.sh $(PKG_NAME).tar.gz
+    displayName: 'Setup LLVM Build dir'
+    workingDirectory: '$(Build.SourcesDirectory)'
+
+  - bash: |
+      cd external/llvm-project/build
+      if [ ! -f $(BuildType)/bin/mlir-tblgen ]; then
+        echo "Copying LLVM Release binaries to $(BuildType)"
+        mkdir -p $(BuildType)/bin
+        cp -r Release/bin/* $(BuildType)/bin
+        mkdir -p $(BuildType)/lib
+        cp -r Release/lib/* $(BuildType)/lib
+      fi
+    displayName: 'Setup LLVM Binaries/Libraries'
+
   - script: |
       mkdir build
       cd build
-      cmake .. -G"Visual Studio 16 2019" -DENABLE_ASSERTS=ON -DVERONA_CI_BUILD=On -DSNMALLOC_CI_BUILD=On -DRT_TESTS=ON
+      cmake .. -G"Visual Studio 16 2019" -DENABLE_ASSERTS=ON -DVERONA_CI_BUILD=On -DSNMALLOC_CI_BUILD=On -DRT_TESTS=ON -DCMAKE_CXX_FLAGS="$(CXXFLAGS)"
     displayName: 'CMake'
 
   - task: MSBuild@1
@@ -128,8 +203,12 @@ jobs:
     inputs:
       failOnAlert: true
 
+############################################## MacOS Builds
 - job:
   displayName: macOS
+  dependsOn: ConfigureCIRun
+  variables:
+    LLVMCommit: $[ dependencies.ConfigureCIRun.outputs['setVarStep.LLVMCommit'] ]
   pool:
     vmImage: 'macOS-10.14'
   strategy:
@@ -141,12 +220,32 @@ jobs:
 
   steps:
   - checkout: self
-    submodules: recursive
+
+  - script: |
+      set -eo pipefail
+      git submodule init
+      git submodule update --depth 1 --recursive
+    displayName: 'Checkout submodules'
 
   - script: |
       set -eo pipefail
       sudo pip install wheel OutputCheck
     displayName:  'Dependencies'
+
+  - script:
+      echo "##vso[task.setvariable variable=PKG_NAME]verona-llvm-x86_64-macos-release-$(LLVMCommit)"
+    displayName: 'Set LLVM Package'
+
+  - script: |
+      set -eo pipefail
+      curl -s --output $(PKG_NAME).tar.gz https://verona.blob.core.windows.net/llvmbuild/$(PKG_NAME)
+    displayName: 'Download package'
+
+  - bash: |
+      set -eo pipefail
+      ./utils/llvm/setup-llvm-builddir.sh $(PKG_NAME).tar.gz
+    displayName: 'Setup LLVM Build dir'
+    workingDirectory: '$(Build.SourcesDirectory)'
 
   - task: CMake@1
     displayName: 'CMake'

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,4 +26,9 @@ add_subdirectory(compiler)
 add_subdirectory(interpreter)
 add_subdirectory(stdlib)
 
+# Some builds (ex. clang format) don't need LLVM
+if(NOT DISABLE_LLVM_BUILD)
+  add_subdirectory(mlir)
+endif()
+
 clangformat_targets()

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -2,6 +2,7 @@ find_package(Threads REQUIRED)
 
 add_library(verona-ast-lib
   ast.cc
+  cli.cc
   err.cc
   files.cc
   lit.cc
@@ -9,6 +10,7 @@ add_library(verona-ast-lib
   parser.cc
   prec.cc
   ref.cc
+  path.cc
   sym.cc
   )
 
@@ -19,5 +21,6 @@ target_link_libraries(verona-ast-lib Threads::Threads)
 add_executable(verona-ast main.cc cli.cc path.cc)
 target_link_libraries(verona-ast verona-ast-lib)
 
+install(TARGETS verona-ast-lib RUNTIME DESTINATION .)
 install(TARGETS verona-ast RUNTIME DESTINATION .)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/grammar.peg DESTINATION .)

--- a/src/mlir/CMakeLists.txt
+++ b/src/mlir/CMakeLists.txt
@@ -1,0 +1,63 @@
+find_package(Threads REQUIRED)
+
+# We're not building LLVM, but downloading the build dir from an artefact
+set(LLVM_BUILD "${CMAKE_SOURCE_DIR}/external/llvm-project/build")
+
+# Find MLIR_DIR and LLVM_EXTERNAL_LIT from LLVM_BUILD
+if (NOT DEFINED MLIR_DIR AND DEFINED LLVM_BUILD)
+  set(LLVM_DIR ${LLVM_BUILD}/lib/cmake/llvm)
+  message(STATUS "Setting LLVM_DIR as ${LLVM_DIR}")
+  set(MLIR_DIR ${LLVM_BUILD}/lib/cmake/mlir)
+  message(STATUS "Setting MLIR_DIR as ${MLIR_DIR}")
+endif()
+if (NOT DEFINED LLVM_EXTERNAL_LIT AND DEFINED LLVM_BUILD)
+  set(LLVM_EXTERNAL_LIT ${LLVM_BUILD}/bin/llvm-lit CACHE STRING "Command used to spawn lit")
+  message(STATUS "Setting LLVM_EXTERNAL_LIT as ${LLVM_EXTERNAL_LIT}")
+endif()
+find_package(MLIR REQUIRED CONFIG)
+
+message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
+message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+
+# Enable exception handling
+set(LLVM_REQUIRES_EH ON)
+set(LLVM_REQUIRES_RTTI ON)
+
+set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
+set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
+set(MLIR_BINARY_DIR ${CMAKE_BINARY_DIR})
+
+list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
+list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+include(TableGen)
+include(AddLLVM)
+include(AddMLIR)
+include(HandleLLVMOptions)
+
+include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(${MLIR_INCLUDE_DIRS})
+include_directories(${PROJECT_SOURCE_DIR}/src/mlir)
+include_directories(${PROJECT_BINARY_DIR}/src/mlir)
+include_directories(${PROJECT_SOURCE_DIR}/external/CLI11/include)
+include_directories(${PROJECT_SOURCE_DIR}/external/cpp-peglib)
+link_directories(${LLVM_BUILD_LIBRARY_DIR})
+add_definitions(${LLVM_DEFINITIONS})
+
+add_subdirectory(dialect)
+
+### Verona Opt (MLIR-to-MLIR/LLVM pipeline)
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
+set(LIBS
+        ${dialect_libs}
+        ${conversion_libs}
+        MLIROptLib
+        MLIRVerona
+        MLIRTargetLLVMIR
+        verona-ast-lib
+        )
+add_llvm_executable(verona-mlir verona-mlir.cc generator.cc ast-utils.cc)
+
+llvm_update_compile_flags(verona-mlir)
+target_link_libraries(verona-mlir PRIVATE ${LIBS} CLI11::CLI11)
+install(TARGETS verona-mlir RUNTIME DESTINATION .)

--- a/src/mlir/README.md
+++ b/src/mlir/README.md
@@ -1,0 +1,23 @@
+# Verona MLIR Dialect
+
+This is a prototype for the Verona MLIR dialect.
+
+## Building LLVM
+
+Build LLVM with the following options:
+
+```bash
+$ cmake -G Ninja ../llvm \
+        -DLLVM_ENABLE_PROJECTS=mlir \
+        -DLLVM_TARGETS_TO_BUILD="X86" \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DLLVM_ENABLE_ASSERTIONS=ON \
+        -DCMAKE_C_COMPILER=clang \
+        -DCMAKE_CXX_COMPILER=clang++ \
+        -DLLVM_ENABLE_LLD=ON \
+        -DLLVM_REQUIRES_EH=ON \
+        -DLLVM_REQUIRES_RTTI=ON
+$ ninja check-mlir
+```
+
+_Note: EH/RTTI is needed by Verona, so you **must** compile LLVM with it, too_

--- a/src/mlir/ast-utils.cc
+++ b/src/mlir/ast-utils.cc
@@ -1,0 +1,127 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include "ast-utils.h"
+
+#include "symbol.h"
+
+namespace mlir::verona::ASTInterface
+{
+  // ================================================= Generic Helpers
+  ::ast::WeakAst findNode(::ast::WeakAst ast, NodeType type)
+  {
+    auto ptr = ast.lock();
+    assert(!ptr->is_token && "Bad node");
+    // Match tag with NodeKind's enum value
+    auto sub = std::find_if(
+      ptr->nodes.begin(), ptr->nodes.end(), [type](::ast::Ast& sub) {
+        return (sub->tag == type);
+      });
+    assert(sub != ptr->nodes.end());
+    return *sub;
+  }
+
+  llvm::StringRef getTokenValue(::ast::WeakAst ast)
+  {
+    auto ptr = ast.lock();
+    assert(ptr->is_token && "Bad node");
+    assert(!ptr->token.empty());
+    return ptr->token;
+  }
+
+  ::ast::WeakAst getType(::ast::WeakAst ast)
+  {
+    return findNode(ast, NodeKind::OfType);
+  }
+
+  // ================================================= Type Helpers
+  const std::string getTypeDesc(::ast::WeakAst ast)
+  {
+    auto ptr = ast.lock();
+    assert(ptr->tag == NodeKind::OfType && "Bad node");
+    if (ptr->nodes.empty())
+      return "";
+
+    std::string desc;
+    // This undoes the work that the ast did to split the types
+    // and it should be rethought, but MLIR doens't allow multiple
+    // types on a single node. Perhaps attributes?
+    auto type = findNode(ptr, NodeKind::Type).lock();
+    for (auto sub : type->nodes)
+    {
+      if (sub->is_token)
+      {
+        desc += sub->token;
+      }
+      else
+      {
+        auto ref = findNode(sub, NodeKind::TypeRef).lock();
+        desc += ref->nodes[0]->token;
+      }
+    }
+    assert(!desc.empty());
+
+    return desc;
+  }
+
+  // ================================================= Function Helpers
+  llvm::StringRef getFunctionName(::ast::WeakAst ast)
+  {
+    auto ptr = ast.lock();
+    assert(ptr->tag == NodeKind::Function && "Bad node");
+
+    // Empty function name is "apply"
+    auto funcname = findNode(ptr, NodeKind::FuncName).lock();
+    assert(!funcname->nodes.empty() && "Bad function");
+
+    // Else, get function name
+    assert(funcname->nodes.size() == 1);
+    return getTokenValue(funcname->nodes[0]);
+  }
+
+  ::ast::WeakAst getFunctionType(::ast::WeakAst ast)
+  {
+    auto ptr = ast.lock();
+    assert(ptr->tag == NodeKind::Function && "Bad node");
+
+    // Return type is in the sig / oftype / type
+    auto sig = findNode(ast, NodeKind::Sig);
+    return getType(sig);
+  }
+
+  std::vector<::ast::WeakAst> getFunctionArgs(::ast::WeakAst ast)
+  {
+    auto ptr = ast.lock();
+    assert(ptr->tag == NodeKind::Function && "Bad node");
+
+    // Arguments is in sig / params
+    std::vector<::ast::WeakAst> args;
+    auto sig = findNode(ptr, NodeKind::Sig).lock();
+    auto params = findNode(sig, NodeKind::Params).lock();
+    for (auto param : params->nodes)
+      args.push_back(findNode(param, NodeKind::NamedParam));
+    return args;
+  }
+
+  std::vector<::ast::WeakAst> getFunctionConstraints(::ast::WeakAst ast)
+  {
+    auto ptr = ast.lock();
+    assert(ptr->tag == NodeKind::Function && "Bad node");
+
+    std::vector<::ast::WeakAst> constraints;
+    auto sig = findNode(ptr, NodeKind::Sig).lock();
+    auto consts = findNode(sig, NodeKind::Constraints).lock();
+    for (auto c : consts->nodes)
+      constraints.push_back(c);
+    return constraints;
+  }
+
+  ::ast::WeakAst getFunctionBody(::ast::WeakAst ast)
+  {
+    auto ptr = ast.lock();
+    assert(ptr->tag == NodeKind::Function && "Bad node");
+
+    // Body is just a block node in the function
+    return findNode(ast, NodeKind::Block);
+  }
+}

--- a/src/mlir/ast-utils.h
+++ b/src/mlir/ast-utils.h
@@ -1,0 +1,85 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include "ast/cli.h"
+#include "ast/files.h"
+#include "ast/parser.h"
+#include "ast/path.h"
+#include "ast/sym.h"
+
+#include "llvm/ADT/StringRef.h"
+
+#include <string>
+#include <vector>
+
+// This is a bag of utility functions to handle AST lookups and fail-safe
+// operation. While the AST design is still in flux, we can keep this around,
+// but once we're set on its structure, this should move to src/ast instead.
+//
+// Current Memory Model
+//
+// The memory of all AST nodes is owned but the AST. Here, we only query
+// temporary values for reading purposes only. The AST uses weak_ptr for
+// temporary variables, so some of our methods use it too to pass areguments.
+//
+// Once we need to actually read the value, we use weak_ptr.lock() as usual.
+//
+// Values returned are either new strings, weak_ptr or a new vector of weak
+// pointers. The idea is to detach the structures of the AST and have a flat
+// representation for the specific types of nodes we need in each call.
+
+namespace mlir::verona::ASTInterface
+{
+  // We need this because the ""_ operator doens't stack well outside of the
+  // peg namespace, so we need to call str2tag directly. Easier to do so in a
+  // constexpr enum type creation and let the rest be unsigned comparisons.
+  // The AST code needs to be flexible, so using the operator directly is more
+  // convenient. But we need to be very strict (with MLIR generation), so this
+  // also creates an additional layer of safety.
+  using NodeType = unsigned int;
+  enum NodeKind : NodeType
+  {
+    None = 0,
+    Module = peg::str2tag("module"),
+    ClassDef = peg::str2tag("classdef"),
+    Function = peg::str2tag("function"),
+    FuncName = peg::str2tag("funcname"),
+    Sig = peg::str2tag("sig"),
+    Block = peg::str2tag("block"),
+    OfType = peg::str2tag("oftype"),
+    Constraints = peg::str2tag("constraints"),
+    Constraint = peg::str2tag("constraint"),
+    Type = peg::str2tag("type"),
+    TypeRef = peg::str2tag("type_ref"),
+    TypeBody = peg::str2tag("typebody"),
+    Params = peg::str2tag("params"),
+    NamedParam = peg::str2tag("namedparam"),
+    ID = peg::str2tag("id"),
+    Seq = peg::str2tag("seq"),
+    Assign = peg::str2tag("assign"),
+    Let = peg::str2tag("let"),
+    Call = peg::str2tag("call"),
+    Args = peg::str2tag("args"),
+    Integer = peg::str2tag("int"),
+    Local = peg::str2tag("local"),
+    Localref = peg::str2tag("localref"),
+    // TODO: Add all
+  };
+
+  // Find a sub-node of tag 'type'
+  ::ast::WeakAst findNode(::ast::WeakAst ast, NodeType type);
+
+  // Get token value
+  llvm::StringRef getTokenValue(::ast::WeakAst ast);
+
+  // Type helpers
+  ::ast::WeakAst getType(::ast::WeakAst ast);
+  const std::string getTypeDesc(::ast::WeakAst ast);
+
+  // Function helpers
+  llvm::StringRef getFunctionName(::ast::WeakAst ast);
+  ::ast::WeakAst getFunctionType(::ast::WeakAst ast);
+  std::vector<::ast::WeakAst> getFunctionArgs(::ast::WeakAst ast);
+  std::vector<::ast::WeakAst> getFunctionConstraints(::ast::WeakAst ast);
+  ::ast::WeakAst getFunctionBody(::ast::WeakAst ast);
+}

--- a/src/mlir/dialect/CMakeLists.txt
+++ b/src/mlir/dialect/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_mlir_dialect(VeronaOps verona)
+add_mlir_doc(VeronaDialect -gen-dialect-doc VeronaDialect Verona/)
+add_mlir_doc(VeronaOps -gen-op-doc VeronaOps Verona/)
+
+add_mlir_dialect_library(MLIRVerona
+    VeronaDialect.cc
+    VeronaOps.cc
+
+    DEPENDS
+    MLIRVeronaOpsIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRIR
+    )

--- a/src/mlir/dialect/VeronaDialect.cc
+++ b/src/mlir/dialect/VeronaDialect.cc
@@ -1,0 +1,123 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include "VeronaDialect.h"
+
+#include "VeronaOps.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "mlir/IR/StandardTypes.h"
+
+using namespace mlir;
+using namespace mlir::verona;
+
+//===----------------------------------------------------------------------===//
+// Verona dialect.
+//===----------------------------------------------------------------------===//
+
+VeronaDialect::VeronaDialect(mlir::MLIRContext* context)
+: Dialect(getDialectNamespace(), context)
+{
+  addOperations<
+#define GET_OP_LIST
+#include "dialect/VeronaOps.cpp.inc"
+    >();
+  addTypes<IntegerType>();
+  allowUnknownOperations();
+  allowUnknownTypes();
+}
+
+Type VeronaDialect::parseType(DialectAsmParser& parser) const
+{
+  StringRef keyword;
+  if (parser.parseKeyword(&keyword))
+    return Type();
+
+  if (keyword.startswith("U") || keyword.startswith("S"))
+  {
+    size_t width = 0;
+    if (keyword.substr(1).getAsInteger(10, width))
+    {
+      parser.emitError(parser.getNameLoc(), "unknown verona type: ") << keyword;
+      return Type();
+    }
+    bool sign = keyword.startswith("S");
+    return IntegerType::get(getContext(), width, sign);
+  }
+
+  parser.emitError(parser.getNameLoc(), "unknown verona type: ") << keyword;
+  return Type();
+}
+
+void VeronaDialect::printType(Type type, DialectAsmPrinter& os) const
+{
+  switch (type.getKind())
+  {
+    case VeronaTypes::Integer:
+    {
+      auto iTy = type.cast<IntegerType>();
+      if (iTy.getSign())
+      {
+        os << "S";
+      }
+      else
+      {
+        os << "U";
+      }
+      os << iTy.getWidth();
+      return;
+    }
+    default:
+      llvm_unreachable("unexpected 'verona' type kind");
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Verona types.
+//===----------------------------------------------------------------------===//
+
+namespace mlir::verona::detail
+{
+  struct IntegerTypeStorage : public ::mlir::TypeStorage
+  {
+    uint8_t width;
+    enum SignType
+    {
+      Unknown,
+      Unsigned,
+      Signed
+    };
+    unsigned sign;
+
+    // width, sign
+    using KeyTy = std::tuple<size_t, unsigned>;
+    IntegerTypeStorage(const KeyTy& key)
+    : TypeStorage(), width(std::get<0>(key)), sign(std::get<1>(key))
+    {}
+
+    bool operator==(const KeyTy& key) const
+    {
+      return key == KeyTy(width, sign);
+    }
+
+    static IntegerTypeStorage*
+    construct(TypeStorageAllocator& allocator, const KeyTy& key)
+    {
+      return new (allocator.allocate<IntegerTypeStorage>())
+        IntegerTypeStorage(key);
+    }
+  };
+} // namespace mlir::verona::detail
+
+verona::IntegerType
+verona::IntegerType::get(MLIRContext* context, size_t width, unsigned sign)
+{
+  return Base::get(context, VeronaTypes::Kind::Integer, width, sign);
+}
+size_t verona::IntegerType::getWidth() const
+{
+  return getImpl()->width;
+}
+bool verona::IntegerType::getSign() const
+{
+  return getImpl()->sign;
+}

--- a/src/mlir/dialect/VeronaDialect.h
+++ b/src/mlir/dialect/VeronaDialect.h
@@ -1,0 +1,43 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "mlir/IR/Dialect.h"
+
+namespace mlir::verona
+{
+  namespace detail
+  {
+    struct IntegerTypeStorage;
+  } // namespace detail
+
+  namespace VeronaTypes
+  {
+    // Needs to be an enum (not an enum class) because 'kindof' methods compare
+    // unsigned values and not class values.
+    enum Kind
+    {
+      Integer = Type::Kind::FIRST_PRIVATE_EXPERIMENTAL_0_TYPE
+    };
+  } // namespace VeronaTypes
+
+#include "dialect/VeronaOpsDialect.h.inc"
+
+  struct IntegerType
+  : public Type::TypeBase<IntegerType, Type, detail::IntegerTypeStorage>
+  {
+    using Base::Base;
+
+    static IntegerType get(MLIRContext* context, size_t width, unsigned sign);
+
+    size_t getWidth() const;
+    bool getSign() const;
+
+    static bool kindof(unsigned kind)
+    {
+      return kind == VeronaTypes::Integer;
+    }
+  };
+
+} // namespace mlir::verona

--- a/src/mlir/dialect/VeronaDialect.td
+++ b/src/mlir/dialect/VeronaDialect.td
@@ -1,0 +1,32 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#ifndef VERONA_DIALECT
+#define VERONA_DIALECT
+
+include "mlir/IR/OpBase.td"
+
+//===----------------------------------------------------------------------===//
+// Verona dialect definition.
+//===----------------------------------------------------------------------===//
+
+def Verona_Dialect : Dialect {
+    let name = "verona";
+    let summary = "A prototype Verona language MLIR dialect.";
+    let cppNamespace = "verona";
+}
+
+//===----------------------------------------------------------------------===//
+// Base verona operation/type definitions.
+//===----------------------------------------------------------------------===//
+
+class Verona_Op<string mnemonic, list<OpTrait> traits = []> :
+        Op<Verona_Dialect, mnemonic, traits>;
+
+def Verona_IntegerType : DialectType<Verona_Dialect,
+    CPred<"$_self.isa<::mlir::verona::IntegerType>()">, "integer type">,
+    BuildableType<"$_builder.getType<::mlir::verona::IntegerType>()">;
+
+def Verona_Type : AnyTypeOf<[Verona_IntegerType]>;
+
+#endif // VERONA_DIALECT

--- a/src/mlir/dialect/VeronaOps.cc
+++ b/src/mlir/dialect/VeronaOps.cc
@@ -1,0 +1,14 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include "VeronaOps.h"
+
+#include "VeronaDialect.h"
+#include "mlir/IR/OpImplementation.h"
+
+namespace mlir::verona
+{
+#define GET_OP_CLASSES
+#include "dialect/VeronaOps.cpp.inc"
+
+} // namespace mlir::verona

--- a/src/mlir/dialect/VeronaOps.h
+++ b/src/mlir/dialect/VeronaOps.h
@@ -1,0 +1,15 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+namespace mlir::verona
+{
+#define GET_OP_CLASSES
+#include "dialect/VeronaOps.h.inc"
+
+} // namespace mlir::verona

--- a/src/mlir/dialect/VeronaOps.td
+++ b/src/mlir/dialect/VeronaOps.td
@@ -1,0 +1,40 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#ifndef VERONA_OPS
+#define VERONA_OPS
+
+include "VeronaDialect.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+
+// This is a useless Verona op that accepts any Verona type as input and output.
+// The purpose of it here is to test a dialect specific operation in the IR,
+// ie. without quotes: verona.foo instead of the opaque "verona.foo".
+def Verona_FooOp : Verona_Op<"foo", [NoSideEffect,
+                                             SameOperandsAndResultType]> {
+    let summary = "Illustrates how to define an operation.";
+    let description = [{
+        The `verona.foo` operation illustrates how to define a new
+        operation in a dialect. It uses an operation trait to declare that it
+        has no side effects.
+
+        This operation takes an integer argument and returns an integer.
+
+        Example:
+
+        ```mlir
+        %0 = constant 2 : i32
+        // Apply the foo operation to %0
+        %1 = verona.foo %0 : i32
+        ```
+    }];
+
+    let arguments = (ins Verona_Type:$input);
+    let results = (outs Verona_Type:$res);
+
+    let assemblyFormat = [{
+        $input attr-dict `:` type($input)
+    }];
+}
+
+#endif // VERONA_OPS

--- a/src/mlir/generator.cc
+++ b/src/mlir/generator.cc
@@ -1,0 +1,356 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include "generator.h"
+
+#include "ast-utils.h"
+#include "dialect/VeronaDialect.h"
+#include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVMPass.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/StandardTypes.h"
+#include "mlir/IR/Types.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Parser.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/FileUtilities.h"
+#include "mlir/Transforms/Passes.h"
+
+#include "llvm/IR/Module.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/ToolOutputFile.h"
+
+namespace mlir::verona
+{
+  // FIXME: Until we decide how the interface is going to be, this helps to
+  // keep the idea of separation without actually doing it. We could have just
+  // a namespace and functions, a static class, or a stateful class, all of
+  // which will have different choices on the calls to the interface.
+  using namespace ASTInterface;
+
+  // ===================================================== Public Interface
+  void Generator::readAST(const ::ast::Ast& ast)
+  {
+    // Parse the AST with the rules below
+    parseModule(ast);
+
+    // On error, dump module for debug purposes
+    if (mlir::failed(mlir::verify(*module)))
+    {
+      module->dump();
+      throw std::runtime_error("MLIR verification failed from Verona file");
+    }
+  }
+
+  void Generator::readMLIR(const std::string& filename)
+  {
+    if (filename.empty())
+      throw std::runtime_error("No input filename provided");
+
+    // Read an MLIR file
+    auto srcOrErr = llvm::MemoryBuffer::getFileOrSTDIN(filename);
+
+    if (auto err = srcOrErr.getError())
+      throw std::runtime_error(
+        "Cannot open file " + filename + ": " + err.message());
+
+    // Setup source manager and parse
+    llvm::SourceMgr sourceMgr;
+    sourceMgr.AddNewSourceBuffer(std::move(*srcOrErr), llvm::SMLoc());
+    module = mlir::parseSourceFile(sourceMgr, builder.getContext());
+
+    // On error, dump module for debug purposes
+    if (mlir::failed(mlir::verify(*module)))
+    {
+      module->dump();
+      throw std::runtime_error("MLIR verification failed from MLIR file");
+    }
+  }
+
+  void Generator::emitMLIR(llvm::StringRef filename, unsigned optLevel)
+  {
+    if (filename.empty())
+      throw std::runtime_error("No output filename provided");
+
+    // Write to the file requested
+    std::error_code error;
+    auto out = llvm::raw_fd_ostream(filename, error);
+    if (error)
+      throw std::runtime_error("Cannot open output filename");
+
+    // We're not optimising the MLIR module like we do for LLVM output
+    // because this is mostly for debug and testing. We could do that
+    // in the future.
+    module->print(out);
+  }
+
+  // FIXME: This function will not work. It must receive an MLIR module that is
+  // 100% composed of dialects that can be fully converted to LLVM dialect.
+  // We keep this code here as future reference on how to lower to LLVM.
+  void Generator::emitLLVM(llvm::StringRef filename, unsigned optLevel)
+  {
+    if (filename.empty())
+      throw std::runtime_error("No output filename provided");
+
+    // The lowering "pass manager"
+    mlir::PassManager pm(&context);
+    if (optLevel > 0)
+    {
+      pm.addPass(mlir::createInlinerPass());
+      pm.addPass(mlir::createSymbolDCEPass());
+      mlir::OpPassManager& optPM = pm.nest<mlir::FuncOp>();
+      optPM.addPass(mlir::createCanonicalizerPass());
+      optPM.addPass(mlir::createCSEPass());
+    }
+    pm.addPass(mlir::createLowerToLLVMPass());
+
+    // First lower to LLVM dialect
+    if (mlir::failed(pm.run(module.get())))
+    {
+      module->dump();
+      throw std::runtime_error("Failed to lower to LLVM dialect");
+    }
+
+    // Then lower to LLVM IR
+    auto llvm = mlir::translateModuleToLLVMIR(module.get());
+    if (!llvm)
+      throw std::runtime_error("Failed to lower to LLVM IR");
+
+    // Write to the file requested
+    std::error_code error;
+    auto out = llvm::raw_fd_ostream(filename, error);
+    if (error)
+      throw std::runtime_error("Failed open output file");
+
+    llvm->print(out, nullptr);
+  }
+
+  // ===================================================== AST -> MLIR
+  mlir::Location Generator::getLocation(const ::ast::Ast& ast)
+  {
+    return builder.getFileLineColLoc(
+      Identifier::get(ast->path, &context), ast->line, ast->column);
+  }
+
+  mlir::Type Generator::parseType(const ::ast::Ast& ast)
+  {
+    assert(ast->tag == NodeKind::OfType && "Bad node");
+    auto desc = getTypeDesc(ast);
+    if (desc.empty())
+      return builder.getNoneType();
+
+    // If type is in the alias table, get it
+    if (typeTable.inScope(desc))
+      return typeTable.lookup(desc);
+
+    // Else, insert into the table and return
+    auto dialect = Identifier::get("type", &context);
+    auto type = mlir::OpaqueType::get(dialect, desc, &context);
+    typeTable.insert(desc, type);
+    return type;
+  }
+
+  void Generator::parseModule(const ::ast::Ast& ast)
+  {
+    assert(ast->tag == NodeKind::ClassDef && "Bad node");
+    module = mlir::ModuleOp::create(getLocation(ast));
+    // TODO: Support more than just functions at the module level
+    auto body = findNode(ast, NodeKind::TypeBody);
+    for (auto fun : body.lock()->nodes)
+      module->push_back(parseFunction(fun));
+  }
+
+  mlir::FuncOp Generator::parseProto(const ::ast::Ast& ast)
+  {
+    assert(ast->tag == NodeKind::Function && "Bad node");
+    auto name = getFunctionName(ast);
+    assert(!functionTable.inScope(name) && "Redeclaration");
+
+    // Parse 'where' clause
+    auto constraints = getFunctionConstraints(ast);
+    for (auto c : constraints)
+    {
+      auto alias = getTokenValue(findNode(c, NodeKind::ID));
+      auto ty = findNode(c, NodeKind::OfType);
+      typeTable.insert(alias, parseType(ty.lock()));
+    }
+
+    // Function type from signature
+    Types types;
+    auto args = getFunctionArgs(ast);
+    for (auto arg : args)
+      types.push_back(parseType(getType(arg).lock()));
+    auto retTy = parseType(getFunctionType(ast).lock());
+    auto funcTy = builder.getFunctionType(types, retTy);
+
+    // Create function
+    auto func = mlir::FuncOp::create(getLocation(ast), name, funcTy);
+    functionTable.insert(name, func);
+    return func;
+  }
+
+  mlir::FuncOp Generator::parseFunction(const ::ast::Ast& ast)
+  {
+    assert(ast->tag == NodeKind::Function && "Bad node");
+
+    // Declare function signature
+    TypeScopeT alias_scope(typeTable);
+    auto name = getFunctionName(ast);
+    if (!functionTable.inScope(name))
+      parseProto(ast);
+    auto func = functionTable.lookup(name);
+    auto retTy = func.getType().getResult(0);
+
+    // Create entry block
+    auto& entryBlock = *func.addEntryBlock();
+    builder.setInsertionPointToStart(&entryBlock);
+
+    // Declare all arguments on current scope
+    SymbolScopeT var_scope(symbolTable);
+    auto args = getFunctionArgs(ast);
+    auto argVals = entryBlock.getArguments();
+    assert(args.size() == argVals.size() && "Argument mismatch");
+    for (auto var_val : llvm::zip(args, argVals))
+    {
+      llvm::StringRef name =
+        findNode(std::get<0>(var_val).lock(), NodeKind::ID).lock()->token;
+      auto value = std::get<1>(var_val);
+      declareVariable(name, value);
+    }
+
+    // Lower body
+    auto body = getFunctionBody(ast);
+    auto last = parseNode(body.lock());
+
+    // Return last value
+    if (last && last.getType() != retTy)
+    {
+      // Cast type (we trust the ast)
+      last = genOperation(last.getLoc(), "verona.cast", {last}, retTy);
+    }
+    else
+    {
+      last = genOperation(getLocation(ast), "verona.none", {}, retTy);
+    }
+    builder.create<mlir::ReturnOp>(getLocation(ast), last);
+
+    return func;
+  }
+
+  void Generator::declareVariable(llvm::StringRef name, mlir::Value val)
+  {
+    assert(!symbolTable.inScope(name) && "Redeclaration");
+    symbolTable.insert(name, val);
+  }
+
+  void Generator::updateVariable(llvm::StringRef name, mlir::Value val)
+  {
+    assert(symbolTable.inScope(name) && "Variable not declared");
+    symbolTable.update(name, val);
+  }
+
+  mlir::Value Generator::parseBlock(const ::ast::Ast& ast)
+  {
+    auto seq = findNode(ast, NodeKind::Seq);
+    mlir::Value last;
+    for (auto sub : seq.lock()->nodes)
+      last = parseNode(sub);
+    return last;
+  }
+
+  mlir::Value Generator::parseNode(const ::ast::Ast& ast)
+  {
+    if (ast->is_token)
+      return parseValue(ast);
+
+    switch (ast->tag)
+    {
+      case NodeKind::Localref:
+        return parseValue(ast);
+      case NodeKind::Block:
+        return parseBlock(ast);
+      case NodeKind::ID:
+        return parseValue(ast);
+      case NodeKind::Assign:
+        return parseAssign(ast);
+      case NodeKind::Call:
+        return parseCall(ast);
+      default:
+        throw std::runtime_error("Node not implemented yet: " + ast->name);
+    }
+  }
+
+  mlir::Value Generator::parseValue(const ::ast::Ast& ast)
+  {
+    assert(ast->is_token && "Bad node");
+
+    // Variables
+    if (ast->tag == NodeKind::Localref)
+    {
+      auto var = symbolTable.lookup(ast->token);
+      return var;
+    }
+    // TODO: Literals need attributes and types
+
+    throw std::runtime_error("Value not implemented yet: " + ast->name);
+  }
+
+  mlir::Value Generator::parseAssign(const ::ast::Ast& ast)
+  {
+    assert(ast->tag == NodeKind::Assign && "Bad node");
+
+    // Must be a Let declaring a variable (for now).
+    auto let = findNode(ast, NodeKind::Let);
+    auto local = findNode(let, NodeKind::Local);
+    llvm::StringRef name = getTokenValue(local);
+
+    // The right-hand side can be any expression
+    // This is the value and we update the variable
+    auto rhs = parseNode(ast->nodes[1]);
+    declareVariable(name, rhs);
+    return symbolTable.lookup(name);
+  }
+
+  mlir::Value Generator::parseCall(const ::ast::Ast& ast)
+  {
+    assert(ast->tag == NodeKind::Call && "Bad node");
+    llvm::StringRef name = findNode(ast, NodeKind::Function).lock()->token;
+
+    // All operations are calls, only calls to previously defined functions
+    // are function calls. FIXME: Is this really what we want?
+    if (functionTable.inScope(name))
+    {
+      // TODO: Lower calls.
+      return mlir::Value();
+    }
+
+    // Else, it should be an operation that we can lower natively
+    // TODO: Separate between unary, binary, ternary, etc.
+    // FIXME: Make this able to discern different types of operations.
+    if (name == "+")
+    {
+      auto arg0 = parseNode(findNode(ast, NodeKind::Localref).lock());
+      auto arg1 = parseNode(findNode(ast, NodeKind::Args).lock()->nodes[0]);
+      auto dialect = Identifier::get("type", &context);
+      auto type = mlir::OpaqueType::get(dialect, "ret", &context);
+      return genOperation(getLocation(ast), "verona.add", {arg0, arg1}, type);
+    }
+    llvm_unreachable("Operation not implemented yet");
+  }
+
+  mlir::Value Generator::genOperation(
+    mlir::Location loc,
+    llvm::StringRef name,
+    llvm::ArrayRef<mlir::Value> ops,
+    mlir::Type retTy)
+  {
+    auto opName = OperationName(name, &context);
+    auto state = OperationState(loc, opName);
+    state.addOperands(ops);
+    state.addTypes({retTy});
+    auto op = builder.createOperation(state);
+    return op->getResult(0);
+  }
+}

--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -1,0 +1,102 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "ast/ast.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Function.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/Module.h"
+#include "mlir/Target/LLVMIR.h"
+#include "symbol.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
+#include <peglib.h>
+#include <string>
+
+namespace mlir::verona
+{
+  // MLIR Generator.
+  //
+  // There are two entry points: AST and MLIR, and two exit points: MLIR
+  // and LLVM IR. The MLIR -> MLIR path is for self-validation and future
+  // optimisation passes (mainly testing).
+  //
+  // The LLVM IR can be dumped or used in the next step of the compilation,
+  // lowering to machine code by the LLVM library.
+  //
+  // For now, the error handling is crude and needs proper consideration,
+  // especially aggregating all errors and context before sending it back to
+  // the public API callers.
+  struct Generator
+  {
+    Generator() : builder(&context)
+    {
+      // Opaque operations and types can only exist if we allow
+      // unregistered dialects to co-exist. Full conversions later will
+      // make sure we end up with onlt Verona dialect, then Standard
+      // dialects, then LLVM dialect, before converting to LLVM IR.
+      context.allowUnregisteredDialects();
+    }
+
+    // Read AST/MLIR into MLIR module, returns false on failure.
+    void readAST(const ::ast::Ast& ast);
+    void readMLIR(const std::string& filename);
+
+    // Transform the opaque MLIR format into Verona dialect and LLVM IR.
+    void emitMLIR(const llvm::StringRef filename = "", unsigned optLevel = 0);
+    void emitLLVM(const llvm::StringRef filename = "", unsigned optLevel = 0);
+
+    using Types = llvm::SmallVector<mlir::Type, 4>;
+    using Values = llvm::SmallVector<mlir::Value, 4>;
+
+  private:
+    // MLIR module, builder and context.
+    mlir::OwningModuleRef module;
+    mlir::OpBuilder builder;
+    mlir::MLIRContext context;
+
+    // Symbol tables for variables, functions and classes.
+    SymbolTableT symbolTable;
+    FunctionTableT functionTable;
+    TypeTableT typeTable;
+
+    // Get location of an ast node
+    mlir::Location getLocation(const ::ast::Ast& ast);
+
+    // Parses a module, the global context.
+    void parseModule(const ::ast::Ast& ast);
+
+    // Parses a function, from a top-level (module) view.
+    mlir::FuncOp parseProto(const ::ast::Ast& ast);
+    mlir::FuncOp parseFunction(const ::ast::Ast& ast);
+
+    // Recursive type parser, gathers all available information on the type
+    // and sub-types, modifiers, annotations, etc.
+    mlir::Type parseType(const ::ast::Ast& ast);
+
+    // Declares/Updates a variable.
+    void declareVariable(llvm::StringRef name, mlir::Value val);
+    void updateVariable(llvm::StringRef name, mlir::Value val);
+
+    // Generic block/node parser, calls other parse functions to handle each
+    // individual type. Block returns last value, for return.
+    mlir::Value parseBlock(const ::ast::Ast& ast);
+    mlir::Value parseNode(const ::ast::Ast& ast);
+    mlir::Value parseValue(const ::ast::Ast& ast);
+
+    // Specific parsers (there will be more).
+    mlir::Value parseAssign(const ::ast::Ast& ast);
+    mlir::Value parseCall(const ::ast::Ast& ast);
+
+    // Wrappers for unary/binary operands
+    mlir::Value genOperation(
+      mlir::Location loc,
+      llvm::StringRef name,
+      llvm::ArrayRef<mlir::Value> ops,
+      mlir::Type retTy);
+  };
+}

--- a/src/mlir/symbol.h
+++ b/src/mlir/symbol.h
@@ -1,0 +1,130 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "ast/ast.h"
+#include "mlir/IR/Function.h"
+#include "mlir/IR/Types.h"
+#include "mlir/IR/Value.h"
+
+namespace mlir::verona
+{
+  // The symbol table has all declared symbols (with the original node
+  // and the MLIR ounterpart) in a scope. Creating a new scope makes
+  // all future insertions happen at that level, destroying it pops
+  // the scope out of the stack.
+
+  // New scopes are created by creating a new local variable like:
+  //   SymbolScopeT scope(symbolTable);
+  // The destructor pops the scope automatically.
+
+  // We cannot use LLVM's ADT/ScopedHashTable like MLIR's Toy example because
+  // that coped hash table does not allow redefinition, which is a problem when
+  // declaring variables with a type only and then assigning values later.
+  template<class T>
+  class ScopedTable
+  {
+    using MapTy = std::map<std::string, T>;
+    std::vector<MapTy> stack;
+
+  public:
+    ScopedTable()
+    {
+      // Global scope
+      pushScope();
+    }
+
+    ~ScopedTable()
+    {
+      // Global scope
+      popScope();
+      assert(stack.empty());
+    }
+
+    // Insert entry on the last scope only
+    bool insert(llvm::StringRef key, T value)
+    {
+      auto& frame = stack.back();
+      if (frame.count(key.str()))
+        return false;
+      auto res = frame.emplace(key, value);
+      return res.second;
+    }
+
+    // Lookup from the last scope to the first
+    T lookup(llvm::StringRef key)
+    {
+      for (auto it = stack.rbegin(), end = stack.rend(); it != end; it++)
+      {
+        auto& frame = *it;
+        if (frame.count(key.str()))
+          return frame[key.str()];
+      }
+      // Use inScope for this not to happen
+      llvm_unreachable("Symbol not found");
+    }
+
+    // Check that the entry is in the last scope
+    bool inScope(llvm::StringRef key)
+    {
+      auto frame = stack.back();
+      return frame.count(key.str());
+    }
+
+    // Update the entry in the last scope, or create new
+    bool update(llvm::StringRef key, T value)
+    {
+      auto& frame = stack.back();
+      if (!frame.count(key.str()))
+        return insert(key, value);
+      // FIXME: Check types are compatible
+      frame[key.str()] = value;
+      return true;
+    }
+
+    // Creates a new scope
+    void pushScope()
+    {
+      stack.emplace_back();
+    }
+
+    // Destroys the inner-most scope
+    void popScope()
+    {
+      stack.pop_back();
+    }
+  };
+
+  // FIXME: This is a hack to control scope. We can do better.
+  template<class T>
+  class ScopedTableScope
+  {
+    ScopedTable<T>& table;
+
+  public:
+    ScopedTableScope(ScopedTable<T>& table) : table(table)
+    {
+      table.pushScope();
+    }
+    ~ScopedTableScope()
+    {
+      table.popScope();
+    }
+  };
+
+  // Variable symbols. New scopes should be created when entering classes,
+  // functions, lexical blocks, lambdas, etc.
+  using SymbolTableT = ScopedTable<mlir::Value>;
+  using SymbolScopeT = ScopedTableScope<mlir::Value>;
+
+  // Function Symbols. New scopes should be created when entering classes
+  // and sub-classes. Modules too, if we allow more than one per file.
+  using FunctionTableT = ScopedTable<mlir::FuncOp>;
+  using FunctionScopeT = ScopedTableScope<mlir::FuncOp>;
+
+  // Type Symbols. New scopes should be created when entering classes
+  // sub-classes and functions, to be used with the 'where' keyword.
+  using TypeTableT = ScopedTable<mlir::Type>;
+  using TypeScopeT = ScopedTableScope<mlir::Type>;
+}

--- a/src/mlir/verona-mlir.cc
+++ b/src/mlir/verona-mlir.cc
@@ -1,0 +1,228 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include "CLI/CLI.hpp"
+#include "ast/cli.h"
+#include "ast/module.h"
+#include "ast/parser.h"
+#include "ast/path.h"
+#include "ast/prec.h"
+#include "ast/ref.h"
+#include "ast/sym.h"
+#include "dialect/VeronaDialect.h"
+#include "generator.h"
+#include "mlir/InitAllDialects.h"
+#include "mlir/InitAllPasses.h"
+
+#include "llvm/Support/InitLLVM.h"
+
+namespace
+{
+  // Source file types, to choose how to parse
+  enum class SourceKind
+  {
+    None,
+    Verona,
+    MLIR
+  };
+
+  // Command line options, with output control
+  struct Opt
+  {
+    std::string grammar;
+    std::string filename;
+    std::string output;
+    bool mlir = false;
+    bool llvm = false;
+  };
+
+  // Parse cmd-line and set defaults
+  Opt parse(int argc, char** argv)
+  {
+    CLI::App app{"Verona MLIR"};
+
+    Opt opt;
+    app.add_flag("--emit-mlir", opt.mlir, "Emit MLIR.");
+    app.add_flag("--emit-llvm", opt.llvm, "Emit LLVM (default).");
+    app.add_option("-g,--grammar", opt.grammar, "Grammar to use.");
+    app.add_option("-o,--output", opt.output, "Output filename.");
+    app.add_option("file", opt.filename, "File to compile.");
+
+    try
+    {
+      app.parse(argc, argv);
+    }
+    catch (const CLI::ParseError& e)
+    {
+      exit(app.exit(e));
+    }
+
+    // Default is to output MLIR
+    if (!opt.llvm)
+      opt.mlir = true;
+
+    // Default grammar
+    if (opt.grammar.empty())
+      opt.grammar = path::directory(path::executable()).append("/grammar.peg");
+
+    // Default input is stdin
+    if (opt.filename.empty())
+      opt.filename = "-";
+
+    return opt;
+  }
+
+  // Print help
+  void help()
+  {
+    std::cout << "Compiler Syntax: verona-mlir AST|MLIR|LLVM <filename.verona>"
+              << std::endl;
+  }
+
+  // Detect source type from extension
+  SourceKind getSourceType(llvm::StringRef filename)
+  {
+    auto source = SourceKind::None;
+    if (filename.endswith(".verona"))
+      source = SourceKind::Verona;
+    else if (filename.endswith(".mlir"))
+      source = SourceKind::MLIR;
+    else if (filename == "-") // STDIN, assume MLIR
+      source = SourceKind::MLIR;
+    return source;
+  }
+
+  // Choose output file extension from output type
+  // Careful with mlir->mlir not to overwrite source file
+  std::string
+  getOutputFilename(llvm::StringRef filename, Opt& opt, SourceKind source)
+  {
+    if (!opt.output.empty())
+      return opt.output;
+    if (filename == "-")
+      return "-";
+
+    std::string newName = filename.substr(0, filename.find_last_of('.')).str();
+    if (opt.mlir)
+    {
+      if (source == SourceKind::MLIR)
+        newName += ".mlir.out";
+      else
+        newName += ".mlir";
+    }
+    else
+    {
+      newName += ".ll";
+    }
+    return newName;
+  }
+} // namespace
+
+int main(int argc, char** argv)
+{
+  // MLIR boilerplace
+  mlir::registerAllDialects();
+  mlir::registerAllPasses();
+  // TODO: Register verona passes here.
+  mlir::registerDialect<mlir::verona::VeronaDialect>();
+
+  // Set up pretty-print signal handlers
+  llvm::InitLLVM y(argc, argv);
+
+  // Parse cmd-line options
+  auto opt = parse(argc, argv);
+  llvm::StringRef filename(opt.filename);
+  auto source = getSourceType(filename);
+  if (source == SourceKind::None)
+  {
+    std::cerr << "ERROR: Unknown source file " << filename.str()
+              << ". Must be [verona, mlir]" << std::endl;
+    return 1;
+  }
+  std::string outputFilename = getOutputFilename(filename, opt, source);
+
+  // MLIR Generator
+  mlir::verona::Generator gen;
+
+  // Parse the source file (verona/mlir)
+  switch (source)
+  {
+    case SourceKind::Verona:
+    {
+      // Parse the file
+      err::Errors err;
+      module::Passes passes = {sym::build, ref::build, prec::build};
+      auto m = module::build(opt.grammar, passes, opt.filename, "verona", err);
+      if (!err.empty())
+      {
+        std::cerr << "ERROR: cannot parse Verona file " << filename.str()
+                  << std::endl
+                  << err.to_s() << std::endl;
+        return 1;
+      }
+      // Parse AST file into MLIR
+      try
+      {
+        gen.readAST(m->ast);
+      }
+      catch (std::runtime_error& e)
+      {
+        std::cerr << "ERROR: cannot convert Verona file " << filename.str()
+                  << " into MLIR" << std::endl
+                  << e.what() << std::endl;
+        return 1;
+      }
+      break;
+    }
+    case SourceKind::MLIR:
+      // Parse MLIR file
+      try
+      {
+        gen.readMLIR(opt.filename);
+      }
+      catch (std::runtime_error& e)
+      {
+        std::cerr << "ERROR: cannot read MLIR file " << filename.str()
+                  << std::endl
+                  << e.what() << std::endl;
+        return 1;
+      }
+      break;
+    default:
+      std::cerr << "ERROR: invalid source file type" << std::endl;
+      return 1;
+  }
+
+  // Emit the MLIR graph
+  if (opt.mlir)
+  {
+    try
+    {
+      gen.emitMLIR(outputFilename);
+    }
+    catch (std::runtime_error& e)
+    {
+      std::cerr << "ERROR: failed to lower to MLIR" << std::endl
+                << e.what() << std::endl;
+      return 1;
+    }
+    return 0;
+  }
+
+  // Emit LLVM IR
+  if (opt.llvm)
+  {
+    try
+    {
+      gen.emitLLVM(outputFilename);
+    }
+    catch (std::runtime_error& e)
+    {
+      std::cerr << "ERROR: failed to lower to LLVM" << std::endl
+                << e.what() << std::endl;
+      return 1;
+    }
+    return 0;
+  }
+  return 0;
+}

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -33,10 +33,12 @@ endif()
 set(VERONAC ${CMAKE_INSTALL_PREFIX}/veronac)
 set(VERONAI ${CMAKE_INSTALL_PREFIX}/interpreter)
 set(VERONAP ${CMAKE_INSTALL_PREFIX}/verona-ast)
+set(VERONAM ${CMAKE_INSTALL_PREFIX}/verona-mlir)
 if(WIN32)
   set(VERONAC ${VERONAC}.exe)
   set(VERONAI ${VERONAI}.exe)
   set(VERONAP ${VERONAP}.exe)
+  set(VERONAM ${VERONAM}.exe)
 endif()
 
 function(subdirlist result curdir)
@@ -52,7 +54,7 @@ endfunction()
 
 function(add_tests mode dir)
   set(testdir ${CMAKE_CURRENT_SOURCE_DIR}/${dir}/${mode})
-  file(GLOB filenames RELATIVE ${testdir} ${testdir}/*.verona)
+  file(GLOB filenames RELATIVE ${testdir} ${testdir}/*.verona ${testdir}/*.mlir)
   foreach(filename ${filenames})
     get_filename_component(stem ${filename} NAME_WE)
     set(testname ${dir}/${mode}/${stem})
@@ -64,6 +66,7 @@ function(add_tests mode dir)
       -DVERONAC=${VERONAC}
       -DINTERPRETER=${VERONAI}
       -DPARSER=${VERONAP}
+      -DMLIRGEN=${VERONAM}
       -DGRAMMAR=${CMAKE_INSTALL_PREFIX}/grammar.peg
       -DFILECHECK=${FILECHECK}
       -DSOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}
@@ -80,6 +83,7 @@ foreach(TEST_FOLDER ${TEST_FOLDERS})
   add_tests(compile-fail ${TEST_FOLDER})
   add_tests(run-pass ${TEST_FOLDER})
   add_tests(ast-parse ${TEST_FOLDER})
+  add_tests(mlir-parse ${TEST_FOLDER})
 endforeach()
 
 set_tests_properties(
@@ -100,6 +104,7 @@ add_custom_target(update-dump COMMAND ${CMAKE_COMMAND}
   -DPYTHON_EXECUTABLE=${Python3_EXECUTABLE}
   -DVERONAC=${VERONAC}
   -DPARSER=${VERONAP}
+  -DMLIRGEN=${VERONAM}
   -DGRAMMAR=${CMAKE_INSTALL_PREFIX}/grammar.peg
   -DPROJECT_SOURCE_DIR=${PROJECT_SOURCE_DIR}
   -P ${CMAKE_CURRENT_SOURCE_DIR}/update-dump.cmake)

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -7,7 +7,7 @@ to. Within each top-level directory, tests are further split by _mode_.
 Each test's expectations depends on its mode.
 - `compile-pass`: Compilation must succeed.
 - `compile-fail`: Compilation must fail. The compiler's standard error will be
-  compared against the test file using `FileCheck`.
+  compared against the test file using `OutputCheck`.
 
 Each mode is implemented by a `.cmake` file at the top of the testsuite
 directory.

--- a/testsuite/mlir-parse.cmake
+++ b/testsuite/mlir-parse.cmake
@@ -1,0 +1,20 @@
+include(${CMAKE_CURRENT_LIST_DIR}/common.cmake)
+
+set(ACTUAL_DUMP ${CMAKE_CURRENT_BINARY_DIR}/${TEST_NAME})
+
+PrepareTest(VERONAM_FLAGS EXPECTED_DUMP ACTUAL_DUMP)
+
+execute_process(
+  COMMAND ${MLIRGEN} -g ${GRAMMAR} ${TEST_FILE} -o -
+  OUTPUT_FILE ${ACTUAL_DUMP}/out.mlir
+  RESULT_VARIABLE EXIT_CODE)
+
+if(NOT ${EXIT_CODE} EQUAL 0)
+  file(READ ${ACTUAL_DUMP}/out.mlir ERROR_MESSAGES)
+  message(STATUS "OUTPUT:\n${ERROR_MESSAGES}")
+  message(FATAL_ERROR " ${MLIRGEN} exited with error code ${EXIT_CODE}")
+endif()
+
+if(EXPECTED_DUMP)
+  CheckDump(${EXPECTED_DUMP} ${ACTUAL_DUMP})
+endif()

--- a/testsuite/mlir/mlir-parse/dummy.mlir
+++ b/testsuite/mlir/mlir-parse/dummy.mlir
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: verona-mlir %s -o - | verona-mlir | FileCheck %s
+
+module {
+  // CHECK: func @bar(%arg0: !verona.U64) -> !type<"U64 & imm"> {
+  func @bar(%arg0: !verona.U64) -> !type<"U64 & imm"> {
+    // CHECK: %[[res:[0-9]+]] = verona.foo %arg0 : !verona.U64
+    %res = verona.foo %arg0 : !verona.U64
+    // CHECK: %[[cast:[0-9]+]] = "verona.cast"(%[[res]]) : (!verona.U64) -> !verona.S64
+    %cast = "verona.cast"(%res) : (!verona.U64) -> !verona.S64
+    // CHECK: %[[foo:[0-9]+]] = "verona.test"(%[[cast]]) : (!verona.S64) -> !type<"U64 & imm">
+    %foo = "verona.test"(%cast) : (!verona.S64) -> (!type<"U64 & imm">)
+    // CHECK: return %[[foo]] : !type<"U64 & imm">
+    return %foo : !type<"U64 & imm">
+  }
+}

--- a/testsuite/mlir/mlir-parse/dummy/out.mlir
+++ b/testsuite/mlir/mlir-parse/dummy/out.mlir
@@ -1,0 +1,10 @@
+
+
+module {
+  func @bar(%arg0: !verona.U64) -> !type<"U64 & imm"> {
+    %0 = verona.foo %arg0 : !verona.U64
+    %1 = "verona.cast"(%0) : (!verona.U64) -> !verona.S64
+    %2 = "verona.test"(%1) : (!verona.S64) -> !type<"U64 & imm">
+    return %2 : !type<"U64 & imm">
+  }
+}

--- a/testsuite/mlir/mlir-parse/function.verona
+++ b/testsuite/mlir/mlir-parse/function.verona
@@ -1,0 +1,23 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+// RUN: verona-mlir %s -o - | FileCheck %s
+
+// CHECK: func @foo(%arg0: !type.imm, %arg1: !type<"U64&imm">) -> !type<"U64&imm"> {
+foo(a: N, b: U64 & imm): R
+  where N: imm
+  where R: U64 & imm
+{
+  // CHECK: "verona.add"(%arg0, %arg1) : (!type.imm, !type<"U64&imm">) -> !type.ret
+  let x = a + b;
+  // This is just an alias to x
+  let r: R = x;
+  // CHECK: "verona.cast"(%{{.*}}) : (!type.ret) -> !type<"U64&imm">
+  // CHECK: return %1 : !type<"U64&imm">
+  x
+}
+
+// CHECK: func @apply() -> none
+// CHECK: "verona.none"() : () -> none
+// CHECK: return %{{.*}} : none
+(){}

--- a/testsuite/mlir/mlir-parse/function/out.mlir
+++ b/testsuite/mlir/mlir-parse/function/out.mlir
@@ -1,0 +1,13 @@
+
+
+module {
+  func @foo(%arg0: !type.imm, %arg1: !type<"U64&imm">) -> !type<"U64&imm"> {
+    %0 = "verona.add"(%arg0, %arg1) : (!type.imm, !type<"U64&imm">) -> !type.ret
+    %1 = "verona.cast"(%0) : (!type.ret) -> !type<"U64&imm">
+    return %1 : !type<"U64&imm">
+  }
+  func @apply() -> none {
+    %0 = "verona.none"() : () -> none
+    return %0 : none
+  }
+}

--- a/testsuite/update-dump.cmake
+++ b/testsuite/update-dump.cmake
@@ -15,6 +15,16 @@ foreach(TEST_FOLDER ${TEST_FOLDERS})
         COMMAND ${PARSER} -a -g ${GRAMMAR} ${PARSE_TEST}
         OUTPUT_FILE ${OUT_FILE})
     endforeach()
+  elseif(${TEST_FOLDER} MATCHES ".*/mlir")
+    file(GLOB MLIR_TESTS "${TEST_FOLDER}/mlir-parse/*.verona" "${TEST_FOLDER}/mlir-parse/*.mlir")
+    foreach(MLIR_TEST ${MLIR_TESTS})
+      get_filename_component(TEST_NAME ${MLIR_TEST} NAME_WE)
+      set(OUT_FILE ${TEST_FOLDER}/mlir-parse/${TEST_NAME}/out.mlir)
+      message(STATUS "Regenerating ${OUT_FILE}")
+      execute_process(
+        COMMAND ${MLIRGEN} -g ${GRAMMAR} ${PARSE_TEST} -o -
+        OUTPUT_FILE ${OUT_FILE})
+    endforeach()
   else()
     execute_process(COMMAND ${PYTHON_EXECUTABLE}
       ${PROJECT_SOURCE_DIR}/utils/update_dump.py

--- a/utils/llvm/setup-llvm-builddir.sh
+++ b/utils/llvm/setup-llvm-builddir.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Sets up the build dir by downloading the tar ball from Azure, unpacking on
+# the external repository and changing the cmake paths to the current dir
+
+set -e
+
+expected_args=1
+if [[ $# != $expected_args ]]; then
+  echo "Usage: $0 <image-file>"
+  exit 1
+fi
+
+git_root="$(git rev-parse --show-toplevel)"
+if [ "$?" != "0" ]; then
+  echo "Not in a git directory"
+  exit 1
+fi
+file="$1"
+image="$(basename $file .tar.gz)"
+
+# Download build cache
+if [ ! -f "$file" ]; then
+  echo "Downloading $image"
+  az artifacts universal download \
+    --organization "https://dev.azure.com/ProjectVeronaCI/" \
+    --project "22b49111-ce1d-420e-8301-3fea815478ea" \
+    --scope project \
+    --feed "LLVMBuild" \
+    --name "$image" \
+    --version "*" \
+    --path /tmp
+fi
+if [ ! -f "$file" ]; then
+  echo "$file not downloaded correctly"
+  exit 1
+fi
+
+# Unpack into llvm's directory
+llvm_root="$git_root/external/llvm-project"
+echo "Rebuilding LLVM's build directory: $llvm_root/build"
+rm -rf "$llvm_root/build"
+tar zxf "$file" --directory "$llvm_root"
+
+# Find what's the LLVM's build root dir
+# cmake_install.cmake is quite helpful, its first line is:
+# Install script for directory: C:/agent/_work/1/s/llvm
+devops_root="$(head -n 1 $llvm_root/build/cmake_install.cmake | perl -ne 'print $1 if / ([A-Z]?:?\/.*?)\/llvm/')"
+
+# Change LLVMConfig with current path
+echo "Replacing CMake paths: $devops_root -> $llvm_root"
+for file in $(find "$llvm_root/build" -name \*.cmake); do
+  perl -pi -e "s,$devops_root,$llvm_root,g" "$file"
+done


### PR DESCRIPTION
This is the initial prototype for the MLIR lowering from Verona code.

It has the main features:
1. Creates an MLIR Generator, that transforms the AST into MLIR nodes. For now it can only lower one file, `function.verona` and does so in an opaque MLIR format (no dialect). It does not have a dialect yet.
2. A prototype of a dialect, empty, but with the minimal structure of an out-of-tree dialect to follow up when we start having proper Verona nodes.
3. A thin layer between AST and MLIR, to help convert the semantics between the two. It's far from complete, but it's an idea on how we should interface these two completely different representations.
4. Adds a LIT + FileCheck testing structure with 3 tests (including `function.verona`).
5. Adds an LLVM build CI loop, where we cache the LLVM builds on Azure artefacts.
6. It uses the artefacts to test Verona without building LLVM from scratch. The artefact can also be used by developers on their machines via the same script the CI uses.

It has the main problems:
1. The Generator's public API is crude. It needs to account that we'll be using it to drive code through MLIR and LLVM, not always printing them to files.
2. Error handling is primitive. Uses the `Error` from `ast` for parsing the source files, but relies on throwing exceptions for the MLIR public API. This should be clearer once we have a better public API.
3. The Windows Debug image for LLVM is too large for our Verona builder and we run out of disk. All other tests pass, including Windows Release, so I'm confident this is just a space issue. We need to decide how we're going to fix that.
4. The code is precariously generating opaque types and operations and not checking for anything. There are various asserts spread around to help convey meaning, but until we have a robust interface between AST and MLIR, and between the opaque MLIR and the Verona dialect, we won't know for sure what's the best way to lower to MLIR.
5. Lowering to LLVM only works when the MLIR is in standard dialect, which the opaque syntax is clearly not. We need to lower to Standard dialect first, then to LLVM, and that will take a while. I just left the code there as boilerplate.

I'm expecting a long round of comments, changes, fixing the CI, etc. But I also expect this to not develop into a full blown MLIR engine before merging. This is a first approach to the problem, and it would be faster and easier to discuss and fix those problems upstream.
