### PR TITLE
Bail out on MLIR parsing errors.

### DIFF
--- a/src/mlir/generator.cc
+++ b/src/mlir/generator.cc
@@ -68,17 +68,14 @@ namespace mlir::verona
       return runtimeError(
         "Cannot open file " + filename + ": " + err.message());
 
-    // Setup source manager and parse
+    // Setup source manager and parse the input. This includes verification of
+    // the IR.
     llvm::SourceMgr sourceMgr;
     sourceMgr.AddNewSourceBuffer(std::move(*srcOrErr), llvm::SMLoc());
     module = mlir::parseSourceFile(sourceMgr, builder.getContext());
+    if (!module)
+      return runtimeError("Can't load MLIR file");
 
-    // On error, dump module for debug purposes
-    if (mlir::failed(mlir::verify(*module)))
-    {
-      module->dump();
-      return runtimeError("MLIR verification failed from MLIR file");
-    }
     return llvm::Error::success();
   }
 


### PR DESCRIPTION
Otherwise we would be proceeding with a null pointer.

Additionally parseSourceFile already runs the verifier, so no point in running it again ourselves.