### PR TITLE
Implement while blocks, improve conditional support and lexical contexts

### DIFF
--- a/src/mlir/ast-utils.cc
+++ b/src/mlir/ast-utils.cc
@@ -342,6 +342,16 @@ namespace mlir::verona::ASTInterface
     return isA(ast, NodeKind::While);
   }
 
+  bool isContinue(::ast::WeakAst ast)
+  {
+    return isValue(ast) && isA(ast, NodeKind::Continue);
+  }
+
+  bool isBreak(::ast::WeakAst ast)
+  {
+    return isValue(ast) && isA(ast, NodeKind::Break);
+  }
+
   ::ast::WeakAst getLoopBlock(::ast::WeakAst ast)
   {
     assert(isWhile(ast) && "Bad node");

--- a/src/mlir/ast-utils.h
+++ b/src/mlir/ast-utils.h
@@ -185,6 +185,8 @@ namespace mlir::verona::ASTInterface
   // ================================================= Loop Helpers
   /// Return true if node is a while loop
   bool isWhile(::ast::WeakAst ast);
+  /// Return true if node is any kind of loop
+  bool isLoop(::ast::WeakAst ast);
   /// Return true if node is a loop continue
   bool isContinue(::ast::WeakAst ast);
   /// Return true if node is a loop break

--- a/src/mlir/ast-utils.h
+++ b/src/mlir/ast-utils.h
@@ -72,6 +72,7 @@ namespace mlir::verona::ASTInterface
     Condition = peg::str2tag("cond"),
     If = peg::str2tag("if"),
     Else = peg::str2tag("else"),
+    While = peg::str2tag("while"),
   };
 
   // ================================================= Generic Helpers
@@ -92,6 +93,8 @@ namespace mlir::verona::ASTInterface
   bool isA(::ast::WeakAst ast, NodeKind kind);
   /// Return true if node is of any kind in a list
   bool isAny(::ast::WeakAst ast, llvm::ArrayRef<NodeKind> kind);
+  /// Return true if node has a certain kind sub-node
+  bool hasA(::ast::WeakAst ast, NodeKind kind);
   /// Find a sub-node of tag 'type'
   ::ast::WeakAst findNode(::ast::WeakAst ast, NodeType type);
   /// Return a list of sub-nodes
@@ -168,10 +171,18 @@ namespace mlir::verona::ASTInterface
   bool isBlock(::ast::WeakAst ast);
   /// Return true if node is an else block
   bool isElse(::ast::WeakAst ast);
+  /// Return true if the 'if' node has an else block
+  bool hasElse(::ast::WeakAst ast);
   /// Return the condition form an if statement
   ::ast::WeakAst getCond(::ast::WeakAst ast);
   /// Return the block form an if statement
   ::ast::WeakAst getIfBlock(::ast::WeakAst ast);
   /// Return the else block form an if statement
   ::ast::WeakAst getElseBlock(::ast::WeakAst ast);
+
+  // ================================================= Loop Helpers
+  /// Return true if node is a while loop
+  bool isWhile(::ast::WeakAst ast);
+  /// Return the block form a loop
+  ::ast::WeakAst getLoopBlock(::ast::WeakAst ast);
 }

--- a/src/mlir/ast-utils.h
+++ b/src/mlir/ast-utils.h
@@ -73,6 +73,8 @@ namespace mlir::verona::ASTInterface
     If = peg::str2tag("if"),
     Else = peg::str2tag("else"),
     While = peg::str2tag("while"),
+    Continue = peg::str2tag("continue"),
+    Break = peg::str2tag("break"),
   };
 
   // ================================================= Generic Helpers
@@ -183,6 +185,10 @@ namespace mlir::verona::ASTInterface
   // ================================================= Loop Helpers
   /// Return true if node is a while loop
   bool isWhile(::ast::WeakAst ast);
+  /// Return true if node is a loop continue
+  bool isContinue(::ast::WeakAst ast);
+  /// Return true if node is a loop break
+  bool isBreak(::ast::WeakAst ast);
   /// Return the block form a loop
   ::ast::WeakAst getLoopBlock(::ast::WeakAst ast);
 }

--- a/src/mlir/generator.cc
+++ b/src/mlir/generator.cc
@@ -339,9 +339,7 @@ namespace mlir::verona
       // We use allocas to track location and load/stores to track access
       auto name = getTokenValue(ast);
       auto var = symbolTable.lookup(name);
-      if (!var)
-        return parsingError(
-          "Variable " + name + " not declared before use", getLocation(ast));
+      assert(var && "Undeclared variable lookup, broken ast");
       if (var.getType() == allocaTy)
         return genOperation(getLocation(ast), "verona.load", {var}, unkTy);
       return var;
@@ -496,11 +494,15 @@ namespace mlir::verona
       elseBB = currentFunc.addBlock();
     auto exitBB = currentFunc.addBlock();
     if (hasElse(ast))
+    {
       builder.create<mlir::CondBranchOp>(
         condLoc, *cond, ifBB, empty, elseBB, empty);
+    }
     else
+    {
       builder.create<mlir::CondBranchOp>(
         condLoc, *cond, ifBB, empty, exitBB, empty);
+    }
 
     {
       // Create local context for the if block variables

--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -74,6 +74,8 @@ namespace mlir::verona
     SymbolTableT symbolTable;
     FunctionTableT functionTable;
     TypeTableT typeTable;
+    // Nested reference for head/exit blocks in loops.
+    BasicBlockTableT loopTable;
 
     // Helper for types, before we start using actual Verona types
     mlir::Type allocaTy;
@@ -110,6 +112,8 @@ namespace mlir::verona
     llvm::Expected<mlir::Value> parseCall(const ::ast::Ast& ast);
     llvm::Expected<mlir::Value> parseCondition(const ::ast::Ast& ast);
     llvm::Expected<mlir::Value> parseWhileLoop(const ::ast::Ast& ast);
+    llvm::Expected<mlir::Value> parseContinue(const ::ast::Ast& ast);
+    llvm::Expected<mlir::Value> parseBreak(const ::ast::Ast& ast);
 
     // Wrappers for opaque operators/types before we use actual Verona dialect
     llvm::Expected<mlir::Value> genOperation(

--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -109,6 +109,7 @@ namespace mlir::verona
     llvm::Expected<mlir::Value> parseAssign(const ::ast::Ast& ast);
     llvm::Expected<mlir::Value> parseCall(const ::ast::Ast& ast);
     llvm::Expected<mlir::Value> parseCondition(const ::ast::Ast& ast);
+    llvm::Expected<mlir::Value> parseWhileLoop(const ::ast::Ast& ast);
 
     // Wrappers for opaque operators/types before we use actual Verona dialect
     llvm::Expected<mlir::Value> genOperation(

--- a/src/mlir/symbol.h
+++ b/src/mlir/symbol.h
@@ -10,18 +10,20 @@
 
 namespace mlir::verona
 {
-  // The symbol table has all declared symbols (with the original node
-  // and the MLIR ounterpart) in a scope. Creating a new scope makes
-  // all future insertions happen at that level, destroying it pops
-  // the scope out of the stack.
+  /**
+   * The symbol table has all declared symbols (with the original node
+   * and the MLIR ounterpart) in a scope. Creating a new scope makes
+   * all future insertions happen at that level, destroying it pops
+   * the scope out of the stack.
 
-  // New scopes are created by creating a new local variable like:
-  //   SymbolScopeT scope(symbolTable);
-  // The destructor pops the scope automatically.
+   * New scopes are created by creating a new local variable like:
+   *   SymbolScopeT scope(symbolTable);
+   * The destructor pops the scope automatically.
 
-  // We cannot use LLVM's ADT/ScopedHashTable like MLIR's Toy example because
-  // that coped hash table does not allow redefinition, which is a problem when
-  // declaring variables with a type only and then assigning values later.
+   * We cannot use LLVM's ADT/ScopedHashTable like MLIR's Toy example because
+   * that coped hash table does not allow redefinition, which is a problem when
+   * declaring variables with a type only and then assigning values later.
+   */
   template<class T>
   class ScopedTable
   {
@@ -42,7 +44,7 @@ namespace mlir::verona
       assert(stack.empty());
     }
 
-    // Insert entry on the last scope only
+    /// Insert entry on the last scope only
     bool insert(llvm::StringRef key, T value)
     {
       auto& frame = stack.back();
@@ -52,7 +54,7 @@ namespace mlir::verona
       return res.second;
     }
 
-    // Lookup from the last scope to the first
+    /// Lookup from the last scope to the first
     T lookup(llvm::StringRef key)
     {
       for (auto it = stack.rbegin(), end = stack.rend(); it != end; it++)
@@ -61,18 +63,17 @@ namespace mlir::verona
         if (frame.count(key.str()))
           return frame[key.str()];
       }
-      // Use inScope for this not to happen
-      llvm_unreachable("Symbol not found");
+      return nullptr;
     }
 
-    // Check that the entry is in the last scope
+    /// Check that the entry is in the last scope
     bool inScope(llvm::StringRef key)
     {
       auto frame = stack.back();
       return frame.count(key.str());
     }
 
-    // Update the entry in the last scope, or create new
+    /// Update the entry in the last scope, or create new
     bool update(llvm::StringRef key, T value)
     {
       auto& frame = stack.back();
@@ -83,13 +84,13 @@ namespace mlir::verona
       return true;
     }
 
-    // Creates a new scope
+    /// Creates a new scope
     void pushScope()
     {
       stack.emplace_back();
     }
 
-    // Destroys the inner-most scope
+    /// Destroys the inner-most scope
     void popScope()
     {
       stack.pop_back();
@@ -113,18 +114,31 @@ namespace mlir::verona
     }
   };
 
-  // Variable symbols. New scopes should be created when entering classes,
-  // functions, lexical blocks, lambdas, etc.
+  /**
+   * Variable symbols. New scopes should be created when entering classes,
+   * functions, lexical blocks, lambdas, etc.
+   */
   using SymbolTableT = ScopedTable<mlir::Value>;
   using SymbolScopeT = ScopedTableScope<mlir::Value>;
 
-  // Function Symbols. New scopes should be created when entering classes
-  // and sub-classes. Modules too, if we allow more than one per file.
+  /**
+   * Function Symbols. New scopes should be created when entering classes
+   * and sub-classes. Modules too, if we allow more than one per file.
+   */
   using FunctionTableT = ScopedTable<mlir::FuncOp>;
   using FunctionScopeT = ScopedTableScope<mlir::FuncOp>;
 
-  // Type Symbols. New scopes should be created when entering classes
-  // sub-classes and functions, to be used with the 'where' keyword.
+  /**
+   * Type Symbols. New scopes should be created when entering classes
+   * sub-classes and functions, to be used with the 'where' keyword.
+   */
   using TypeTableT = ScopedTable<mlir::Type>;
   using TypeScopeT = ScopedTableScope<mlir::Type>;
+
+  /**
+   * Basic Block Symbols. New scopes should be created when entering loops
+   * to determine what is the head/exit block for 'break'/'continue'.
+   */
+  using BasicBlockTableT = ScopedTable<mlir::Block*>;
+  using BasicBlockScopeT = ScopedTableScope<mlir::Block*>;
 }

--- a/testsuite/mlir/mlir-parse/while-cont-brk.verona
+++ b/testsuite/mlir/mlir-parse/while-cont-brk.verona
@@ -1,0 +1,21 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+f(a, x)
+{
+  while (a < 5)
+  {
+    a = a + 1;
+
+    if (a < x)
+    {
+      continue;
+    }
+
+    if (a > x)
+    {
+      break;
+    }
+  }
+  a;
+}

--- a/testsuite/mlir/mlir-parse/while-cont-brk/mlir.out
+++ b/testsuite/mlir/mlir-parse/while-cont-brk/mlir.out
@@ -1,0 +1,41 @@
+
+
+module {
+  func @f(%arg0: none, %arg1: none) -> none {
+    %0 = "verona.alloca"() : () -> !type.alloca
+    %1 = "verona.store"(%arg0, %0) : (none, !type.alloca) -> !type.unk
+    %2 = "verona.alloca"() : () -> !type.alloca
+    %3 = "verona.store"(%arg1, %2) : (none, !type.alloca) -> !type.unk
+    br ^bb1
+  ^bb1:  // 3 preds: ^bb0, ^bb4, ^bb7
+    %4 = "verona.load"(%0) : (!type.alloca) -> !type.unk
+    %5 = "verona.constant(5)"() : () -> !type.int
+    %6 = "verona.lt"(%4, %5) : (!type.unk, !type.int) -> i1
+    cond_br %6, ^bb2, ^bb3
+  ^bb2:  // pred: ^bb1
+    %7 = "verona.alloca"() : () -> !type.alloca
+    %8 = "verona.load"(%7) : (!type.alloca) -> !type.unk
+    %9 = "verona.constant(1)"() : () -> !type.int
+    %10 = "verona.add"(%8, %9) : (!type.unk, !type.int) -> !type.unk
+    %11 = "verona.store"(%10, %7) : (!type.unk, !type.alloca) -> !type.unk
+    %12 = "verona.load"(%7) : (!type.alloca) -> !type.unk
+    %13 = "verona.load"(%2) : (!type.alloca) -> !type.unk
+    %14 = "verona.lt"(%12, %13) : (!type.unk, !type.unk) -> i1
+    cond_br %14, ^bb4, ^bb5
+  ^bb3:  // 2 preds: ^bb1, ^bb6
+    %15 = "verona.load"(%0) : (!type.alloca) -> !type.unk
+    %16 = "verona.cast"(%15) : (!type.unk) -> none
+    return %16 : none
+  ^bb4:  // pred: ^bb2
+    br ^bb1
+  ^bb5:  // pred: ^bb2
+    %17 = "verona.load"(%7) : (!type.alloca) -> !type.unk
+    %18 = "verona.load"(%2) : (!type.alloca) -> !type.unk
+    %19 = "verona.gt"(%17, %18) : (!type.unk, !type.unk) -> i1
+    cond_br %19, ^bb6, ^bb7
+  ^bb6:  // pred: ^bb5
+    br ^bb3
+  ^bb7:  // pred: ^bb5
+    br ^bb1
+  }
+}

--- a/testsuite/mlir/mlir-parse/while-context.verona
+++ b/testsuite/mlir/mlir-parse/while-context.verona
@@ -1,0 +1,15 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+f(a)
+{
+  let x = 1;
+  while (a < 5)
+  {
+    // Redefinition, should use this below
+    let x = 2;
+    let y = x + 3;
+    a = a + y;
+  }
+  a;
+}

--- a/testsuite/mlir/mlir-parse/while-context/out.mlir
+++ b/testsuite/mlir/mlir-parse/while-context/out.mlir
@@ -1,0 +1,35 @@
+
+
+module {
+  func @f(%arg0: none) -> none {
+    %0 = "verona.alloca"() : () -> !type.alloca
+    %1 = "verona.store"(%arg0, %0) : (none, !type.alloca) -> !type.unk
+    %2 = "verona.alloca"() : () -> !type.alloca
+    %3 = "verona.constant(1)"() : () -> !type.int
+    %4 = "verona.store"(%3, %2) : (!type.int, !type.alloca) -> !type.unk
+    br ^bb1
+  ^bb1:  // 2 preds: ^bb0, ^bb2
+    %5 = "verona.load"(%0) : (!type.alloca) -> !type.unk
+    %6 = "verona.constant(5)"() : () -> !type.int
+    %7 = "verona.lt"(%5, %6) : (!type.unk, !type.int) -> i1
+    cond_br %7, ^bb2, ^bb3
+  ^bb2:  // pred: ^bb1
+    %8 = "verona.alloca"() : () -> !type.alloca
+    %9 = "verona.constant(2)"() : () -> !type.int
+    %10 = "verona.store"(%9, %8) : (!type.int, !type.alloca) -> !type.unk
+    %11 = "verona.alloca"() : () -> !type.alloca
+    %12 = "verona.load"(%8) : (!type.alloca) -> !type.unk
+    %13 = "verona.constant(3)"() : () -> !type.int
+    %14 = "verona.add"(%12, %13) : (!type.unk, !type.int) -> !type.unk
+    %15 = "verona.store"(%14, %11) : (!type.unk, !type.alloca) -> !type.unk
+    %16 = "verona.load"(%0) : (!type.alloca) -> !type.unk
+    %17 = "verona.load"(%11) : (!type.alloca) -> !type.unk
+    %18 = "verona.add"(%16, %17) : (!type.unk, !type.unk) -> !type.unk
+    %19 = "verona.store"(%18, %0) : (!type.unk, !type.alloca) -> !type.unk
+    br ^bb1
+  ^bb3:  // pred: ^bb1
+    %20 = "verona.load"(%0) : (!type.alloca) -> !type.unk
+    %21 = "verona.cast"(%20) : (!type.unk) -> none
+    return %21 : none
+  }
+}

--- a/testsuite/mlir/mlir-parse/while-if.verona
+++ b/testsuite/mlir/mlir-parse/while-if.verona
@@ -1,0 +1,14 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+f(a, x)
+{
+  while (a < 5)
+  {
+    if (a != x)
+    {
+      a = a + 1;
+    }
+  }
+  a;
+}

--- a/testsuite/mlir/mlir-parse/while-if/out.mlir
+++ b/testsuite/mlir/mlir-parse/while-if/out.mlir
@@ -1,0 +1,33 @@
+
+
+module {
+  func @f(%arg0: none, %arg1: none) -> none {
+    %0 = "verona.alloca"() : () -> !type.alloca
+    %1 = "verona.store"(%arg0, %0) : (none, !type.alloca) -> !type.unk
+    %2 = "verona.alloca"() : () -> !type.alloca
+    %3 = "verona.store"(%arg1, %2) : (none, !type.alloca) -> !type.unk
+    br ^bb1
+  ^bb1:  // 2 preds: ^bb0, ^bb5
+    %4 = "verona.load"(%0) : (!type.alloca) -> !type.unk
+    %5 = "verona.constant(5)"() : () -> !type.int
+    %6 = "verona.lt"(%4, %5) : (!type.unk, !type.int) -> i1
+    cond_br %6, ^bb2, ^bb3
+  ^bb2:  // pred: ^bb1
+    %7 = "verona.load"(%0) : (!type.alloca) -> !type.unk
+    %8 = "verona.load"(%2) : (!type.alloca) -> !type.unk
+    %9 = "verona.ne"(%7, %8) : (!type.unk, !type.unk) -> i1
+    cond_br %9, ^bb4, ^bb5
+  ^bb3:  // pred: ^bb1
+    %10 = "verona.load"(%0) : (!type.alloca) -> !type.unk
+    %11 = "verona.cast"(%10) : (!type.unk) -> none
+    return %11 : none
+  ^bb4:  // pred: ^bb2
+    %12 = "verona.load"(%0) : (!type.alloca) -> !type.unk
+    %13 = "verona.constant(1)"() : () -> !type.int
+    %14 = "verona.add"(%12, %13) : (!type.unk, !type.int) -> !type.unk
+    %15 = "verona.store"(%14, %0) : (!type.unk, !type.alloca) -> !type.unk
+    br ^bb5
+  ^bb5:  // 2 preds: ^bb2, ^bb4
+    br ^bb1
+  }
+}

--- a/testsuite/mlir/mlir-parse/while.verona
+++ b/testsuite/mlir/mlir-parse/while.verona
@@ -1,0 +1,11 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+f(a)
+{
+  while (a < 5)
+  {
+    a = a + 1;
+  }
+  a;
+}

--- a/testsuite/mlir/mlir-parse/while/mlir.out
+++ b/testsuite/mlir/mlir-parse/while/mlir.out
@@ -1,0 +1,24 @@
+
+
+module {
+  func @f(%arg0: none) -> none {
+    %0 = "verona.alloca"() : () -> !type.alloca
+    %1 = "verona.store"(%arg0, %0) : (none, !type.alloca) -> !type.unk
+    br ^bb1
+  ^bb1:  // 2 preds: ^bb0, ^bb2
+    %2 = "verona.load"(%0) : (!type.alloca) -> !type.unk
+    %3 = "verona.constant(5)"() : () -> !type.int
+    %4 = "verona.lt"(%2, %3) : (!type.unk, !type.int) -> i1
+    cond_br %4, ^bb2, ^bb3
+  ^bb2:  // pred: ^bb1
+    %5 = "verona.load"(%0) : (!type.alloca) -> !type.unk
+    %6 = "verona.constant(1)"() : () -> !type.int
+    %7 = "verona.add"(%5, %6) : (!type.unk, !type.int) -> !type.unk
+    %8 = "verona.store"(%7, %0) : (!type.unk, !type.alloca) -> !type.unk
+    br ^bb1
+  ^bb3:  // pred: ^bb1
+    %9 = "verona.load"(%0) : (!type.alloca) -> !type.unk
+    %10 = "verona.cast"(%9) : (!type.unk) -> none
+    return %10 : none
+  }
+}


### PR DESCRIPTION
While implementing simple while blocks, I realised the variable context for lexical blocks wasn't pushing new frames when entering if/else blocks, which were also needed when entering loop blocks. This PR fixes that problem and implements simple while loops with conditionals, continue and break.

Not supported yet: nested loops. I need to do the refactor of the BranchOp / Value return that I mention in the TODO. This will be done next.

The patches can be reviewed as one or individually.

Continues to implement #117.