### PR TITLE
Add a driver class responsible for running passes.

### DIFF
--- a/src/mlir/CMakeLists.txt
+++ b/src/mlir/CMakeLists.txt
@@ -60,7 +60,11 @@ set(LIBS
         MLIRTargetLLVMIR
         verona-ast-lib
         )
-add_llvm_executable(verona-mlir verona-mlir.cc generator.cc error.cc)
+add_llvm_executable(verona-mlir
+  verona-mlir.cc
+  generator.cc
+  error.cc
+  driver.cc)
 
 # Disable exception handling once we separated peglib from LLVM
 #target_compile_options(verona-mlir PRIVATE -fno-rtti -fno-exceptions)

--- a/src/mlir/driver.cc
+++ b/src/mlir/driver.cc
@@ -1,0 +1,130 @@
+#include "driver.h"
+
+#include "generator.h"
+#include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVMPass.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Parser.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/Passes.h"
+
+#include "llvm/IR/Module.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/ToolOutputFile.h"
+
+namespace mlir::verona
+{
+  Driver::Driver(unsigned optLevel, bool lowerToLLVM) : passManager(&context)
+  {
+    // Opaque operations and types can only exist if we allow
+    // unregistered dialects to co-exist. Full conversions later will
+    // make sure we end up with only Verona dialect, then Standard
+    // dialects, then LLVM dialect, before converting to LLVM IR.
+    context.allowUnregisteredDialects();
+
+    // TODO: make the set of passes configurable from the command-line
+    if (optLevel > 0)
+    {
+      passManager.addPass(mlir::createInlinerPass());
+      passManager.addPass(mlir::createSymbolDCEPass());
+
+      mlir::OpPassManager& funcPM = passManager.nest<mlir::FuncOp>();
+      funcPM.addPass(mlir::createCanonicalizerPass());
+      funcPM.addPass(mlir::createCSEPass());
+    }
+    if (lowerToLLVM)
+    {
+      passManager.addPass(mlir::createLowerToLLVMPass());
+    }
+  }
+
+  llvm::Error Driver::readAST(const ::ast::Ast& ast)
+  {
+    auto result = Generator::lower(&context, ast);
+    if (!result)
+      return result.takeError();
+
+    module = std::move(*result);
+
+    if (failed(verify(*module)))
+    {
+      module->dump();
+      return runtimeError("AST was lowered to invalid MLIR");
+    }
+
+    return llvm::Error::success();
+  }
+
+  llvm::Error Driver::readMLIR(const std::string& filename)
+  {
+    if (filename.empty())
+      return runtimeError("No input filename provided");
+
+    // Read an MLIR file
+    auto srcOrErr = llvm::MemoryBuffer::getFileOrSTDIN(filename);
+
+    if (auto err = srcOrErr.getError())
+      return runtimeError(
+        "Cannot open file " + filename + ": " + err.message());
+
+    // Setup source manager and parse the input.
+    // `parseSourceFile` already includes verification of the IR.
+    llvm::SourceMgr sourceMgr;
+    sourceMgr.AddNewSourceBuffer(std::move(*srcOrErr), llvm::SMLoc());
+    module = mlir::parseSourceFile(sourceMgr, &context);
+    if (!module)
+      return runtimeError("Can't load MLIR file");
+
+    return llvm::Error::success();
+  }
+
+  llvm::Error Driver::process()
+  {
+    if (failed(passManager.run(module.get())))
+    {
+      module->dump();
+      return runtimeError("Failed to run some passes");
+    }
+
+    return llvm::Error::success();
+  }
+
+  llvm::Error Driver::emitMLIR(llvm::StringRef filename)
+  {
+    if (filename.empty())
+      return runtimeError("No output filename provided");
+
+    // Write to the file requested
+    std::error_code error;
+    auto out = llvm::raw_fd_ostream(filename, error);
+    if (error)
+      return runtimeError("Cannot open output filename");
+
+    module->print(out);
+    return llvm::Error::success();
+  }
+
+  llvm::Error Driver::emitLLVM(llvm::StringRef filename)
+  {
+    if (filename.empty())
+      return runtimeError("No output filename provided");
+
+    // Lower the module to LLVM IR.
+    // For this to work, the module must only contain LLVM dialect, ie. the
+    // driver must have been configured to run the "Lower to LLVM" pass.
+    auto llvm = mlir::translateModuleToLLVMIR(module.get());
+    if (!llvm)
+    {
+      module->dump();
+      return runtimeError("Failed to lower to LLVM IR");
+    }
+
+    // Write to the file requested
+    std::error_code error;
+    auto out = llvm::raw_fd_ostream(filename, error);
+    if (error)
+      return runtimeError("Cannot open output filename");
+
+    llvm->print(out, nullptr);
+    return llvm::Error::success();
+  }
+}

--- a/src/mlir/driver.cc
+++ b/src/mlir/driver.cc
@@ -1,3 +1,6 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
 #include "driver.h"
 
 #include "generator.h"

--- a/src/mlir/driver.h
+++ b/src/mlir/driver.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "ast/ast.h"
+#include "error.h"
+#include "mlir/IR/Module.h"
+#include "mlir/Pass/PassManager.h"
+
+namespace mlir::verona
+{
+  /**
+   * Main compiler API.
+   *
+   * The driver is used by calling three methods in succession:
+   * - `readXXX` is used to load the MLIR module. It can either be loaded from
+   *    textual MLIR or from the AST.
+   * - `process` runs the MLIR lowering pipeline. Passes are selected by the
+   *    Driver's constructor's arguments.
+   * - `emitXXX` writes the result to a text file, either in MLIR or in LLVM IR
+   *    format.
+   *
+   * For now, the error handling is crude and needs proper consideration,
+   * especially aggregating all errors and context before sending it back to
+   * the public API callers.
+   */
+  class Driver
+  {
+  public:
+    Driver(unsigned optLevel = 0, bool lowerToLLVM = false);
+
+    // TODO: add a readSource function that parses Verona source code.
+    // this might be more thinking about the error API of the Driver.
+
+    /// Lower an AST into an MLIR module, which is loaded in the driver.
+    llvm::Error readAST(const ::ast::Ast& ast);
+
+    /// Read textual MLIR into the driver's module.
+    llvm::Error readMLIR(const std::string& filename);
+
+    // Run the MLIR pipeline on the module. This uses the passes that were
+    // configured by the driver's constructor.
+    llvm::Error process();
+
+    /// Emit the module as textual LLVM IR.
+    /// This will fail if the module is not in LLVM dialect yet.
+    llvm::Error emitLLVM(const llvm::StringRef filename);
+
+    /// Emit the module as textual MLIR.
+    llvm::Error emitMLIR(const llvm::StringRef filename);
+
+  private:
+    /// MLIR context.
+    mlir::MLIRContext context;
+
+    /// MLIR module.
+    /// It gets modified as the driver progresses through its passes.
+    mlir::OwningModuleRef module;
+
+    /// MLIR Pass Manager
+    /// It gets configured by the constructor based on the provided arguments.
+    mlir::PassManager passManager;
+  };
+}

--- a/src/mlir/driver.h
+++ b/src/mlir/driver.h
@@ -10,13 +10,11 @@ namespace mlir::verona
   /**
    * Main compiler API.
    *
-   * The driver is used by calling three methods in succession:
-   * - `readXXX` is used to load the MLIR module. It can either be loaded from
-   *    textual MLIR or from the AST.
-   * - `process` runs the MLIR lowering pipeline. Passes are selected by the
-   *    Driver's constructor's arguments.
-   * - `emitXXX` writes the result to a text file, either in MLIR or in LLVM IR
-   *    format.
+   * The driver is user by first calling one of the `readXXX` methods, followed
+   * by `emitMLIR`. The various `readXXX` methods allow using different kinds of
+   * input.
+   *
+   * The lowering pipeline is configured through Driver's constructor arguments.
    *
    * For now, the error handling is crude and needs proper consideration,
    * especially aggregating all errors and context before sending it back to
@@ -25,7 +23,7 @@ namespace mlir::verona
   class Driver
   {
   public:
-    Driver(unsigned optLevel = 0, bool lowerToLLVM = false);
+    Driver(unsigned optLevel = 0);
 
     // TODO: add a readSource function that parses Verona source code.
     // this might be more thinking about the error API of the Driver.
@@ -35,14 +33,6 @@ namespace mlir::verona
 
     /// Read textual MLIR into the driver's module.
     llvm::Error readMLIR(const std::string& filename);
-
-    // Run the MLIR pipeline on the module. This uses the passes that were
-    // configured by the driver's constructor.
-    llvm::Error process();
-
-    /// Emit the module as textual LLVM IR.
-    /// This will fail if the module is not in LLVM dialect yet.
-    llvm::Error emitLLVM(const llvm::StringRef filename);
 
     /// Emit the module as textual MLIR.
     llvm::Error emitMLIR(const llvm::StringRef filename);

--- a/src/mlir/driver.h
+++ b/src/mlir/driver.h
@@ -1,3 +1,6 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
 #pragma once
 
 #include "ast/ast.h"

--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -133,10 +133,13 @@ namespace mlir::verona
 
     /// MLIR module.
     mlir::OwningModuleRef module;
-    /// MLIR context.
+
+    /// MLIR context. This is owned by the caller of Generator::lower.
     mlir::MLIRContext* context;
+
     /// MLIR builder.
     mlir::OpBuilder builder;
+
     /// Current MLIR function.
     mlir::FuncOp currentFunc;
 

--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -104,55 +104,39 @@ namespace mlir::verona
 
   /**
    * MLIR Generator.
-   *
-   * There are two entry points: AST and MLIR, and two exit points: MLIR
-   * and LLVM IR. The MLIR -> MLIR path is for self-validation and future
-   * optimisation passes (mainly testing).
-   *
-   * The LLVM IR can be dumped or used in the next step of the compilation,
-   * lowering to machine code by the LLVM library.
-   *
-   * For now, the error handling is crude and needs proper consideration,
-   * especially aggregating all errors and context before sending it back to
-   * the public API callers.
    */
   struct Generator
   {
-    Generator() : builder(&context)
-    {
-      // Opaque operations and types can only exist if we allow
-      // unregistered dialects to co-exist. Full conversions later will
-      // make sure we end up with onlt Verona dialect, then Standard
-      // dialects, then LLVM dialect, before converting to LLVM IR.
-      context.allowUnregisteredDialects();
+    /**
+     * Convert an AST into a high-level MLIR module.
+     *
+     * Currently this generates opaque MLIR operations, which can't be processed
+     * by the rest of the compiler, but we will slowly be transitioning to the
+     * Verona dialect.
+     *
+     */
+    static llvm::Expected<mlir::OwningModuleRef>
+    lower(MLIRContext* context, const ::ast::Ast& ast);
 
+  private:
+    Generator(MLIRContext* context) : context(context), builder(context)
+    {
       // Initialise known opaque types, for comparison.
       // TODO: Use Verona dialect types directly and isA<>.
-      allocaTy = genOpaqueType("alloca", context);
-      unkTy = genOpaqueType("unk", context);
-      noneTy = genOpaqueType("none", context);
+      allocaTy = genOpaqueType("alloca");
+      unkTy = genOpaqueType("unk");
+      noneTy = genOpaqueType("none");
       boolTy = builder.getI1Type();
     }
 
-    /// Read AST into MLIR module.
-    llvm::Error readAST(const ::ast::Ast& ast);
-    /// Read MLIR into MLIR module.
-    llvm::Error readMLIR(const std::string& filename);
-
-    /// Transform the opaque MLIR format into Verona dialect.
-    llvm::Error emitMLIR(const llvm::StringRef filename, unsigned optLevel = 0);
-    /// Transform the Verona dialect into LLVM IR.
-    llvm::Error emitLLVM(const llvm::StringRef filename, unsigned optLevel = 0);
-
     using Types = llvm::SmallVector<mlir::Type, 4>;
 
-  private:
     /// MLIR module.
     mlir::OwningModuleRef module;
+    /// MLIR context.
+    mlir::MLIRContext* context;
     /// MLIR builder.
     mlir::OpBuilder builder;
-    /// MLIR context.
-    mlir::MLIRContext context;
     /// Current MLIR function.
     mlir::FuncOp currentFunc;
 
@@ -225,8 +209,8 @@ namespace mlir::verona
       llvm::StringRef name,
       llvm::ArrayRef<mlir::Value> ops,
       mlir::Type retTy);
+
     /// Wrappers for opaque types before we use actual Verona dialect.
-    mlir::OpaqueType
-    genOpaqueType(llvm::StringRef name, mlir::MLIRContext& context);
+    mlir::OpaqueType genOpaqueType(llvm::StringRef name);
   };
 }

--- a/src/mlir/verona-mlir.cc
+++ b/src/mlir/verona-mlir.cc
@@ -154,7 +154,6 @@ int main(int argc, char** argv)
       return 1;
   }
 
-  check(driver.process());
   check(driver.emitMLIR(outputFile));
 
   return 0;

--- a/src/mlir/verona-mlir.cc
+++ b/src/mlir/verona-mlir.cc
@@ -9,7 +9,7 @@
 #include "ast/ref.h"
 #include "ast/sym.h"
 #include "dialect/VeronaDialect.h"
-#include "generator.h"
+#include "driver.h"
 #include "mlir/InitAllDialects.h"
 #include "mlir/InitAllPasses.h"
 
@@ -122,8 +122,7 @@ int main(int argc, char** argv)
     return 1;
   }
 
-  // MLIR Generator
-  mlir::verona::Generator gen;
+  mlir::verona::Driver driver(optLevel);
   llvm::ExitOnError check;
 
   // Parse the source file (verona/mlir)
@@ -143,19 +142,20 @@ int main(int argc, char** argv)
         return 1;
       }
       // Parse AST file into MLIR
-      check(gen.readAST(m->ast));
+      check(driver.readAST(m->ast));
     }
     break;
     case InputKind::MLIR:
       // Parse MLIR file
-      check(gen.readMLIR(inputFile));
+      check(driver.readMLIR(inputFile));
       break;
     default:
       std::cerr << "ERROR: invalid source file type" << std::endl;
       return 1;
   }
 
-  // Emit MLIR
-  check(gen.emitMLIR(outputFile, optLevel));
+  check(driver.process());
+  check(driver.emitMLIR(outputFile));
+
   return 0;
 }


### PR DESCRIPTION
This moves the MLIR/LLVM pipeline logic out of the generator and into
a new class. The Generator is now only responsible for AST->MLIR
conversion.

This will be helpful as we start adding more passes, and the logic to
handle those becomes more complicated.