### PR TITLE
Adding support for function calls and return values

### DIFF
--- a/src/mlir/ast-utils.cc
+++ b/src/mlir/ast-utils.cc
@@ -56,6 +56,13 @@ namespace mlir::verona::ASTInterface
     return *sub;
   }
 
+  ::ast::WeakAst getSingleSubNode(::ast::WeakAst ast)
+  {
+    auto ptr = ast.lock();
+    assert(ptr->nodes.size() == 1 && "Wrong number of nodes");
+    return ptr->nodes[0];
+  }
+
   std::vector<::ast::WeakAst> getSubNodes(::ast::WeakAst ast)
   {
     auto ptr = ast.lock();
@@ -237,6 +244,11 @@ namespace mlir::verona::ASTInterface
     return isA(ast, NodeKind::Call);
   }
 
+  bool isReturn(::ast::WeakAst ast)
+  {
+    return isA(ast, NodeKind::Return);
+  }
+
   bool isAssign(::ast::WeakAst ast)
   {
     return isA(ast, NodeKind::Assign);
@@ -286,6 +298,15 @@ namespace mlir::verona::ASTInterface
     // All others in 'args'
     auto args = findNode(ast, NodeKind::Args);
     return args.lock()->nodes[n - 1];
+  }
+
+  std::vector<::ast::WeakAst> getAllOperands(::ast::WeakAst ast)
+  {
+    auto numOps = numOperands(ast);
+    std::vector<::ast::WeakAst> ops;
+    for (size_t i = 0; i < numOps; i++)
+      ops.push_back(getOperand(ast, i));
+    return ops;
   }
 
   // ================================================= Condition Helpers

--- a/src/mlir/ast-utils.h
+++ b/src/mlir/ast-utils.h
@@ -64,6 +64,7 @@ namespace mlir::verona::ASTInterface
     Assign = peg::str2tag("assign"),
     Let = peg::str2tag("let"),
     Call = peg::str2tag("call"),
+    Return = peg::str2tag("return"),
     Args = peg::str2tag("args"),
     Integer = peg::str2tag("int"),
     Local = peg::str2tag("local"),
@@ -99,6 +100,8 @@ namespace mlir::verona::ASTInterface
   bool hasA(::ast::WeakAst ast, NodeKind kind);
   /// Find a sub-node of tag 'type'
   ::ast::WeakAst findNode(::ast::WeakAst ast, NodeType type);
+  /// Return the single sub-node, error out if more than one
+  ::ast::WeakAst getSingleSubNode(::ast::WeakAst ast);
   /// Return a list of sub-nodes
   std::vector<::ast::WeakAst> getSubNodes(::ast::WeakAst ast);
 
@@ -149,6 +152,8 @@ namespace mlir::verona::ASTInterface
   // ================================================= Operation Helpers
   /// Return true if node is an operation/call
   bool isCall(::ast::WeakAst ast);
+  /// Return true if node is a return
+  bool isReturn(::ast::WeakAst ast);
   /// Return true if node is an assignment
   bool isAssign(::ast::WeakAst ast);
   /// Return the left-hand side of an assignment
@@ -163,6 +168,8 @@ namespace mlir::verona::ASTInterface
   bool isBinary(::ast::WeakAst ast);
   /// Return the n-th operand of the operation
   ::ast::WeakAst getOperand(::ast::WeakAst ast, size_t n);
+  /// Return all operands of the operation
+  std::vector<::ast::WeakAst> getAllOperands(::ast::WeakAst ast);
 
   // ================================================= Condition Helpers
   /// Return true if node is an if statement

--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -110,6 +110,7 @@ namespace mlir::verona
     // Specific parsers (there will be more).
     llvm::Expected<mlir::Value> parseAssign(const ::ast::Ast& ast);
     llvm::Expected<mlir::Value> parseCall(const ::ast::Ast& ast);
+    llvm::Expected<mlir::Value> parseReturn(const ::ast::Ast& ast);
     llvm::Expected<mlir::Value> parseCondition(const ::ast::Ast& ast);
     llvm::Expected<mlir::Value> parseWhileLoop(const ::ast::Ast& ast);
     llvm::Expected<mlir::Value> parseContinue(const ::ast::Ast& ast);

--- a/testsuite/mlir/mlir-parse/call.verona
+++ b/testsuite/mlir/mlir-parse/call.verona
@@ -6,7 +6,17 @@ foo(a: N, b: U64 & imm): R
   where R: U64 & imm
 {
   let x = a + b;
-  // CHECK: Function calls not implemented yet at loc.*call.verona":${LINE:+1}:14
-  let r: R = foo(a, b);
-  x
+  let y = a - b;
+  if (x < 100)
+  {
+    return foo(x, y);
+  }
+  x + y;
+}
+
+()
+{
+  let a: imm = 10;
+  let b: U64 & imm = 20;
+  foo(a, b);
 }

--- a/testsuite/mlir/mlir-parse/call/out.mlir
+++ b/testsuite/mlir/mlir-parse/call/out.mlir
@@ -1,0 +1,52 @@
+
+
+module {
+  func @foo(%arg0: !type.imm, %arg1: !type<"U64&imm">) -> !type<"U64&imm"> {
+    %0 = "verona.alloca"() : () -> !type.alloca
+    %1 = "verona.store"(%arg0, %0) : (!type.imm, !type.alloca) -> !type.unk
+    %2 = "verona.alloca"() : () -> !type.alloca
+    %3 = "verona.store"(%arg1, %2) : (!type<"U64&imm">, !type.alloca) -> !type.unk
+    %4 = "verona.alloca"() : () -> !type.alloca
+    %5 = "verona.load"(%0) : (!type.alloca) -> !type.unk
+    %6 = "verona.load"(%2) : (!type.alloca) -> !type.unk
+    %7 = "verona.add"(%5, %6) : (!type.unk, !type.unk) -> !type.unk
+    %8 = "verona.store"(%7, %4) : (!type.unk, !type.alloca) -> !type.unk
+    %9 = "verona.alloca"() : () -> !type.alloca
+    %10 = "verona.load"(%0) : (!type.alloca) -> !type.unk
+    %11 = "verona.load"(%2) : (!type.alloca) -> !type.unk
+    %12 = "verona.sub"(%10, %11) : (!type.unk, !type.unk) -> !type.unk
+    %13 = "verona.store"(%12, %9) : (!type.unk, !type.alloca) -> !type.unk
+    %14 = "verona.load"(%4) : (!type.alloca) -> !type.unk
+    %15 = "verona.constant(100)"() : () -> !type.int
+    %16 = "verona.lt"(%14, %15) : (!type.unk, !type.int) -> i1
+    cond_br %16, ^bb1, ^bb2
+  ^bb1:  // pred: ^bb0
+    %17 = "verona.load"(%4) : (!type.alloca) -> !type.unk
+    %18 = "verona.cast"(%17) : (!type.unk) -> !type.imm
+    %19 = "verona.load"(%9) : (!type.alloca) -> !type.unk
+    %20 = "verona.cast"(%19) : (!type.unk) -> !type<"U64&imm">
+    %21 = call @foo(%18, %20) : (!type.imm, !type<"U64&imm">) -> !type<"U64&imm">
+    return %21 : !type<"U64&imm">
+  ^bb2:  // pred: ^bb0
+    %22 = "verona.load"(%4) : (!type.alloca) -> !type.unk
+    %23 = "verona.load"(%9) : (!type.alloca) -> !type.unk
+    %24 = "verona.add"(%22, %23) : (!type.unk, !type.unk) -> !type.unk
+    %25 = "verona.cast"(%24) : (!type.unk) -> !type<"U64&imm">
+    return %25 : !type<"U64&imm">
+  }
+  func @apply() -> none {
+    %0 = "verona.alloca"() : () -> !type.alloca
+    %1 = "verona.constant(10)"() : () -> !type.int
+    %2 = "verona.store"(%1, %0) : (!type.int, !type.alloca) -> !type.unk
+    %3 = "verona.alloca"() : () -> !type.alloca
+    %4 = "verona.constant(20)"() : () -> !type.int
+    %5 = "verona.store"(%4, %3) : (!type.int, !type.alloca) -> !type.unk
+    %6 = "verona.load"(%0) : (!type.alloca) -> !type.unk
+    %7 = "verona.cast"(%6) : (!type.unk) -> !type.imm
+    %8 = "verona.load"(%3) : (!type.alloca) -> !type.unk
+    %9 = "verona.cast"(%8) : (!type.unk) -> !type<"U64&imm">
+    %10 = call @foo(%7, %9) : (!type.imm, !type<"U64&imm">) -> !type<"U64&imm">
+    %11 = "verona.cast"(%10) : (!type<"U64&imm">) -> none
+    return %11 : none
+  }
+}


### PR DESCRIPTION
Changing how to detect basic-block termination to account for all known
terminators and empty basic blocks, so we don't need to terminate blocks
that have already been handled.

Implementing return values (of single expressions) as well as function
calls with the appropriate casts for the arguments, given we don't yet
know all types at this time.

If Verona accepts multiple return values, we'll need to change the
return value of all `parseX` functions to a vector of values. This
should be done later, as a refactor PR with examples. It will also fix
the `return mlir::Value()` problem, as we can return an empty list.

(ref. #117)