### PR TITLE
Rewrite object hashmap

### DIFF
--- a/src/rt/ds/hashmap.h
+++ b/src/rt/ds/hashmap.h
@@ -69,18 +69,18 @@ namespace verona::rt
     struct inspect_entry_type<K*> : std::true_type
     {
       static_assert(std::is_base_of_v<Object, K>);
-      using key_type = K*;
-      using value_type = key_type;
-      using entry_view = key_type;
+      using key_type = K;
+      using value_type = key_type*;
+      using entry_view = value_type;
       static constexpr bool is_set = true;
     };
     template<typename K, typename V>
     struct inspect_entry_type<std::pair<K*, V>> : std::true_type
     {
       static_assert(std::is_base_of_v<Object, K>);
-      using key_type = K*;
+      using key_type = K;
       using value_type = V;
-      using entry_view = std::pair<key_type, V*>;
+      using entry_view = std::pair<key_type*, V*>;
       static constexpr bool is_set = false;
     };
 
@@ -195,9 +195,9 @@ namespace verona::rt
       Iterator(const ObjectMap& m, size_t i) : map(m), index(i) {}
 
     public:
-      KeyType key()
+      KeyType* key()
       {
-        return (KeyType)unmark_key(key_of(entry()));
+        return (KeyType*)unmark_key(key_of(entry()));
       }
 
       template<bool v = !is_set, typename = typename std::enable_if_t<v>>
@@ -309,7 +309,7 @@ namespace verona::rt
      * corresponding entry. If no entry exitsts, the return value will be equal
      * to the return value of `end()`.
      */
-    Iterator find(const KeyType key) const
+    Iterator find(const KeyType* key) const
     {
       if (key == nullptr)
         return end();
@@ -389,7 +389,7 @@ namespace verona::rt
      * Remove an entry from the map corresponding to the given key. The return
      * value is false if no entry was found for the key and true otherwise.
      */
-    bool erase(Alloc* alloc, const KeyType key)
+    bool erase(Alloc* alloc, const KeyType* key)
     {
       auto it = find(key);
       if (it == end())
@@ -466,8 +466,8 @@ namespace verona::rt
           out << " ∅";
           continue;
         }
-        out << " (" << (const KeyType)unmark_key(key_of(slots[i])) << ", probe "
-            << (size_t)probe_index(key) << ")";
+        out << " (" << (const KeyType*)unmark_key(key_of(slots[i]))
+            << ", probe " << (size_t)probe_index(key) << ")";
       }
       out << " } cap: " << capacity();
       return out;

--- a/src/rt/ds/hashmap.h
+++ b/src/rt/ds/hashmap.h
@@ -338,8 +338,7 @@ namespace verona::rt
     template<typename E>
     std::pair<bool, Iterator> insert(Alloc* alloc, E entry)
     {
-      // Resize at ~.8 load factor.
-      if (size() >= ((capacity() * 4) / 5))
+      if (unlikely(size() == capacity()))
         resize(alloc);
 
       assert(key_of(entry) != 0);

--- a/src/rt/ds/hashmap.h
+++ b/src/rt/ds/hashmap.h
@@ -3,23 +3,19 @@
 #pragma once
 
 #include "../object/object.h"
-#include "mem/allocconfig.h"
 
 namespace verona::rt
 {
   template<typename Entry>
   struct DefaultMapCallbacks
   {
-    static void on_insert(Entry&) {}
-    static void on_erase(Entry&) {}
+    static void on_insert(Alloc*, Entry&) {}
+    static void on_erase(Alloc*, Entry&) {}
   };
 
   /**
-   * Robinhood hashmap from Object* to Value. The Entry is either Object*,
-   * using hashmap as a set, or std::pair{Object*, Value}.
-   *
-   * The key must be Object*, because the low bits are used to encode marking
-   * status (MARK) and distance-to-initial-bucket (DIB).
+   * Robin Hood hash map where the key type is `K*`, where `K` is derrived from
+   * `Object`. The `Entry` type must be either `K*` or `std::pair<K*, Value>`.
    *
    * Static callbacks may be supplied as the second template parameter as
    * follows:
@@ -40,57 +36,43 @@ namespace verona::rt
    *
    *   using MyMap = PtrKeyHashMap<std::pair<Object*, uint8_t>, MyMapCallbacks>;
    *   ```
-   *   Note that all callbacks will have the low bits of the Entry key unmarked
-   *   so that it may be used as expected.
    */
   template<typename Entry, typename CB = DefaultMapCallbacks<Entry>>
-  class PtrKeyHashMap
+  class ObjectMap
   {
-  private:
-    // Number of elements present and size of the array.
-    size_t count = 0;
-    Entry* set = nullptr;
+    Entry* slots;
+    size_t filled_slots = 0;
+    uint8_t capacity_shift;
+    uint8_t longest_probe = 0;
 
-    // Compact representation of the allocated size of the set as a bit count.
-    uint8_t size_bits = 0;
+    /**
+     * The key type must be derrived from `Object` because the low bits are used
+     * to encode a mark bit and the probe length of the entry from its ideal
+     * slot.
+     */
+    static constexpr uintptr_t MARK_MASK = Object::ALIGNMENT >> 1;
+    static constexpr uintptr_t PROBE_MASK = MARK_MASK - 1;
 
-    static constexpr uint8_t INITIAL_SIZE_BITS = 3;
-    static constexpr uint8_t MARK = 1 << (MIN_ALLOC_BITS - 1);
-    static constexpr size_t DIB_MAX = MARK - 1;
-    static constexpr uintptr_t POINTER_MASK =
-      ~(((uintptr_t)1 << MIN_ALLOC_BITS) - 1);
-
-    // Both the Object and hashmap implementations steal some of the bottom
-    // bits of an Object* pointer. The number of bits used may not be the
-    // same, but we need to reserve the same number of bits and not use those
-    // bits for addressing, which affects Object alignment.
-    static_assert(~(POINTER_MASK | DIB_MAX | MARK) == 0);
-    static_assert(~(POINTER_MASK | Object::MASK) == 0);
-
-    inline static Object* get_pointer(size_t p)
-    {
-      // The Object* returned will retain its RememberedSet mark bit, but not
-      // its dib.
-      return (Object*)(p & ~DIB_MAX);
-    }
+    static_assert((MARK_MASK & PROBE_MASK) == 0);
+    static_assert(((MARK_MASK | PROBE_MASK) & ~Object::MASK) == 0);
 
     template<typename>
     struct inspect_entry_type : std::false_type
     {};
-
-    template<>
-    struct inspect_entry_type<Object*> : std::true_type
+    template<typename K>
+    struct inspect_entry_type<K*> : std::true_type
     {
-      using value_type = Object*;
+      static_assert(std::is_base_of_v<Object, K>);
+      using value_type = K*;
       using entry_view = value_type;
       static constexpr bool is_set = true;
     };
-
-    template<typename V>
-    struct inspect_entry_type<std::pair<Object*, V>> : std::true_type
+    template<typename K, typename V>
+    struct inspect_entry_type<std::pair<K*, V>> : std::true_type
     {
+      static_assert(std::is_base_of_v<Object, K>);
       using value_type = V;
-      using entry_view = std::pair<Object*, V*>;
+      using entry_view = std::pair<K*, V*>;
       static constexpr bool is_set = false;
     };
 
@@ -102,6 +84,9 @@ namespace verona::rt
     using EntryView = typename inspect_entry_type<Entry>::entry_view;
     static constexpr bool is_set = inspect_entry_type<Entry>::is_set;
 
+    /**
+     * Return a reference to the entry key.
+     */
     static uintptr_t& key_of(Entry& entry)
     {
       if constexpr (is_set)
@@ -110,141 +95,95 @@ namespace verona::rt
         return (uintptr_t&)entry.first;
     }
 
-    void grow(Alloc* alloc)
+    /**
+     * Return the original key value, where the low bits have been cleared.
+     */
+    static uintptr_t unmark_key(uintptr_t key)
     {
-      // Decide if we should grow or not. Grow at 75% capacity.
-      size_t size = get_size();
-      size_t grow_threshold = (size * 3) / 4;
-
-      if (count < grow_threshold)
-        return;
-
-      Entry* old_set = set;
-      size_t old_size = size;
-      count = 0;
-      assert(size_bits < UINT8_MAX);
-      size_bits =
-        (size_bits > 0) ? (uint8_t)(size_bits + 1) : INITIAL_SIZE_BITS;
-      size = get_size();
-
-      set = (Entry*)alloc->alloc<YesZero>(size * sizeof(Entry));
-
-      if (old_set != nullptr)
-      {
-        for (size_t index = 0; index < old_size; index++)
-        {
-          auto& entry = old_set[index];
-          const auto key = unmark_key(key_of(entry));
-          if (key != 0)
-          {
-            insert(alloc, entry);
-          }
-        }
-
-        alloc->dealloc(old_set, old_size * sizeof(size_t*));
-      }
-    }
-
-    void shrink(Alloc* alloc, size_t marked)
-    {
-      Entry* old_set = set;
-      size_t old_size = get_size();
-      count = 0;
-
-      size_bits = marked > 3 ?
-        (uint8_t)snmalloc::bits::next_pow2_bits(marked << 1) :
-        INITIAL_SIZE_BITS;
-
-      size_t size = get_size();
-      assert(size > 0);
-
-      set = (Entry*)alloc->alloc<YesZero>(size * sizeof(Entry));
-
-      if (old_size != 0)
-      {
-        for (size_t index = 0; index < old_size; index++)
-        {
-          auto& entry = old_set[index];
-          auto& key = key_of(entry);
-
-          if ((key & MARK) != 0)
-          {
-            key = unmark_key(key);
-            insert(alloc, entry);
-          }
-          else if (key != 0)
-          {
-            delete_entry(entry);
-          }
-        }
-
-        alloc->dealloc(old_set, old_size * sizeof(Entry));
-      }
-    }
-
-    inline size_t get_dib(size_t size, size_t index, uintptr_t key)
-    {
-      size_t dib = key & DIB_MAX;
-
-      if (dib == DIB_MAX)
-      {
-        // If we've encoded the maximum DIB, it could be an overflow.
-        // Recalculate the DIB.
-        size_t mask = size - 1;
-        dib = (index + size -
-               (verona::rt::bits::hash((void*)unmark_key(key)) & mask)) &
-          mask;
-      }
-
-      return dib;
-    }
-
-    template<typename E>
-    inline void set_entry(size_t index, E entry, size_t dib)
-    {
-      // When entry is passed in, it may or may not have a mark bit, but it
-      // must have no dib. If the DIB is greater than the maximum DIB, encode
-      // it as the maximum DIB. We will recalculate the real DIB when we
-      // fetch it.
-      auto& key = key_of(entry);
-      key = key | (dib < DIB_MAX ? dib : DIB_MAX);
-      set[index] = std::forward<E>(entry);
-    }
-
-    static void delete_entry(Entry& entry)
-    {
-      auto& key = key_of(entry);
-      key = unmark_key(key);
-      CB::on_erase(entry);
-      entry.~Entry();
-    }
-
-    inline size_t get_size()
-    {
-      return (size_t)1 << size_bits;
+      return key & ~Object::MASK;
     }
 
     /**
-     * This iterator enables range-based for-loop, traversing each non-empty
-     * Entry in the map.
+     * Return the probe index of the entry.
+     */
+    static size_t probe_index(uintptr_t key)
+    {
+      return (size_t)(key & PROBE_MASK);
+    }
+
+    /**
+     * Increase the allocation size by approximately 50%, rounded up to the
+     * nearest allocation size. The entries in the previous allocation will be
+     * reinserted.
+     */
+    void resize(Alloc* alloc)
+    {
+      auto prev = *this;
+
+      const auto alloc_size = bits::next_pow2(capacity() * sizeof(Entry) * 2);
+      slots = (Entry*)alloc->alloc<YesZero>(alloc_size);
+      capacity_shift = bits::ctz(alloc_size / sizeof(Entry));
+      filled_slots = 0;
+      longest_probe = 0;
+
+      for (auto it = prev.begin(); it != prev.end(); ++it)
+      {
+        if constexpr (is_set)
+          insert(alloc, it.key());
+        else
+          insert(alloc, std::make_pair(it.key(), std::move(it.value())));
+      }
+    }
+
+    /**
+     * Place an entry into the map at the given index, overwriting any existing
+     * entry. The probe bits of the key are set to `probe_len` and the
+     * `longest_probe` value is updated if `probe_len` is greater.
+     */
+    template<typename E>
+    void place_entry(E entry, size_t index, uint8_t probe_len)
+    {
+      slots[index] = std::forward<E>(entry);
+      auto& key = key_of(slots[index]);
+      assert(probe_len <= PROBE_MASK);
+      key = (key & ~PROBE_MASK) | probe_len;
+      if (probe_len > longest_probe)
+        longest_probe = probe_len;
+    }
+
+    /**
+     * Call a function using an `Entry&` where the key is temporarily reset to
+     * the original value.
+     */
+    template<typename F>
+    void call_cb(F f, Alloc* alloc, Entry& entry)
+    {
+      const auto key_swap = key_of(entry);
+      key_of(entry) = unmark_key(key_of(entry));
+      f(alloc, entry);
+      key_of(entry) = key_swap;
+    }
+
+  public:
+    /**
+     * Iterator over the entries in an `ObjectMap`, starting from a slot index.
      */
     class Iterator
     {
-    private:
       template<typename _Entry, typename _CB>
-      friend class PtrKeyHashMap;
+      friend class ObjectMap;
 
-      PtrKeyHashMap* map;
-      size_t i;
+      const ObjectMap& map;
+      size_t index;
 
       Entry& entry()
       {
-        return map->set[i];
+        return map.slots[index];
       }
 
-    public:
-      Iterator(PtrKeyHashMap* map_, size_t i_) : map{map_}, i{i_} {}
+      Iterator(const ObjectMap& m, size_t i) : map(m), index(i) {}
 
+    public:
       Object* key()
       {
         return (Object*)unmark_key(key_of(entry()));
@@ -256,411 +195,272 @@ namespace verona::rt
         return entry().second;
       }
 
+      bool is_marked()
+      {
+        return key_of(entry()) & MARK_MASK;
+      }
+
+      void mark()
+      {
+        key_of(entry()) |= MARK_MASK;
+      }
+
       EntryView operator*()
       {
-        auto* key = (Object*)unmark_key(key_of(entry()));
         if constexpr (is_set)
-          return key;
+          return key();
         else
-          return std::make_pair(key, &entry().second);
+          return std::make_pair(key(), &value());
       }
 
       Iterator& operator++()
       {
-        assert(map->count > 0);
-
-        auto size = map->get_size();
-        while (true)
+        while (++index < map.capacity())
         {
-          i++;
-          if (i == size)
-            break;
-          if (key_of(map->set[i]) != 0)
+          const auto key = key_of(map.slots[index]);
+          if (key != 0)
             break;
         }
-
         return *this;
       }
 
-      size_t get_index()
+      bool operator==(const Iterator& other) const
       {
-        return i;
+        return (index == other.index) && (&map == &other.map);
       }
 
-      bool operator!=(const Iterator& it) const
+      bool operator!=(const Iterator& other) const
       {
-        return i != it.i;
-      }
-
-      bool operator==(const Iterator& it) const
-      {
-        return i == it.i;
+        return !(*this == other);
       }
     };
 
-    // The key returned has no mark bits or dib.
-    static uintptr_t unmark_key(uintptr_t p)
+    /**
+     * Create an `ObjectMap` with an initial capacity for at least 8 entries.
+     */
+    ObjectMap(Alloc* alloc)
     {
-      assert(p != 0);
-      return p & POINTER_MASK;
+      static constexpr size_t init_alloc =
+        bits::next_pow2_const(sizeof(Entry) * 8);
+      capacity_shift = bits::ctz(init_alloc / sizeof(Entry));
+      slots = (Entry*)alloc->alloc<init_alloc, YesZero>();
     }
 
-  public:
-    static PtrKeyHashMap* create()
+    ~ObjectMap()
     {
-      auto r = ThreadAlloc::get()->alloc<sizeof(PtrKeyHashMap)>();
-      return new (r) PtrKeyHashMap();
+      dealloc(ThreadAlloc::get());
     }
 
-    Iterator begin()
+    static ObjectMap<Entry, CB>* create(Alloc* alloc)
     {
-      Iterator i{this, 0};
-      if (count == 0)
-      {
-        return i;
-      }
-      if (key_of(set[0]) != 0)
-      {
-        return i;
-      }
-      ++i;
-      return i;
+      return new (alloc->alloc<sizeof(ObjectMap<Entry, CB>)>())
+        ObjectMap(alloc);
     }
 
-    Iterator end()
+    void dealloc(Alloc* alloc)
     {
-      size_t c = (count == 0) ? 0 : get_size();
-      return Iterator(this, c);
+      clear(alloc);
+      alloc->dealloc(slots, capacity() * sizeof(Entry));
     }
 
-    void mark_slot(size_t index, size_t& marked)
+    /**
+     * Return the amount of entries in this map.
+     */
+    size_t size() const
     {
-      assert(index < get_size());
-      auto& key = key_of(set[index]);
-      assert(key != 0);
-
-      if ((key & MARK) == 0)
-      {
-        key = key | MARK;
-        marked++;
-      }
+      return filled_slots;
     }
 
-    template<bool require_destructor = true>
-    inline void dealloc(Alloc* alloc)
+    /**
+     * Return the capacity for entries in the map. Note that this should not be
+     * used to approximate when the map will resize.
+     */
+    size_t capacity() const
     {
-      if (size_bits > 0)
-      {
-        if (require_destructor)
-        {
-          auto size = get_size();
-          for (size_t i = 0; i < size; ++i)
-          {
-            auto& e = set[i];
-            if (key_of(e) != 0)
-            {
-              delete_entry(e);
-            }
-          }
-        }
-        alloc->dealloc(set, get_size() * sizeof(Entry));
-      }
+      return (1 << capacity_shift);
     }
 
-    // Returns true if newly added, false if previously present.
-    template<typename E>
-    bool insert(Alloc* alloc, E entry, size_t& location)
+    Iterator begin() const
     {
-      auto& orig_key = key_of(entry);
-      assert(orig_key == unmark_key(orig_key));
+      auto it = Iterator(*this, 0);
+      if (unmark_key(key_of(slots[0])) == 0)
+        ++it;
 
-      if (size_bits == 0)
-        grow(alloc);
-
-      size_t size = get_size();
-      size_t mask = size - 1;
-      size_t index = verona::rt::bits::hash((void*)orig_key) & mask;
-      size_t dib_entry = 0;
-
-      for (size_t i = 0; i <= mask; i++)
-      {
-        auto& other = set[index];
-        auto& other_key = key_of(other);
-
-        if (other_key == 0)
-        {
-          if (key_of(entry) == orig_key)
-            location = index;
-
-          // This index is empty, insert here.
-          uintptr_t key_swap = orig_key;
-          orig_key = unmark_key(orig_key);
-          CB::on_insert(entry);
-          orig_key = key_swap;
-
-          set_entry(index, std::forward<E>(entry), dib_entry);
-
-          count++;
-          grow(alloc);
-          return true;
-        }
-
-        size_t dib_other = get_dib(size, index, other_key);
-
-        if (dib_entry == dib_other)
-        {
-          // This entry is already present. This should only happen for the
-          // original o, not for any swapped pointer.
-          if (
-            (key_of(entry) == orig_key) &&
-            (key_of(entry) == unmark_key(other_key)))
-          {
-            location = index;
-            return false;
-          }
-        }
-        else if (dib_entry > dib_other)
-        {
-          auto tmp = std::move(other);
-
-          if (key_of(entry) == orig_key)
-            location = index;
-
-          // The DIB of the entry to insert is greater than the DIB of the
-          // entry at this index. Insert o here, and continue looking for
-          // somewhere to insert other.
-          set_entry(index, std::forward<E>(entry), dib_entry);
-
-          key_of(tmp) = (uintptr_t)get_pointer(key_of(tmp));
-          entry = std::move(tmp);
-          dib_entry = dib_other;
-        }
-
-        // Advance both the index, wrapping around, and the DIB.
-        index = (index + 1) & mask;
-        dib_entry++;
-      }
-
-      assert(0);
-      return false;
+      return it;
     }
 
-    template<typename E>
-    bool insert(Alloc* alloc, E entry)
+    Iterator end() const
     {
-      size_t dummy;
-      return insert(alloc, std::forward<E>(entry), dummy);
+      return Iterator(*this, capacity());
     }
 
-    template<typename E>
-    void insert_unique(Alloc* alloc, E entry)
+    /**
+     * Find an entry in the map with the given key and return an iterator to the
+     * corresponding entry. If no entry exitsts, the return value will be equal
+     * to the return value of `end()`.
+     */
+    Iterator find(const Object* key) const
     {
-      auto unique = insert(alloc, std::forward<E>(entry));
-      assert(unique);
-      UNUSED(unique);
-    }
-
-    void sweep_set(Alloc* alloc, size_t marked)
-    {
-      if (size_bits == 0)
-        return;
-
-      size_t size = get_size();
-
-      // If our marked object count is low, build a new set instead.
-      if (size_bits > INITIAL_SIZE_BITS)
-      {
-        size_t shrink_threshold = size >> 3;
-
-        if (marked <= shrink_threshold)
-        {
-          // Pick a size that can hold twice the marked count.
-          shrink(alloc, marked);
-          return;
-        }
-      }
-
-      size_t empty_dib = 0;
-      size_t fill_dib = 0;
-      count = marked;
-
-      for (size_t index = 0; index < size; index++)
-      {
-        auto& entry = set[index];
-        auto& key = key_of(entry);
-
-        if (key == 0)
-        {
-          if (fill_dib > 0)
-          {
-            empty_dib++;
-          }
-          else
-          {
-            empty_dib = 1;
-            fill_dib = 0;
-          }
-        }
-        else if ((key & MARK) != 0)
-        {
-          key = unmark_key(key);
-          size_t dib = get_dib(size, index, key);
-
-          if (dib == 0)
-          {
-            set[index] = std::move(entry);
-            empty_dib = 0;
-            fill_dib = 0;
-          }
-          else if (empty_dib == 0)
-          {
-            set_entry(index, entry, dib);
-            empty_dib = 0;
-            fill_dib = 0;
-          }
-          else
-          {
-            set_entry(
-              index - empty_dib + fill_dib, entry, dib - empty_dib + fill_dib);
-
-            key_of(set[index]) = 0;
-            empty_dib++;
-            fill_dib++;
-          }
-        }
-        else
-        {
-          delete_entry(set[index]);
-
-          key_of(set[index]) = 0;
-
-          if (fill_dib > 0)
-          {
-            empty_dib++;
-          }
-          else
-          {
-            empty_dib = 1;
-            fill_dib = 0;
-          }
-        }
-      }
-
-      if (empty_dib > 0)
-      {
-        size_t mask = size - 1;
-
-        for (size_t index = 0; index < size; index++)
-        {
-          auto& entry = set[index];
-          auto& key = key_of(entry);
-
-          size_t dib = get_dib(size, index, key);
-
-          if (dib > 0)
-          {
-            key = unmark_key(key);
-
-            set_entry(
-              (index - empty_dib + fill_dib + size) & mask,
-              entry,
-              dib - empty_dib + fill_dib);
-
-            key_of(set[index]) = 0;
-            empty_dib++;
-            fill_dib++;
-          }
-          else
-          {
-            break;
-          }
-        }
-      }
-    }
-
-    void clear(Alloc* alloc)
-    {
-      sweep_set(alloc, 0);
-    }
-
-    Iterator find(const Object* key)
-    {
-      if (count == 0)
-      {
+      if (key == nullptr)
         return end();
-      }
 
-      assert((uintptr_t)key == unmark_key((uintptr_t)key));
-
-      auto size = get_size();
-      auto mask = (uintptr_t)size - 1;
-      auto index = verona::rt::bits::hash((void*)key) & mask;
-      uintptr_t dib_entry = 0;
-
-      for (size_t i = 0; i <= mask; i++)
+      const auto hash = bits::hash((void*)key);
+      auto index = hash % capacity();
+      for (size_t probe_len = 0; probe_len <= longest_probe; probe_len++)
       {
-        auto& k = key_of(set[index]);
-        if (k == 0)
-        {
-          return end();
-        }
+        const auto k = unmark_key(key_of(slots[index]));
+        if (k == (uintptr_t)key)
+          return Iterator(*this, index);
 
-        auto dib_other = get_dib(size, index, k);
-
-        if (dib_entry == dib_other)
-        {
-          // This entry is already present. This should only happen for the
-          // original o, not for any swapped pointer.
-          if ((k == (uintptr_t)key) && (k == unmark_key(k)))
-          {
-            return {this, index};
-          }
-        }
-        else if (dib_entry > dib_other)
-        {
-          return end();
-        }
-
-        // Advance both the index, wrapping around, and the DIB.
-        index = (index + 1) & mask;
-        dib_entry++;
+        if (++index == capacity())
+          index = 0;
       }
 
-      assert(0);
       return end();
     }
 
-    void erase(const Object* p)
+    /**
+     * Insert an entry into the map. The first element of the returned pair will
+     * be true if a new key is inserted, and false if an existing entry is
+     * updated. The second element of the returned pair is an iterator to the
+     * inserted entry. The key of the inserted entry must not be null.
+     */
+    template<typename E>
+    std::pair<bool, Iterator> insert(Alloc* alloc, E entry)
     {
-      if (count == 0)
+      // Resize at ~.8 load factor.
+      if (size() >= ((capacity() * 4) / 5))
+        resize(alloc);
+
+      assert(key_of(entry) != 0);
+      const auto key = unmark_key(key_of(entry));
+      const auto hash = bits::hash((void*)key);
+      auto index = hash % capacity();
+
+      for (uint8_t probe_len = 0; probe_len <= PROBE_MASK; probe_len++)
       {
-        return;
+        const auto k = key_of(slots[index]);
+
+        if (unmark_key(k) == key)
+        { // Update existing entry.
+          if constexpr (!is_set)
+            entry.second = std::forward<E>(entry).second;
+
+          return std::make_pair(false, Iterator(*this, index));
+        }
+
+        if (k == 0)
+        { // Place into empty slot.
+          place_entry(std::forward<E>(entry), index, probe_len);
+          assert(!(key_of(slots[index]) & MARK_MASK));
+          filled_slots++;
+          call_cb(CB::on_insert, alloc, slots[index]);
+          return std::make_pair(true, Iterator(*this, index));
+        }
+
+        if (probe_index(k) < probe_len)
+        { // Robin Hood time. Swap with current slot and continue.
+          Entry swap = std::move(slots[index]);
+          place_entry(std::forward<E>(entry), index, probe_len);
+          entry = swap;
+          probe_len = probe_index(key_of(entry));
+        }
+
+        if (++index == capacity())
+          index = 0;
       }
-      auto i = find(p);
-      if (i == end())
+
+      // Maximum probe length reached, resize and retry.
+      resize(alloc);
+      return insert(alloc, std::forward<E>(entry));
+    }
+
+    /**
+     * Remove an entry from the map corresponding to the given key. The return
+     * value is false if no entry was found for the key and true otherwise.
+     */
+    bool erase(Alloc* alloc, const Object* key)
+    {
+      auto it = find(key);
+      if (it == end())
+        return false;
+
+      erase(alloc, it);
+      return true;
+    }
+
+    /**
+     * Remove an entry from the map at the given iterator position. The iterator
+     * must be valid. This operation will not invalidate the iterator.
+     */
+    void erase(Alloc* alloc, Iterator& it)
+    {
+      assert(key_of(it.entry()) != 0);
+
+      // No tombstones are necessary because our insertion algorithm relies on
+      // the the minimum probe length determined by the maximum value we can
+      // stash in the lower bits of the key.
+
+      call_cb(CB::on_erase, alloc, it.entry());
+      it.entry().~Entry();
+      key_of(it.entry()) = 0;
+      filled_slots--;
+    }
+
+    /**
+     * Empty the map, removing all entries. If `callback` is false, then the
+     * entries removed will not have the callback `on_erase` called with the
+     * removed entries.
+     */
+    void clear(Alloc* alloc, bool callback = true)
+    {
+      for (auto it = begin(); it != end(); ++it)
       {
-        return;
+        if (callback)
+          call_cb(CB::on_erase, alloc, it.entry());
+
+        it.entry().~Entry();
+        key_of(it.entry()) = 0;
       }
+      longest_probe = 0;
+      filled_slots = 0;
+    }
 
-      auto size = get_size();
-      auto mask = size - 1;
-      auto cur_index = i.get_index();
-      delete_entry(i.entry());
-      auto next_index = (cur_index + 1) & mask;
-
-      uintptr_t key = 0;
-      size_t dib = 0;
-      while ((key = key_of(set[next_index])) != 0 &&
-             (dib = get_dib(size, next_index, key)) != 0)
+    /**
+     * Erase all unmarked entries from the map and unmark the remaining entries.
+     */
+    void sweep(Alloc* alloc)
+    {
+      for (auto it = begin(); it != end(); ++it)
       {
-        set_entry(cur_index, set[next_index], dib - 1);
-
-        cur_index = next_index;
-        next_index = (next_index + 1) & mask;
+        if (!it.is_marked())
+          erase(alloc, it);
+        else
+          key_of(it.entry()) &= ~MARK_MASK;
       }
+    }
 
-      key_of(set[cur_index]) = 0;
-      count--;
+    /**
+     * Return a string representation of the map showing empty slots (`∅`),
+     * key positions, and probe lengths.
+     */
+    template<typename OutStream>
+    OutStream& debug_layout(OutStream& out) const
+    {
+      out << "{";
+      for (size_t i = 0; i < capacity(); i++)
+      {
+        const auto key = key_of(slots[i]);
+        if (key == 0)
+        {
+          out << " ∅";
+          continue;
+        }
+        out << " (" << (const Object*)unmark_key(key_of(slots[i])) << ", probe "
+            << (size_t)probe_index(key) << ")";
+      }
+      out << " } cap: " << capacity();
+      return out;
     }
   };
-} // namespace verona::rt
+}

--- a/src/rt/object/object.h
+++ b/src/rt/object/object.h
@@ -301,7 +301,7 @@ namespace verona::rt
     friend class RememberedSet;
     friend class ExternalReferenceTable;
     template<typename Entry, typename CB>
-    friend class PtrKeyHashMap;
+    friend class ObjectMap;
     friend class Message;
     friend class LocalEpoch;
 

--- a/src/rt/region/region_arena.h
+++ b/src/rt/region/region_arena.h
@@ -583,7 +583,7 @@ namespace verona::rt
       }
 
       // Sweep the RememberedSet, to ensure destructors are called.
-      hash_set->sweep_set(alloc, 0);
+      hash_set->sweep(alloc);
 
       // Deallocate RegionArena
       // Don't need to deallocate `o`, since it was part of the arena or ring.

--- a/src/rt/test/func/hashmap/hashmap.cc
+++ b/src/rt/test/func/hashmap/hashmap.cc
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include "ds/hashmap.h"
+
+#include "test/opt.h"
+#include "test/xoroshiro.h"
+#include "verona.h"
+
+#include <unordered_map>
+
+using namespace snmalloc;
+using namespace verona::rt;
+
+template<typename Entry, typename Model>
+bool model_check(
+  const ObjectMap<Entry>& map, const Model& model, std::stringstream& err)
+{
+  map.debug_layout(err) << "\n";
+
+  if (map.size() != model.size())
+  {
+    err << "map size (" << map.size() << ") is not expected (" << model.size()
+        << ")"
+        << "\n";
+    return false;
+  }
+
+  for (const auto& e : model)
+  {
+    auto it = map.find(e.first);
+    if (it == map.end())
+    {
+      err << "not found: " << e.first << "\n";
+      return false;
+    }
+    assert(!it.is_marked());
+  }
+
+  auto iter_model = model;
+  for (auto it = map.begin(); it != map.end(); ++it)
+    iter_model.erase(it.key());
+
+  for (const auto& e : iter_model)
+  {
+    err << "not found: " << e.first << "\n";
+    return false;
+  }
+
+  return true;
+}
+
+bool test(size_t seed)
+{
+  auto* alloc = ThreadAlloc::get();
+  ObjectMap<std::pair<Object*, int32_t>> map(alloc);
+  std::unordered_map<Object*, int32_t> model;
+
+  xoroshiro::p128r64 rng{seed};
+  std::stringstream err;
+
+  map.debug_layout(err) << "\n";
+
+  static constexpr size_t entries = 100;
+  for (size_t i = 0; i < entries; i++)
+  {
+    auto* key = (Object*)(rng.next() * Object::ALIGNMENT);
+    auto entry = std::make_pair(key, (int32_t)i);
+    err << "insert " << key << "\n";
+    model.insert(entry);
+    auto inserted = map.insert(alloc, entry).first;
+    if (!model_check(map, model, err))
+    {
+      std::cout << err.str() << std::flush;
+      return false;
+    }
+    assert(inserted);
+    UNUSED(inserted);
+
+    if (rng.next() % 10)
+    {
+      err << "update " << key << "\n";
+      entry.second = -entry.second;
+      model.insert(entry);
+      auto inserted = map.insert(alloc, entry).first;
+      if (!model_check(map, model, err))
+      {
+        std::cout << err.str() << std::flush;
+        return false;
+      }
+      assert(!inserted);
+      UNUSED(inserted);
+    }
+
+    if (rng.next() % 10)
+    {
+      err << "erase " << key << "\n";
+      model.erase(entry.first);
+      auto erased = map.erase(alloc, entry.first);
+      if (!model_check(map, model, err))
+      {
+        std::cout << err.str() << std::flush;
+        return false;
+      }
+      assert(erased);
+      UNUSED(erased);
+    }
+  }
+
+  return true;
+}
+
+int main(int argc, char** argv)
+{
+  opt::Opt opt(argc, argv);
+  auto seed = opt.is<size_t>("--seed", 5489);
+  const auto seed_upper = opt.is<size_t>("--seed_upper", seed);
+
+  for (; seed <= seed_upper; seed++)
+  {
+    std::cout << "seed: " << seed << std::endl;
+    if (!test(seed))
+      return 1;
+  }
+
+  return 0;
+}

--- a/src/rt/test/func/hashmap/hashmap.cc
+++ b/src/rt/test/func/hashmap/hashmap.cc
@@ -76,12 +76,12 @@ bool test(size_t seed)
     assert(inserted);
     UNUSED(inserted);
 
-    if (rng.next() % 10)
+    if ((rng.next() % 10) == 0)
     {
       err << "update " << key << "\n";
       entry.second = -entry.second;
       model.insert(entry);
-      auto inserted = map.insert(alloc, entry).first;
+      inserted = map.insert(alloc, entry).first;
       if (!model_check(map, model, err))
       {
         std::cout << err.str() << std::flush;
@@ -91,7 +91,7 @@ bool test(size_t seed)
       UNUSED(inserted);
     }
 
-    if (rng.next() % 10)
+    if ((rng.next() % 10) == 0)
     {
       err << "erase " << key << "\n";
       model.erase(entry.first);

--- a/src/rt/test/func/hashmap/hashmap.cc
+++ b/src/rt/test/func/hashmap/hashmap.cc
@@ -33,16 +33,22 @@ bool model_check(
       err << "not found: " << e.first << "\n";
       return false;
     }
-    assert(!it.is_marked());
+    else if (it.is_marked())
+    {
+      err << "marked: " << e.first << "\n";
+      return false;
+    }
   }
 
   auto iter_model = model;
   for (auto it = map.begin(); it != map.end(); ++it)
     iter_model.erase(it.key());
 
-  for (const auto& e : iter_model)
+  if (!iter_model.empty())
   {
-    err << "not found: " << e.first << "\n";
+    for (const auto& e : iter_model)
+      err << "not found: " << e.first << "\n";
+
     return false;
   }
 
@@ -73,8 +79,12 @@ bool test(size_t seed)
       std::cout << err.str() << std::flush;
       return false;
     }
-    assert(inserted);
-    UNUSED(inserted);
+
+    if (!inserted)
+    {
+      std::cout << err.str() << "not inserted: " << entry.first << std::flush;
+      return false;
+    }
 
     if ((rng.next() % 10) == 0)
     {
@@ -87,8 +97,12 @@ bool test(size_t seed)
         std::cout << err.str() << std::flush;
         return false;
       }
-      assert(!inserted);
-      UNUSED(inserted);
+
+      if (inserted)
+      {
+        std::cout << err.str() << "not updated: " << entry.first << std::flush;
+        return false;
+      }
     }
 
     if ((rng.next() % 10) == 0)
@@ -101,8 +115,12 @@ bool test(size_t seed)
         std::cout << err.str() << std::flush;
         return false;
       }
-      assert(erased);
-      UNUSED(erased);
+
+      if (!erased)
+      {
+        std::cout << err.str() << "not erased: " << entry.first << std::flush;
+        return false;
+      }
     }
   }
 


### PR DESCRIPTION
This PR makes several improvements over the initial implementation of
the hashmap. These improvements include documentation of member
functions and the internal algorithm used for the implementation. Tests
have also been added to compare the correctness of the map against the
standard `unordered_map` on randomized sequences of insert, update, and
delete operations.