### PR TITLE
Update copyright headers.

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -235,8 +235,8 @@ jobs:
   - script: |
       set -eo pipefail
       files=`git ls-files -- '*.cpp' '*.cc' '*.h' '*.hh' '*.verona'| xargs`
-      grep -L "Copyright (c)"  $files | tee header_missing
+      grep -L "Copyright Microsoft and Project Verona Contributors."  $files | tee header_missing
       [ ! -s header_missing ]
-      grep -L "Licensed under the MIT License." $files | tee header_missing
+      grep -L "SPDX-License-Identifier: MIT" $files | tee header_missing
       [ ! -s header_missing ]
     displayName: 'Check Copyright and License'

--- a/src/ast/ast.cc
+++ b/src/ast/ast.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "ast.h"
 
 namespace ast

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <peglib.h>

--- a/src/ast/cli.cc
+++ b/src/ast/cli.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "cli.h"
 
 #include "path.h"

--- a/src/ast/cli.h
+++ b/src/ast/cli.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <string>

--- a/src/ast/dfs.h
+++ b/src/ast/dfs.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 namespace dfs

--- a/src/ast/err.cc
+++ b/src/ast/err.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "err.h"
 
 namespace err

--- a/src/ast/err.h
+++ b/src/ast/err.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "ast.h"

--- a/src/ast/files.cc
+++ b/src/ast/files.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "files.h"
 
 namespace files

--- a/src/ast/files.h
+++ b/src/ast/files.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "err.h"

--- a/src/ast/lit.cc
+++ b/src/ast/lit.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "lit.h"
 
 using namespace peg::udl;

--- a/src/ast/lit.h
+++ b/src/ast/lit.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "ast.h"

--- a/src/ast/main.cc
+++ b/src/ast/main.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "cli.h"
 #include "module.h"
 #include "prec.h"

--- a/src/ast/module.cc
+++ b/src/ast/module.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "module.h"
 
 #include "path.h"

--- a/src/ast/module.h
+++ b/src/ast/module.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "ast.h"

--- a/src/ast/parser.cc
+++ b/src/ast/parser.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "parser.h"
 
 #include "files.h"

--- a/src/ast/parser.h
+++ b/src/ast/parser.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "ast.h"

--- a/src/ast/path.cc
+++ b/src/ast/path.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "path.h"
 
 #include <algorithm>

--- a/src/ast/path.h
+++ b/src/ast/path.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <string>

--- a/src/ast/prec.cc
+++ b/src/ast/prec.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "prec.h"
 
 using namespace peg::udl;

--- a/src/ast/prec.h
+++ b/src/ast/prec.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "ast.h"

--- a/src/ast/ref.cc
+++ b/src/ast/ref.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "ref.h"
 
 using namespace peg::udl;

--- a/src/ast/ref.h
+++ b/src/ast/ref.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "ast.h"

--- a/src/ast/sym.cc
+++ b/src/ast/sym.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "sym.h"
 
 #include "lit.h"

--- a/src/ast/sym.h
+++ b/src/ast/sym.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "ast.h"

--- a/src/compiler/analysis.cc
+++ b/src/compiler/analysis.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/analysis.h"
 
 #include "compiler/dataflow/liveness.h"

--- a/src/compiler/analysis.h
+++ b/src/compiler/analysis.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/dataflow/liveness.h"

--- a/src/compiler/assignssymbols.h
+++ b/src/compiler/assignssymbols.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 #include "recursive_visitor.h"
 

--- a/src/compiler/ast.cc
+++ b/src/compiler/ast.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/ast.h"
 
 #include "compiler/format.h"

--- a/src/compiler/ast.h
+++ b/src/compiler/ast.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/context.h"

--- a/src/compiler/codegen/builtins.cc
+++ b/src/compiler/codegen/builtins.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/codegen/builtins.h"
 
 #include "compiler/codegen/generator.h"

--- a/src/compiler/codegen/builtins.h
+++ b/src/compiler/codegen/builtins.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/codegen/function.h"

--- a/src/compiler/codegen/codegen.cc
+++ b/src/compiler/codegen/codegen.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/codegen/codegen.h"
 
 #include "compiler/ast.h"

--- a/src/compiler/codegen/codegen.h
+++ b/src/compiler/codegen/codegen.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/analysis.h"

--- a/src/compiler/codegen/descriptor.cc
+++ b/src/compiler/codegen/descriptor.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/codegen/descriptor.h"
 
 #include "ds/helpers.h"

--- a/src/compiler/codegen/descriptor.h
+++ b/src/compiler/codegen/descriptor.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/codegen/reachability.h"

--- a/src/compiler/codegen/function.cc
+++ b/src/compiler/codegen/function.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/codegen/function.h"
 
 #include "compiler/codegen/builtins.h"

--- a/src/compiler/codegen/function.h
+++ b/src/compiler/codegen/function.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/analysis.h"

--- a/src/compiler/codegen/generator.cc
+++ b/src/compiler/codegen/generator.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/codegen/generator.h"
 
 #include "ds/helpers.h"

--- a/src/compiler/codegen/generator.h
+++ b/src/compiler/codegen/generator.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "interpreter/bytecode.h"

--- a/src/compiler/codegen/ir.h
+++ b/src/compiler/codegen/ir.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/codegen/function.h"
 #include "compiler/ir/ir.h"
 #include "compiler/printing.h"

--- a/src/compiler/codegen/reachability.cc
+++ b/src/compiler/codegen/reachability.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/codegen/reachability.h"
 
 #include "compiler/analysis.h"

--- a/src/compiler/codegen/reachability.h
+++ b/src/compiler/codegen/reachability.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/ast.h"

--- a/src/compiler/codegen/selector.cc
+++ b/src/compiler/codegen/selector.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/codegen/selector.h"
 
 #include "compiler/codegen/reachability.h"

--- a/src/compiler/codegen/selector.h
+++ b/src/compiler/codegen/selector.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/type.h"

--- a/src/compiler/coercion.h
+++ b/src/compiler/coercion.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/recursive_visitor.h"

--- a/src/compiler/context.cc
+++ b/src/compiler/context.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/context.h"
 
 #include "compiler/freevars.h"

--- a/src/compiler/context.h
+++ b/src/compiler/context.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/intern.h"

--- a/src/compiler/dataflow/backwards_analysis.h
+++ b/src/compiler/dataflow/backwards_analysis.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/dataflow/work_set.h"

--- a/src/compiler/dataflow/liveness.cc
+++ b/src/compiler/dataflow/liveness.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/dataflow/liveness.h"
 
 #include "compiler/dataflow/use_def.h"

--- a/src/compiler/dataflow/liveness.h
+++ b/src/compiler/dataflow/liveness.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/dataflow/backwards_analysis.h"

--- a/src/compiler/dataflow/liveness_reason.h
+++ b/src/compiler/dataflow/liveness_reason.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/dataflow/backwards_analysis.h"

--- a/src/compiler/dataflow/use_def.h
+++ b/src/compiler/dataflow/use_def.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/dataflow/variable_set.h"

--- a/src/compiler/dataflow/variable_set.h
+++ b/src/compiler/dataflow/variable_set.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/ir/variable.h"

--- a/src/compiler/dataflow/work_set.h
+++ b/src/compiler/dataflow/work_set.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/ir/ir.h"

--- a/src/compiler/elaboration.cc
+++ b/src/compiler/elaboration.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/elaboration.h"
 
 #include "compiler/visitor.h"

--- a/src/compiler/elaboration.h
+++ b/src/compiler/elaboration.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/ast.h"

--- a/src/compiler/fixpoint.cc
+++ b/src/compiler/fixpoint.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/fixpoint.h"
 
 namespace verona::compiler

--- a/src/compiler/fixpoint.h
+++ b/src/compiler/fixpoint.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/mapper.h"

--- a/src/compiler/format.h
+++ b/src/compiler/format.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <memory>

--- a/src/compiler/freevars.h
+++ b/src/compiler/freevars.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/visitor.h"

--- a/src/compiler/fs.h
+++ b/src/compiler/fs.h
@@ -1,5 +1,5 @@
-// Copyright (c) Contributers to Project Verona. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/compiler/instantiation.h
+++ b/src/compiler/instantiation.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/ast.h"

--- a/src/compiler/intern.cc
+++ b/src/compiler/intern.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/intern.h"
 
 #include "compiler/format.h"

--- a/src/compiler/intern.h
+++ b/src/compiler/intern.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/type.h"

--- a/src/compiler/ir/builder.cc
+++ b/src/compiler/ir/builder.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/ir/builder.h"
 
 #include "compiler/zip.h"

--- a/src/compiler/ir/builder.h
+++ b/src/compiler/ir/builder.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 #include "compiler/assignssymbols.h"
 #include "compiler/ir/ir.h"

--- a/src/compiler/ir/dominance.cc
+++ b/src/compiler/ir/dominance.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/ir/dominance.h"
 
 namespace verona::compiler

--- a/src/compiler/ir/dominance.h
+++ b/src/compiler/ir/dominance.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/ir/ir.h"

--- a/src/compiler/ir/ir.cc
+++ b/src/compiler/ir/ir.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/ir/ir.h"
 
 #include "compiler/format.h"

--- a/src/compiler/ir/ir.h
+++ b/src/compiler/ir/ir.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/ast.h"

--- a/src/compiler/ir/point.cc
+++ b/src/compiler/ir/point.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/ir/point.h"
 
 #include "compiler/ir/ir.h"

--- a/src/compiler/ir/point.h
+++ b/src/compiler/ir/point.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <iosfwd>

--- a/src/compiler/ir/print.cc
+++ b/src/compiler/ir/print.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/ir/print.h"
 
 #include "compiler/format.h"

--- a/src/compiler/ir/print.h
+++ b/src/compiler/ir/print.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/dataflow/liveness.h"

--- a/src/compiler/ir/type_arguments.h
+++ b/src/compiler/ir/type_arguments.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <cstdint>

--- a/src/compiler/ir/variable.h
+++ b/src/compiler/ir/variable.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/local_id.h"

--- a/src/compiler/ir/variable_renaming.cc
+++ b/src/compiler/ir/variable_renaming.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/ir/variable_renaming.h"
 
 #include "compiler/format.h"

--- a/src/compiler/ir/variable_renaming.h
+++ b/src/compiler/ir/variable_renaming.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 #include "compiler/ir/variable.h"
 

--- a/src/compiler/local_id.h
+++ b/src/compiler/local_id.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "pegmatite.hh"

--- a/src/compiler/main.cc
+++ b/src/compiler/main.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 #include "compiler/analysis.h"
 #include "compiler/ast.h"

--- a/src/compiler/mapper.cc
+++ b/src/compiler/mapper.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/mapper.h"
 
 #include "ds/helpers.h"

--- a/src/compiler/mapper.h
+++ b/src/compiler/mapper.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/visitor.h"

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/parser.h"
 
 #include "compiler/ast.h"

--- a/src/compiler/parser.h
+++ b/src/compiler/parser.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/ast.h"

--- a/src/compiler/pegmatite-extra.h
+++ b/src/compiler/pegmatite-extra.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 #include <pegmatite.hh>
 

--- a/src/compiler/polarize.cc
+++ b/src/compiler/polarize.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/polarize.h"
 
 #include "compiler/freevars.h"

--- a/src/compiler/polarize.h
+++ b/src/compiler/polarize.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/context.h"

--- a/src/compiler/printing.cc
+++ b/src/compiler/printing.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/printing.h"
 
 #include "compiler/format.h"

--- a/src/compiler/printing.h
+++ b/src/compiler/printing.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/ast.h"

--- a/src/compiler/recursive_visitor.h
+++ b/src/compiler/recursive_visitor.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/visitor.h"

--- a/src/compiler/region.h
+++ b/src/compiler/region.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/ir/variable.h"

--- a/src/compiler/regionck/check_regions.h
+++ b/src/compiler/regionck/check_regions.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/dataflow/liveness_reason.h"
 #include "compiler/typecheck/capability_predicate.h"
 #include "compiler/zip.h"

--- a/src/compiler/regionck/region_graph.cc
+++ b/src/compiler/regionck/region_graph.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/regionck/region_graph.h"
 
 #include "compiler/format.h"

--- a/src/compiler/regionck/region_graph.h
+++ b/src/compiler/regionck/region_graph.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 #include "compiler/ir/ir.h"
 

--- a/src/compiler/resolution.cc
+++ b/src/compiler/resolution.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/resolution.h"
 
 #include "compiler/ast.h"

--- a/src/compiler/resolution.h
+++ b/src/compiler/resolution.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/ast.h"

--- a/src/compiler/source_manager.h
+++ b/src/compiler/source_manager.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 #include "ds/helpers.h"
 

--- a/src/compiler/substitution.h
+++ b/src/compiler/substitution.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/ast.h"

--- a/src/compiler/traits.h
+++ b/src/compiler/traits.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <type_traits>

--- a/src/compiler/type.cc
+++ b/src/compiler/type.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/type.h"
 
 #include "compiler/context.h"

--- a/src/compiler/type.h
+++ b/src/compiler/type.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/ir/variable_renaming.h"

--- a/src/compiler/typecheck/assertion.cc
+++ b/src/compiler/typecheck/assertion.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/typecheck/assertion.h"
 
 #include "compiler/context.h"

--- a/src/compiler/typecheck/assertion.h
+++ b/src/compiler/typecheck/assertion.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/ast.h"

--- a/src/compiler/typecheck/capability_predicate.cc
+++ b/src/compiler/typecheck/capability_predicate.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/typecheck/capability_predicate.h"
 
 #include "compiler/printing.h"

--- a/src/compiler/typecheck/capability_predicate.h
+++ b/src/compiler/typecheck/capability_predicate.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/mapper.h"

--- a/src/compiler/typecheck/constraint.cc
+++ b/src/compiler/typecheck/constraint.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/typecheck/constraint.h"
 
 #include "compiler/ast.h"

--- a/src/compiler/typecheck/constraint.h
+++ b/src/compiler/typecheck/constraint.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/ast.h"

--- a/src/compiler/typecheck/indirect_type.h
+++ b/src/compiler/typecheck/indirect_type.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/fixpoint.h"

--- a/src/compiler/typecheck/infer.cc
+++ b/src/compiler/typecheck/infer.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/typecheck/infer.h"
 
 #include "compiler/ast.h"

--- a/src/compiler/typecheck/infer.h
+++ b/src/compiler/typecheck/infer.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/ast.h"

--- a/src/compiler/typecheck/permission_check.cc
+++ b/src/compiler/typecheck/permission_check.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/typecheck/permission_check.h"
 
 #include "compiler/printing.h"

--- a/src/compiler/typecheck/permission_check.h
+++ b/src/compiler/typecheck/permission_check.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/type.h"
 #include "compiler/typecheck/typecheck.h"
 

--- a/src/compiler/typecheck/solver.cc
+++ b/src/compiler/typecheck/solver.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/typecheck/solver.h"
 
 #include "compiler/printing.h"

--- a/src/compiler/typecheck/solver.h
+++ b/src/compiler/typecheck/solver.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/typecheck/constraint.h"

--- a/src/compiler/typecheck/structural.cc
+++ b/src/compiler/typecheck/structural.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/typecheck/structural.h"
 
 #include "compiler/resolution.h"

--- a/src/compiler/typecheck/structural.h
+++ b/src/compiler/typecheck/structural.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/instantiation.h"
 #include "compiler/typecheck/constraint.h"
 #include "compiler/visitor.h"

--- a/src/compiler/typecheck/typecheck.cc
+++ b/src/compiler/typecheck/typecheck.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/typecheck/typecheck.h"
 
 #include "compiler/format.h"

--- a/src/compiler/typecheck/typecheck.h
+++ b/src/compiler/typecheck/typecheck.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/typecheck/infer.h"

--- a/src/compiler/typecheck/wf_types.cc
+++ b/src/compiler/typecheck/wf_types.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "compiler/typecheck/wf_types.h"
 
 #include "compiler/instantiation.h"

--- a/src/compiler/typecheck/wf_types.h
+++ b/src/compiler/typecheck/wf_types.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/ast.h"

--- a/src/compiler/visitor.h
+++ b/src/compiler/visitor.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "compiler/ast.h"

--- a/src/compiler/zip.h
+++ b/src/compiler/zip.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 namespace verona::compiler

--- a/src/ds/console.h
+++ b/src/ds/console.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #ifdef _MSC_VER
 #  define WIN32_LEAN_AND_MEAN
 #  define NOMINMAX

--- a/src/ds/helpers.h
+++ b/src/ds/helpers.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 #include <cstdlib>
 #include <variant>

--- a/src/ds/taggedptr.h
+++ b/src/ds/taggedptr.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 namespace rt

--- a/src/interpreter/bytecode.cc
+++ b/src/interpreter/bytecode.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "interpreter/bytecode.h"
 
 #include "ds/helpers.h"

--- a/src/interpreter/bytecode.h
+++ b/src/interpreter/bytecode.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <cstdint>

--- a/src/interpreter/code.h
+++ b/src/interpreter/code.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "interpreter/bytecode.h"

--- a/src/interpreter/convert.h
+++ b/src/interpreter/convert.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "interpreter/vm.h"

--- a/src/interpreter/format.h
+++ b/src/interpreter/format.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 #include "ds/helpers.h"
 

--- a/src/interpreter/interpreter.cc
+++ b/src/interpreter/interpreter.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "interpreter/code.h"
 #include "interpreter/vm.h"
 #include "options.h"

--- a/src/interpreter/interpreter.h
+++ b/src/interpreter/interpreter.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "interpreter/code.h"
 #include "options.h"
 

--- a/src/interpreter/main.cc
+++ b/src/interpreter/main.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "ds/console.h"
 #include "interpreter/code.h"
 #include "interpreter/interpreter.h"

--- a/src/interpreter/object.cc
+++ b/src/interpreter/object.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "interpreter/object.h"
 
 #include "vm.h"

--- a/src/interpreter/object.h
+++ b/src/interpreter/object.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "interpreter/bytecode.h"

--- a/src/interpreter/options.h
+++ b/src/interpreter/options.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 #include <CLI/CLI.hpp>
 #include <string>

--- a/src/interpreter/value.cc
+++ b/src/interpreter/value.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "interpreter/value.h"
 
 #include "ds/helpers.h"

--- a/src/interpreter/value.h
+++ b/src/interpreter/value.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "interpreter/bytecode.h"

--- a/src/interpreter/vm.cc
+++ b/src/interpreter/vm.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "interpreter/vm.h"
 
 #include "interpreter/convert.h"

--- a/src/interpreter/vm.h
+++ b/src/interpreter/vm.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "interpreter/code.h"

--- a/src/rt/cpp/vaction.h
+++ b/src/rt/cpp/vaction.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "../sched/action.h"

--- a/src/rt/cpp/vobject.h
+++ b/src/rt/cpp/vobject.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "../region/region.h"

--- a/src/rt/ds/asymlock.h
+++ b/src/rt/ds/asymlock.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 #include "barrier.h"
 

--- a/src/rt/ds/barrier.h
+++ b/src/rt/ds/barrier.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 #include <cassert>
 #ifdef _WIN32

--- a/src/rt/ds/forward_list.h
+++ b/src/rt/ds/forward_list.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <utility>

--- a/src/rt/ds/hashmap.h
+++ b/src/rt/ds/hashmap.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "../object/object.h"

--- a/src/rt/ds/morebits.h
+++ b/src/rt/ds/morebits.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "ds/address.h"

--- a/src/rt/ds/mpscq.h
+++ b/src/rt/ds/mpscq.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <atomic>

--- a/src/rt/ds/queue.h
+++ b/src/rt/ds/queue.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 namespace verona
 {
   template<class T>

--- a/src/rt/ds/scramble.h
+++ b/src/rt/ds/scramble.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 #include "test/xoroshiro.h"
 

--- a/src/rt/ds/stack.h
+++ b/src/rt/ds/stack.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <cassert>

--- a/src/rt/object/object.h
+++ b/src/rt/object/object.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "../ds/stack.h"

--- a/src/rt/region/externalreference.h
+++ b/src/rt/region/externalreference.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "../object/object.h"

--- a/src/rt/region/freeze.h
+++ b/src/rt/region/freeze.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "region.h"

--- a/src/rt/region/immutable.h
+++ b/src/rt/region/immutable.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "../object/object.h"

--- a/src/rt/region/linked_object_stack.h
+++ b/src/rt/region/linked_object_stack.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "../object/object.h"
 
 namespace verona::rt

--- a/src/rt/region/region.h
+++ b/src/rt/region/region.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "../object/object.h"

--- a/src/rt/region/region_arena.h
+++ b/src/rt/region/region_arena.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "../object/object.h"

--- a/src/rt/region/region_base.h
+++ b/src/rt/region/region_base.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "../object/object.h"

--- a/src/rt/region/region_trace.h
+++ b/src/rt/region/region_trace.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "../object/object.h"

--- a/src/rt/region/rememberedset.h
+++ b/src/rt/region/rememberedset.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "../object/object.h"

--- a/src/rt/sched/action.h
+++ b/src/rt/sched/action.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "../object/object.h"

--- a/src/rt/sched/base_noticeboard.h
+++ b/src/rt/sched/base_noticeboard.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "../ds/forward_list.h"

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "../ds/forward_list.h"

--- a/src/rt/sched/cpu.h
+++ b/src/rt/sched/cpu.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <snmalloc.h>

--- a/src/rt/sched/epoch.h
+++ b/src/rt/sched/epoch.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "../ds/asymlock.h"

--- a/src/rt/sched/multimessage.h
+++ b/src/rt/sched/multimessage.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "../ds/mpscq.h"

--- a/src/rt/sched/noticeboard.h
+++ b/src/rt/sched/noticeboard.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "../ds/forward_list.h"

--- a/src/rt/sched/schedulerstats.h
+++ b/src/rt/sched/schedulerstats.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <iostream>

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "../object/object.h"

--- a/src/rt/sched/spmcq.h
+++ b/src/rt/sched/spmcq.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "epoch.h"

--- a/src/rt/sched/threadpool.h
+++ b/src/rt/sched/threadpool.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "cpu.h"

--- a/src/rt/sched/threadstate.h
+++ b/src/rt/sched/threadstate.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <snmalloc.h>

--- a/src/rt/test/func/cown_weak_ref/cown_weak_ref.cc
+++ b/src/rt/test/func/cown_weak_ref/cown_weak_ref.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include <test/harness.h>
 
 /**

--- a/src/rt/test/func/cowngc1/cowngc1.cc
+++ b/src/rt/test/func/cowngc1/cowngc1.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include <random>
 #include <test/harness.h>
 #include <test/xoroshiro.h>

--- a/src/rt/test/func/cowngc2/cowngc2.cpp
+++ b/src/rt/test/func/cowngc2/cowngc2.cpp
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include <test/harness.h>
 
 struct CCown : public VCown<CCown>

--- a/src/rt/test/func/cowngc3/cowngc3.cc
+++ b/src/rt/test/func/cowngc3/cowngc3.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 /**
  * This examples is exploiting a complexity in the leak detector and
  * noticeboards.

--- a/src/rt/test/func/cowngc4/cowngc4.cc
+++ b/src/rt/test/func/cowngc4/cowngc4.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include <random>
 #include <test/harness.h>
 #include <test/xoroshiro.h>

--- a/src/rt/test/func/diningphilosophers/diningphil.cc
+++ b/src/rt/test/func/diningphilosophers/diningphil.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include <ds/scramble.h>
 #include <random>
 #include <test/harness.h>

--- a/src/rt/test/func/ext_ref/ext_ref.cc
+++ b/src/rt/test/func/ext_ref/ext_ref.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "ext_ref_basic.h"
 #include "ext_ref_merge.h"
 

--- a/src/rt/test/func/ext_ref/ext_ref_basic.h
+++ b/src/rt/test/func/ext_ref/ext_ref_basic.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include <verona.h>
 
 using namespace snmalloc;

--- a/src/rt/test/func/ext_ref/ext_ref_merge.h
+++ b/src/rt/test/func/ext_ref/ext_ref_merge.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include <verona.h>
 
 using namespace snmalloc;

--- a/src/rt/test/func/ext_ref_freeze/ext_ref_freeze.cc
+++ b/src/rt/test/func/ext_ref_freeze/ext_ref_freeze.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include <test/opt.h>
 #include <verona.h>
 

--- a/src/rt/test/func/fair/fair.cc
+++ b/src/rt/test/func/fair/fair.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include <ctime>
 #include <test/harness.h>
 

--- a/src/rt/test/func/fair_variance/fair_variance.cc
+++ b/src/rt/test/func/fair_variance/fair_variance.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include <ctime>
 #include <test/harness.h>
 #include <test/opt.h>

--- a/src/rt/test/func/finalisers/finalisers.cc
+++ b/src/rt/test/func/finalisers/finalisers.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include <test/harness.h>
 #include <test/log.h>
 #include <verona.h>

--- a/src/rt/test/func/freeze/freeze.cc
+++ b/src/rt/test/func/freeze/freeze.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "test/harness.h"
 #include "test/xoroshiro.h"
 

--- a/src/rt/test/func/hashmap/hashmap.cc
+++ b/src/rt/test/func/hashmap/hashmap.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "ds/hashmap.h"
 
 #include "test/opt.h"

--- a/src/rt/test/func/memory/memory.cc
+++ b/src/rt/test/func/memory/memory.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include "memory.h"
 
 #include "memory_alloc.h"

--- a/src/rt/test/func/memory/memory.h
+++ b/src/rt/test/func/memory/memory.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <verona.h>

--- a/src/rt/test/func/memory/memory_alloc.h
+++ b/src/rt/test/func/memory/memory_alloc.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "memory.h"

--- a/src/rt/test/func/memory/memory_gc.h
+++ b/src/rt/test/func/memory/memory_gc.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "memory.h"

--- a/src/rt/test/func/memory/memory_iterator.h
+++ b/src/rt/test/func/memory/memory_iterator.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "memory.h"

--- a/src/rt/test/func/memory/memory_merge.h
+++ b/src/rt/test/func/memory/memory_merge.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "memory.h"

--- a/src/rt/test/func/memory/memory_subregion.h
+++ b/src/rt/test/func/memory/memory_subregion.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "memory.h"

--- a/src/rt/test/func/memory/memory_swap_root.h
+++ b/src/rt/test/func/memory/memory_swap_root.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "memory.h"

--- a/src/rt/test/func/memory/second_tu.cc
+++ b/src/rt/test/func/memory/second_tu.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include <verona.h>
 
 size_t do_nothing(size_t x)

--- a/src/rt/test/func/multimessage/multimessage.cc
+++ b/src/rt/test/func/multimessage/multimessage.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include <test/harness.h>
 #include <test/log.h>
 #include <test/opt.h>

--- a/src/rt/test/func/noticeboard/noticeboard.cc
+++ b/src/rt/test/func/noticeboard/noticeboard.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 #include "./noticeboard_basic.h"
 #include "./noticeboard_primitive_weak.h"

--- a/src/rt/test/func/noticeboard/noticeboard_basic.h
+++ b/src/rt/test/func/noticeboard/noticeboard_basic.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include <test/harness.h>
 
 namespace noticeboard_basic

--- a/src/rt/test/func/noticeboard/noticeboard_primitive_weak.h
+++ b/src/rt/test/func/noticeboard/noticeboard_primitive_weak.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 namespace noticeboard_primitive_weak
 {
   struct Writer : public VCown<Writer>

--- a/src/rt/test/func/noticeboard/noticeboard_weak.h
+++ b/src/rt/test/func/noticeboard/noticeboard_weak.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 namespace noticeboard_weak
 {
   struct C : public V<C>

--- a/src/rt/test/func/noticeboard_weak_memory/noticeboard_weak_memory.cc
+++ b/src/rt/test/func/noticeboard_weak_memory/noticeboard_weak_memory.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #ifdef USE_SYSTEMATIC_TESTING
 #  define USE_SYSTEMATIC_TESTING_WEAK_NOTICEBOARDS
 #endif

--- a/src/rt/test/func/notify/notify.cc
+++ b/src/rt/test/func/notify/notify.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include <test/harness.h>
 // Harness must come before tests.
 #include "./notify_basic.h"

--- a/src/rt/test/func/notify/notify_basic.h
+++ b/src/rt/test/func/notify/notify_basic.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 namespace notify_basic
 {
   struct Ping : public VAction<Ping>

--- a/src/rt/test/func/notify/notify_coalesce.h
+++ b/src/rt/test/func/notify/notify_coalesce.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 namespace notify_coalesce
 {
   static size_t g_called;

--- a/src/rt/test/func/notify/notify_interleave.h
+++ b/src/rt/test/func/notify/notify_interleave.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 namespace notify_interleave
 {
   struct Ping : public VAction<Ping>

--- a/src/rt/test/func/rememberedset/rememberedset.cc
+++ b/src/rt/test/func/rememberedset/rememberedset.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Contributers to Project Verona. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 #include <verona.h>
 

--- a/src/rt/test/func/runtimepause/runtimepause.cc
+++ b/src/rt/test/func/runtimepause/runtimepause.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include <random>
 #include <test/opt.h>
 #include <verona.h>

--- a/src/rt/test/func/scramble/scramble.cc
+++ b/src/rt/test/func/scramble/scramble.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include <ds/scramble.h>
 
 // Simple test that perm is not preserving orders.

--- a/src/rt/test/func/steal/steal.cc
+++ b/src/rt/test/func/steal/steal.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include <ctime>
 #include <test/harness.h>
 

--- a/src/rt/test/func/weak_leak_bug/weak_leak_bug.cc
+++ b/src/rt/test/func/weak_leak_bug/weak_leak_bug.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Project Verona contributers. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors
+// SPDX-License-Identifier: MIT
 
 // See issue #84 for origin of this test.
 #include <test/harness.h>

--- a/src/rt/test/harness.h
+++ b/src/rt/test/harness.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <cassert>

--- a/src/rt/test/log.h
+++ b/src/rt/test/log.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <iostream>

--- a/src/rt/test/perf/epoch/epoch.cc
+++ b/src/rt/test/perf/epoch/epoch.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include <test/measuretime.h>
 #include <test/opt.h>
 #include <verona.h>

--- a/src/rt/test/perf/linkedlist/linkedlist.cc
+++ b/src/rt/test/perf/linkedlist/linkedlist.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include <iomanip>
 #include <iostream>
 #include <test/measuretime.h>

--- a/src/rt/test/systematic.h
+++ b/src/rt/test/systematic.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #ifdef _MSC_VER

--- a/src/rt/verona.h
+++ b/src/rt/verona.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #if (defined(__FreeBSD__) && defined(_KERNEL))

--- a/src/stdlib/builtin.verona
+++ b/src/stdlib/builtin.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 /**
  * This file contains the start of the standard library. It is just enough to 

--- a/testsuite/codegen/compile-fail/main-bad-return-type.verona
+++ b/testsuite/codegen/compile-fail/main-bad-return-type.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class Main {
   // CHECK-L: main-bad-return-type.verona:${LINE:+1}:3: error: Method 'main' has an invalid signature
   main(): U64 { 0 }

--- a/testsuite/codegen/compile-fail/main-class-has-generics.verona
+++ b/testsuite/codegen/compile-fail/main-class-has-generics.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 // CHECK-L: main-class-has-generics.verona:${LINE:+1}:7: error: Class 'Main' must not be generic
 class Main[X] {
   main() { }

--- a/testsuite/codegen/compile-fail/main-class-missing.verona
+++ b/testsuite/codegen/compile-fail/main-class-missing.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class Foo { }
 
 // CHECK-L: error: Class 'Main' is missing

--- a/testsuite/codegen/compile-fail/main-has-arguments.verona
+++ b/testsuite/codegen/compile-fail/main-has-arguments.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class Main {
   // CHECK-L: main-has-arguments.verona:${LINE:+1}:3: error: Method 'main' has an invalid signature
   main(x: U64) { }

--- a/testsuite/codegen/compile-fail/main-is-field.verona
+++ b/testsuite/codegen/compile-fail/main-is-field.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 // CHECK-L: main-is-field.verona:${LINE:+1}:7: error: Class 'Main' does not have a 'main' method
 class Main {
   main: U64 & imm;

--- a/testsuite/codegen/compile-fail/main-is-interface.verona
+++ b/testsuite/codegen/compile-fail/main-is-interface.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 // CHECK-L: main-is-interface.verona:${LINE:+1}:11: error: 'Main' must be a class
 interface Main {
   main() { }

--- a/testsuite/codegen/compile-fail/main-method-has-generics.verona
+++ b/testsuite/codegen/compile-fail/main-method-has-generics.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class Main {
   // CHECK-L: main-method-has-generics.verona:${LINE:+1}:3: error: Method 'main' has an invalid signature
   main[X]() { }

--- a/testsuite/codegen/compile-fail/main-method-missing.verona
+++ b/testsuite/codegen/compile-fail/main-method-missing.verona
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 // CHECK-L: main-method-missing.verona:${LINE:+1}:7: error: Class 'Main' does not have a 'main' method
 class Main { }

--- a/testsuite/demo/run-pass/bank1.verona
+++ b/testsuite/demo/run-pass/bank1.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 /*****************************************************************************
  * This example is the simplest example of concurrency in Verona.

--- a/testsuite/demo/run-pass/bank2.verona
+++ b/testsuite/demo/run-pass/bank2.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 /*****************************************************************************
  * This examples illustrates the `when` syntax for operating over multiple

--- a/testsuite/demo/run-pass/bank3.verona
+++ b/testsuite/demo/run-pass/bank3.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 /*****************************************************************************
  * This example illustrates the nested use of `when`.

--- a/testsuite/demo/run-pass/channel.verona
+++ b/testsuite/demo/run-pass/channel.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 /*****************************************************************************
  * This example demonstrates how one could build a channel in verona using

--- a/testsuite/demo/run-pass/dining_phil.verona
+++ b/testsuite/demo/run-pass/dining_phil.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 /*****************************************************************************
  * This example uses the Verona concurrency model for the classic 

--- a/testsuite/demo/run-pass/fib.verona
+++ b/testsuite/demo/run-pass/fib.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class Fib
 {
   /**

--- a/testsuite/demo/run-pass/library/queue.verona
+++ b/testsuite/demo/run-pass/library/queue.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 /**
  *  This file implements a simple queue.  The queue always 

--- a/testsuite/demo/run-pass/queue_harness.verona
+++ b/testsuite/demo/run-pass/queue_harness.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 // This just directly includes the queue file. Stop gap until module system
 // and packaging implenented

--- a/testsuite/demo/run-pass/region101.verona
+++ b/testsuite/demo/run-pass/region101.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 /************************************************************************
  *  This file illustrates some of the region design.

--- a/testsuite/demo/run-pass/scheduler.verona
+++ b/testsuite/demo/run-pass/scheduler.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 // This just directly includes the queue file. Stop gap until module system
 // and packaging implenented

--- a/testsuite/elaboration/compile-fail/multiple-clauses.verona
+++ b/testsuite/elaboration/compile-fail/multiple-clauses.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class A {}
 class Main
 {

--- a/testsuite/features/compile-fail/assertion.verona
+++ b/testsuite/features/compile-fail/assertion.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class A {}
 class B {}
 class Main { main() {} }

--- a/testsuite/features/compile-fail/bad-branch.verona
+++ b/testsuite/features/compile-fail/bad-branch.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class A {}
 class Cell[X] { value: X }
 

--- a/testsuite/features/compile-fail/cown.verona
+++ b/testsuite/features/compile-fail/cown.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class IsoHolder 
 {
   contents: iso & None;

--- a/testsuite/features/compile-fail/finalisers.verona
+++ b/testsuite/features/compile-fail/finalisers.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 class Generic[Value]
 {

--- a/testsuite/features/compile-fail/when.verona
+++ b/testsuite/features/compile-fail/when.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 // Example using when 
 class NotLog
 {

--- a/testsuite/features/compile-pass/assertion.verona
+++ b/testsuite/features/compile-pass/assertion.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class A {}
 class B {}
 class Main { main() {} }

--- a/testsuite/features/compile-pass/cell.verona
+++ b/testsuite/features/compile-pass/cell.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class Cell[X] {
   fvalue: X | (None & iso);
 

--- a/testsuite/features/compile-pass/cown.verona
+++ b/testsuite/features/compile-pass/cown.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class IsoHolder 
 {
   contents: iso & None;

--- a/testsuite/features/compile-pass/fixpoint.verona
+++ b/testsuite/features/compile-pass/fixpoint.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class A { f: B & mut; }
 class B { f: A & mut; }
 

--- a/testsuite/features/compile-pass/library/child.verona
+++ b/testsuite/features/compile-pass/library/child.verona
@@ -1,4 +1,4 @@
-// Copyright (c) Contributers to Project Verona. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 use "sibling.verona"

--- a/testsuite/features/compile-pass/library/sibling.verona
+++ b/testsuite/features/compile-pass/library/sibling.verona
@@ -1,2 +1,2 @@
-// Copyright (c) Contributers to Project Verona. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT

--- a/testsuite/features/compile-pass/match-extra.verona
+++ b/testsuite/features/compile-pass/match-extra.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class A { }
 class B { }
 class C { }

--- a/testsuite/features/compile-pass/use.verona
+++ b/testsuite/features/compile-pass/use.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Contributers to Project Verona. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 use "library/child.verona"
 

--- a/testsuite/features/run-pass/binary-tree.verona
+++ b/testsuite/features/run-pass/binary-tree.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 // Creates a binary tree that can be used for either `iso` or `mut` values.
 //

--- a/testsuite/features/run-pass/branch.verona
+++ b/testsuite/features/run-pass/branch.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class A {
   create(): A & iso { new A }
 }

--- a/testsuite/features/run-pass/finalisers-extract.verona
+++ b/testsuite/features/run-pass/finalisers-extract.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 // This test demostrates the "extract and return in finalisers" pattern.
 // A Handle owns a Value object. When the Handle goes out of scope and its

--- a/testsuite/features/run-pass/finalisers.verona
+++ b/testsuite/features/run-pass/finalisers.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 class Generic[Value]
 {

--- a/testsuite/features/run-pass/freeze.verona
+++ b/testsuite/features/run-pass/freeze.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class A { f: (A & mut) | (None & imm); }
 
 class Main

--- a/testsuite/features/run-pass/integer.verona
+++ b/testsuite/features/run-pass/integer.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class Main {
   main() {
     // CHECK-L: 0

--- a/testsuite/features/run-pass/loop.verona
+++ b/testsuite/features/run-pass/loop.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class True {
   create(): True & imm {
     Builtin.freeze (new True)

--- a/testsuite/features/run-pass/match.verona
+++ b/testsuite/features/run-pass/match.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class A { }
 class B { }
 class C { }

--- a/testsuite/features/run-pass/operators.verona
+++ b/testsuite/features/run-pass/operators.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Contributers to Project Verona. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 
 class Main {

--- a/testsuite/features/run-pass/primitive.verona
+++ b/testsuite/features/run-pass/primitive.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 // We can add methods to primitives and call them.
 primitive P {

--- a/testsuite/features/run-pass/promise.verona
+++ b/testsuite/features/run-pass/promise.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class Main
 {
   promise_test(i: U64 & imm)

--- a/testsuite/features/run-pass/when.verona
+++ b/testsuite/features/run-pass/when.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 // Example using when 
 class Log
 {

--- a/testsuite/ir/compile-pass/copy.verona
+++ b/testsuite/ir/compile-pass/copy.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class A { }
 class Main
 {

--- a/testsuite/ir/compile-pass/loop-complexity.verona
+++ b/testsuite/ir/compile-pass/loop-complexity.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class Main
 {
   main() { }

--- a/testsuite/ir/compile-pass/loop.verona
+++ b/testsuite/ir/compile-pass/loop.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class Main {
   main() { }
   use[X](value: X) { }

--- a/testsuite/ir/compile-pass/unused-value.verona
+++ b/testsuite/ir/compile-pass/unused-value.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 /**
  * This file uses U64 return values to avoid the implicit unit return value,
  * which would cause confusion in generated IR.

--- a/testsuite/liveness/compile-pass/branch.verona
+++ b/testsuite/liveness/compile-pass/branch.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class A {}
 class Main
 {

--- a/testsuite/liveness/compile-pass/loop.verona
+++ b/testsuite/liveness/compile-pass/loop.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class A {}
 class Main
 {

--- a/testsuite/parse/ast-parse/alloc.verona
+++ b/testsuite/parse/ast-parse/alloc.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 foo()
 {

--- a/testsuite/parse/ast-parse/function.verona
+++ b/testsuite/parse/ast-parse/function.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 foo(a: N, b: U64 & imm): R
   where N: imm

--- a/testsuite/parse/ast-parse/import.verona
+++ b/testsuite/parse/ast-parse/import.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 type Foo = "module_foo" [A, B];
 

--- a/testsuite/parse/ast-parse/literal.verona
+++ b/testsuite/parse/ast-parse/literal.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 f()
 {

--- a/testsuite/parse/ast-parse/loop.verona
+++ b/testsuite/parse/ast-parse/loop.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 f(x)
 {

--- a/testsuite/parse/ast-parse/module_foo/foo.verona
+++ b/testsuite/parse/ast-parse/module_foo/foo.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 module [A, B] : C;
 

--- a/testsuite/parse/ast-parse/staticcall.verona
+++ b/testsuite/parse/ast-parse/staticcall.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 class B
 {

--- a/testsuite/parse/ast-parse/strings.verona
+++ b/testsuite/parse/ast-parse/strings.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 (x: U64, y: U64)
 {

--- a/testsuite/parse/ast-parse/typedef.verona
+++ b/testsuite/parse/ast-parse/typedef.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 type UInt = U64 & imm;
 

--- a/testsuite/parse/ast-parse/when.verona
+++ b/testsuite/parse/ast-parse/when.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 foo(a: Cown[A], b: Cown[B])
 {

--- a/testsuite/reachability/compile-pass/visit-receiver.verona
+++ b/testsuite/reachability/compile-pass/visit-receiver.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 /*
  * This test fixes https://github.com/microsoft/verona/issues/35

--- a/testsuite/reachability/compile-pass/visit-variable-renaming-type.verona
+++ b/testsuite/reachability/compile-pass/visit-variable-renaming-type.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 /*
  * This test checks https://github.com/microsoft/verona/issues/67

--- a/testsuite/resolution/compile-fail/builtin-body.verona
+++ b/testsuite/resolution/compile-fail/builtin-body.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Contributers to Project Verona. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 class Main {
   // CHECK-L: builtin-body.verona:${LINE:+1}:11: error: Builtin method 'foo' in 'Main' must not have a body

--- a/testsuite/resolution/compile-fail/invalid-number-of-type-arguments.verona
+++ b/testsuite/resolution/compile-fail/invalid-number-of-type-arguments.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class N0 {}
 class N1[X] {}
 class N2[X, Y] {}

--- a/testsuite/resolution/compile-fail/missing-method-body.verona
+++ b/testsuite/resolution/compile-fail/missing-method-body.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 // Only interfaces are allowed to have body-less methods.
 class Test {
   // CHECK-L: missing-method-body.verona:${LINE:+1}:3: error: Method 'foo' in class 'Test' must have a body

--- a/testsuite/resolution/compile-fail/module.verona
+++ b/testsuite/resolution/compile-fail/module.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Contributers to Project Verona. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 // Reported errors should point to the proper source location.
 use "module/child.verona"

--- a/testsuite/resolution/compile-fail/module/child.verona
+++ b/testsuite/resolution/compile-fail/module/child.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Contributers to Project Verona. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 class A {
   m(x: T) {}

--- a/testsuite/resolution/compile-fail/multiple-definitions.verona
+++ b/testsuite/resolution/compile-fail/multiple-definitions.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 // CHECK-L: multiple-definitions.verona:${LINE:+3}:7: error: Symbol 'SameClass' is already defined in this scope
 // CHECK-L: multiple-definitions.verona:${LINE:+1}:7: note: 'SameClass' was previously defined here
 class SameClass {}

--- a/testsuite/resolution/compile-fail/new-expr.verona
+++ b/testsuite/resolution/compile-fail/new-expr.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class A {}
 interface I {}
 primitive P {}

--- a/testsuite/resolution/compile-fail/primitive-field.verona
+++ b/testsuite/resolution/compile-fail/primitive-field.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 
 primitive P {
   // CHECK-L: primitive-field.verona:${LINE:+1}:3: error: Primitives cannot have fields

--- a/testsuite/resolution/compile-fail/unknown-symbol.verona
+++ b/testsuite/resolution/compile-fail/unknown-symbol.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class Main {
   // CHECK-L: unknown-symbol.verona:${LINE:+1}:6: error: Cannot find value for symbol 'Foo'
   f: Foo;

--- a/testsuite/resolution/compile-fail/where-clause.verona
+++ b/testsuite/resolution/compile-fail/where-clause.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class A {}
 class Main
 {

--- a/testsuite/resolution/compile-pass/circular.verona
+++ b/testsuite/resolution/compile-pass/circular.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 // Class fields can form cycles, without forward declarations.
 class A { f: B & iso; }
 class B { f: A & iso; }

--- a/testsuite/resolution/compile-pass/interleaved.verona
+++ b/testsuite/resolution/compile-pass/interleaved.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 // Field and method definitions can be interleaved
 
 class A {

--- a/testsuite/structural-subtyping/compile-pass/class-invariance.verona
+++ b/testsuite/structural-subtyping/compile-pass/class-invariance.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class Main { main() { } }
 
 interface Any { }

--- a/testsuite/structural-subtyping/compile-pass/empty-interface.verona
+++ b/testsuite/structural-subtyping/compile-pass/empty-interface.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class Main { main() { } }
 
 interface EmptyIface { }

--- a/testsuite/structural-subtyping/compile-pass/equivalent.verona
+++ b/testsuite/structural-subtyping/compile-pass/equivalent.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class Main { main() { } }
 
 interface I1 {

--- a/testsuite/structural-subtyping/compile-pass/generic-method.verona
+++ b/testsuite/structural-subtyping/compile-pass/generic-method.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class Main { main() { } }
 
 interface Iface {

--- a/testsuite/structural-subtyping/compile-pass/method-arity.verona
+++ b/testsuite/structural-subtyping/compile-pass/method-arity.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class Main { main() { } }
 
 interface IArity0 {

--- a/testsuite/structural-subtyping/compile-pass/mutually-recursive.verona
+++ b/testsuite/structural-subtyping/compile-pass/mutually-recursive.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class Main { main() { } }
 
 interface MutualRecursiveA {

--- a/testsuite/structural-subtyping/compile-pass/recursive.verona
+++ b/testsuite/structural-subtyping/compile-pass/recursive.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class Main { main() { } }
 
 interface Recursive {

--- a/testsuite/structural-subtyping/compile-pass/split-interface.verona
+++ b/testsuite/structural-subtyping/compile-pass/split-interface.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class Main { main() { } }
 
 interface I1 {

--- a/testsuite/structural-subtyping/compile-pass/variance.verona
+++ b/testsuite/structural-subtyping/compile-pass/variance.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class Main { main() { } }
 
 interface Get[X] {

--- a/testsuite/typechecking/compile-fail/freeze.verona
+++ b/testsuite/typechecking/compile-fail/freeze.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class A { }
 
 class Main

--- a/testsuite/typechecking/compile-fail/invalid-field-read.verona
+++ b/testsuite/typechecking/compile-fail/invalid-field-read.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class A { }
 class Cell { value: A & iso; }
 

--- a/testsuite/typechecking/compile-fail/invalid-field-write.verona
+++ b/testsuite/typechecking/compile-fail/invalid-field-write.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class A { }
 class Cell { value: A & iso; }
 

--- a/testsuite/typechecking/compile-fail/mut-view.verona
+++ b/testsuite/typechecking/compile-fail/mut-view.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class A { f: A & iso; }
 
 class Main

--- a/testsuite/typechecking/compile-fail/type-argument-bounds.verona
+++ b/testsuite/typechecking/compile-fail/type-argument-bounds.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 interface IHasFoo
 {
   foo();

--- a/testsuite/typechecking/compile-pass/field-read.verona
+++ b/testsuite/typechecking/compile-pass/field-read.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class A { }
 class Cell { value: A & iso; }
 class GenericCell[X] { value: X; }

--- a/testsuite/typechecking/compile-pass/field-write.verona
+++ b/testsuite/typechecking/compile-pass/field-write.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class A { }
 class Cell { value: A & iso; }
 class GenericCell[X] { value: X; }

--- a/testsuite/typechecking/compile-pass/mut-view.verona
+++ b/testsuite/typechecking/compile-pass/mut-view.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class A { f: A & iso; }
 
 class Main

--- a/testsuite/typechecking/compile-pass/new-expr.verona
+++ b/testsuite/typechecking/compile-pass/new-expr.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 class A { }
 class Main
 {

--- a/testsuite/typechecking/compile-pass/type-argument-bounds.verona
+++ b/testsuite/typechecking/compile-pass/type-argument-bounds.verona
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 interface IHasFoo
 {
   foo(self: mut);

--- a/utils/doctool/mkdoc.cc
+++ b/utils/doctool/mkdoc.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #include <clang-c/Index.h>
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
 - Change the text to state copyright Microsoft and contributors.
 - Use SPDX license tags that license auditing tools can parse.