### PR TITLE
Force 2h timeout for all builds

### DIFF
--- a/devops/ci.yml
+++ b/devops/ci.yml
@@ -50,6 +50,7 @@ jobs:
     LLVMCommit: $[ dependencies.ConfigureCIRun.outputs['setVarStep.LLVMCommit'] ]
   pool:
     vmImage: 'ubuntu-18.04'
+  timeoutInMinutes: 120
   strategy:
     matrix:
       # GCC Release:
@@ -125,6 +126,7 @@ jobs:
     LLVMCommit: $[ dependencies.ConfigureCIRun.outputs['setVarStep.LLVMCommit'] ]
   pool:
     vmImage: 'windows-2019'
+  timeoutInMinutes: 120
   strategy:
     matrix:
       Release:
@@ -188,6 +190,7 @@ jobs:
     LLVMCommit: $[ dependencies.ConfigureCIRun.outputs['setVarStep.LLVMCommit'] ]
   pool:
     vmImage: 'macOS-10.14'
+  timeoutInMinutes: 120
   strategy:
     matrix:
       Release:

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -39,6 +39,7 @@ jobs:
     LLVMCommit: $[ dependencies.ConfigureCIRun.outputs['setVarStep.LLVMCommit'] ]
   pool:
     vmImage: 'ubuntu-18.04'
+  timeoutInMinutes: 120
   strategy:
     matrix:
       # GCC Debug:
@@ -136,6 +137,7 @@ jobs:
     LLVMCommit: $[ dependencies.ConfigureCIRun.outputs['setVarStep.LLVMCommit'] ]
   pool:
     vmImage: 'windows-2019'
+  timeoutInMinutes: 120
   strategy:
     matrix:
       RelWithDebInfo:
@@ -211,6 +213,7 @@ jobs:
     LLVMCommit: $[ dependencies.ConfigureCIRun.outputs['setVarStep.LLVMCommit'] ]
   pool:
     vmImage: 'macOS-10.14'
+  timeoutInMinutes: 120
   strategy:
     matrix:
       Debug:


### PR DESCRIPTION
Some builds recently failed because the Mac builders were too slow and the RT tests were too long. Ramping up timeouts to 2hs and hopping the free builders can cope with it.