### PR TITLE
Use MD5 hash to avoid downloading LLVM every time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ if (NOT DEFINED VERONA_LLVM_LOCATION)
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/external/llvm-project"
       OUTPUT_VARIABLE LLVM_PACKAGE_GIT_VERSION
     )
+    string(STRIP ${LLVM_PACKAGE_GIT_VERSION} LLVM_PACKAGE_GIT_VERSION)
 
     string(TOLOWER ${CMAKE_SYSTEM_NAME} PLATFORM)
 
@@ -108,7 +109,13 @@ if (NOT DEFINED VERONA_LLVM_LOCATION)
         set(LLVM_BUILD_TYPE release)
       endif ()
 
+      # Setup LLVM download (+MD5 string)
+      set(LLVM_URL https://verona.blob.core.windows.net/llvmbuild)
       set(PKG_NAME verona-llvm-install-x86_64-${PLATFORM}-${LLVM_BUILD_TYPE}-${LLVM_PACKAGE_GIT_VERSION})
+      set(MD5_NAME ${PKG_NAME}.md5)
+      file(DOWNLOAD "${LLVM_URL}/${MD5_NAME}" ${CMAKE_BINARY_DIR}/${MD5_NAME})
+      file(STRINGS ${CMAKE_BINARY_DIR}/${MD5_NAME} LLVM_MD5_SUM REGEX [0-9a-f]+)
+      string(STRIP ${LLVM_MD5_SUM} LLVM_MD5_SUM)
 
       # Quiet downloads are the default. Note that the download flag is reversed
       # so we created a more meaningful variable "verbose=true" -> "no progress=false"
@@ -119,7 +126,8 @@ if (NOT DEFINED VERONA_LLVM_LOCATION)
       endif()
 
       ExternalProject_Add(mlir-${BUILD_TYPE}
-        URL https://verona.blob.core.windows.net/llvmbuild/${PKG_NAME}
+        URL ${LLVM_URL}/${PKG_NAME}
+        URL_MD5 ${LLVM_MD5_SUM}
         DOWNLOAD_NO_PROGRESS ${LLVM_DOWNLOAD_NO_PROGRESS}
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""

--- a/devops/llvm.yml
+++ b/devops/llvm.yml
@@ -64,11 +64,13 @@ jobs:
       set -eo pipefail
       rm -f $(PKG_NAME).tar.gz
       tar zcf $(PKG_NAME).tar.gz build/install
+      md5sum $(PKG_NAME).tar.gz | awk '{print $1}' > $(PKG_NAME).tar.gz.md5
     displayName: 'Create package'
 
   - script: |
       set -eo pipefail
       az storage blob upload --container-name llvmbuild --file $(PKG_NAME).tar.gz --name $(PKG_NAME) --connection-string "$(BLOB_CONNECTION_STRING)"
+      az storage blob upload --container-name llvmbuild --file $(PKG_NAME).tar.gz.md5 --name $(PKG_NAME).md5 --connection-string "$(BLOB_CONNECTION_STRING)"
     displayName: 'Upload package'
 
 ############################################## Windows Builds
@@ -127,9 +129,17 @@ jobs:
       tar.exe -z -c -f $(PKG_NAME).tar.gz build/install
     displayName: 'Create package'
 
+  - powershell:
+      Get-FileHash $(PKG_NAME).tar.gz -Algorithm MD5 | Select-Object Hash | Format-Wide > $(PKG_NAME).tar.gz.md5
+    displayName: 'Create MD5'
+
   - script: |
       "C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\wbin\az" storage blob upload --container-name llvmbuild --file $(PKG_NAME).tar.gz --name $(PKG_NAME) --connection-string "$(BLOB_CONNECTION_STRING)"
     displayName: 'Upload package'
+
+  - script: |
+      "C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\wbin\az" storage blob upload --container-name llvmbuild --file $(PKG_NAME).tar.gz.md5 --name $(PKG_NAME).md5 --connection-string "$(BLOB_CONNECTION_STRING)"
+    displayName: 'Upload MD5'
 
 ############################################## MacOS Builds
 - job:
@@ -175,9 +185,11 @@ jobs:
       set -eo pipefail
       rm -f $(PKG_NAME).tar.gz
       tar zcf $(PKG_NAME).tar.gz build/install
+      md5 -r $(PKG_NAME).tar.gz | awk '{print $1}' > $(PKG_NAME).tar.gz.md5
     displayName: 'Create package'
 
   - script: |
       set -eo pipefail
       az storage blob upload --container-name llvmbuild --file $(PKG_NAME).tar.gz --name $(PKG_NAME) --connection-string "$(BLOB_CONNECTION_STRING)"
+      az storage blob upload --container-name llvmbuild --file $(PKG_NAME).tar.gz.md5 --name $(PKG_NAME).md5 --connection-string "$(BLOB_CONNECTION_STRING)"
     displayName: 'Upload package'

--- a/src/mlir/CMakeLists.txt
+++ b/src/mlir/CMakeLists.txt
@@ -10,6 +10,10 @@ if (MSVC)
   add_compile_definitions(_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING)
 endif ()
 
+# LLVM requires CMake 3.13+ and this policy is for 3.12-, so we force new to
+# avoid the CMake warnings on LLVM CMake files that we can't change
+cmake_policy(SET CMP0077 NEW)
+
 # Find MLIR_DIR and LLVM_EXTERNAL_LIT from LLVM_BUILD
 set(LLVM_DIR ${LLVM_BUILD}/lib/cmake/llvm)
 message(STATUS "Setting LLVM_DIR as ${LLVM_DIR}")


### PR DESCRIPTION
LLVM Build: https://dev.azure.com/ProjectVeronaCI/Project%20Verona/_build/results?buildId=1364&view=results

All MD5 files are in the container, Verona build works nicely with and without the archive.