### PR TITLE
Use the new NoRegionArguments trait.

### DIFF
--- a/src/mlir/dialect/VeronaOps.cc
+++ b/src/mlir/dialect/VeronaOps.cc
@@ -87,10 +87,6 @@ static LogicalResult verify(verona::ClassOp classOp)
 {
   Block* body = classOp.getBody();
 
-  // This is the NoRegionArguments trait in recent LLVM
-  if (body->getNumArguments() != 0)
-    return classOp.emitOpError("expected body to have no arguments");
-
   // Verify that classes contain only fields, and that there are no duplicates.
   // TODO: once we add methods, verify that there are no duplicates either.
   llvm::StringSet<> fields;

--- a/src/mlir/dialect/VeronaOps.td
+++ b/src/mlir/dialect/VeronaOps.td
@@ -185,7 +185,8 @@ def Verona_AllocateObjectOp : Verona_Op<"new_object"> {
 
 def Verona_ClassOp : Verona_Op<"class", [
   Symbol, IsolatedFromAbove, SymbolTable,
-  SingleBlockImplicitTerminator<"ClassEndOp">
+  SingleBlockImplicitTerminator<"ClassEndOp">,
+  NoRegionArguments
 ]> {
     let summary = "Verona class definition";
     let description = [{


### PR DESCRIPTION
Class operations' regions shouldn't accept any arguments. Rather than
have custom logic for it, we can use upstream's new NoRegionArguments
trait.