### PR TITLE
LLVM update to 6ce97eee354

### DIFF
--- a/devops/ci.yml
+++ b/devops/ci.yml
@@ -69,6 +69,8 @@ jobs:
       set -eo pipefail
       sudo apt-get update
       sudo apt-get install -y ninja-build
+      sudo apt-get remove --purge cmake
+      sudo snap install cmake --classic
       sudo pip install wheel OutputCheck
     displayName: 'Dependencies'
 

--- a/devops/llvm.yml
+++ b/devops/llvm.yml
@@ -43,7 +43,8 @@ jobs:
   - script: |
       set -eo pipefail
       sudo apt-get update
-      sudo apt-get install -y clang ninja-build cmake lld
+      sudo apt-get install -y clang ninja-build lld
+      sudo snap install cmake --classic
       curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
     displayName: 'Install Build Dependencies'
 

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -71,6 +71,8 @@ jobs:
       set -eo pipefail
       sudo apt-get update
       sudo apt-get install -y ninja-build
+      sudo apt-get remove --purge cmake
+      sudo snap install cmake --classic
       sudo pip install wheel OutputCheck
     displayName: 'Dependencies'
 


### PR DESCRIPTION
Other than updating CMake, the change brings 4000-ish commits closer to trunk and breaks nothing else.