### PR TITLE
Refactor MLIR generator to use ast_utils for all AST handling

### DIFF
--- a/src/mlir/ast-utils.cc
+++ b/src/mlir/ast-utils.cc
@@ -53,8 +53,7 @@ namespace mlir::verona::ASTInterface
       ptr = ptr->nodes[0];
 
     // Return the nodes
-    for (auto n : ptr->nodes)
-      nodes.push_back(n);
+    nodes.insert(nodes.end(), ptr->nodes.begin(), ptr->nodes.end());
     return nodes;
   }
 

--- a/testsuite/mlir/mlir-fail/operator.verona
+++ b/testsuite/mlir/mlir-fail/operator.verona
@@ -5,7 +5,7 @@ foo(a: N, b: U64 & imm): R
   where N: imm
   where R: U64 & imm
 {
-  // CHECK: Operation '-' not implemented yet at loc.*operator.verona":${LINE:+1}:13
+  // CHECK: Operation '-' not implemented yet at loc.*operator.verona":${LINE:+1}:11
   let x = a - b;
   let r: R = x;
   x


### PR DESCRIPTION
This removes every dependency that the MLIR generator had on the
AST structure. All searches in the AST structure and accessors to names,
IDs, types are done via helper functions.

The only knowledge of the AST is via a NodeKind switch in parseNode,
which is a lot better than calling "isFoo" and "isBar" functons, but it
could be made so if people feel strongly inclined. Given that this is a
helper enum, not an AST enum, it should be ok.

The logic for accessing the AST structure is now 100% encoded in the
helper functions and comments were added where things were less than
clear. This makes it easier for us to exchange knowledge and refine the
API of both AST and MLIR to make things simpler.