### PR TITLE
Update build matrix with specific types of builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ This project is at a very early stage, parts of the type checker are still to be
 implemented, and there are very few language features implemented yet. This will
 change, but will take time.
 
-Nightly Build (Win/Lin/Mac) [![Build Status](https://dev.azure.com/ProjectVeronaCI/Project%20Verona/_apis/build/status/Verona%20Nightly?branchName=master)](https://dev.azure.com/ProjectVeronaCI/Project%20Verona/_build/latest?definitionId=6&branchName=master)
+## Nightly Build
+
+Distro\Build | Release | Debug | ASAN 
+--------|---------|-------|--------
+Linux | [![Build Status](https://dev.azure.com/ProjectVeronaCI/Project%20Verona/_apis/build/status/Verona%20Nightly?branchName=master&jobName=Linux&configuration=Linux%20Clang%20Release)](https://dev.azure.com/ProjectVeronaCI/Project%20Verona/_build/latest?definitionId=6&branchName=master) | [![Build Status](https://dev.azure.com/ProjectVeronaCI/Project%20Verona/_apis/build/status/Verona%20Nightly?branchName=master&jobName=Linux&configuration=Linux%20Clang%20Debug)](https://dev.azure.com/ProjectVeronaCI/Project%20Verona/_build/latest?definitionId=6&branchName=master) | [![Build Status](https://dev.azure.com/ProjectVeronaCI/Project%20Verona/_apis/build/status/Verona%20Nightly?branchName=master&jobName=Linux&configuration=Linux%20Clang%20Debug%20(ASAN))](https://dev.azure.com/ProjectVeronaCI/Project%20Verona/_build/latest?definitionId=6&branchName=master)
+Windows | [![Build Status](https://dev.azure.com/ProjectVeronaCI/Project%20Verona/_apis/build/status/Verona%20Nightly?branchName=master&jobName=Windows&configuration=Windows%20Release)](https://dev.azure.com/ProjectVeronaCI/Project%20Verona/_build/latest?definitionId=6&branchName=master) | [![Build Status](https://dev.azure.com/ProjectVeronaCI/Project%20Verona/_apis/build/status/Verona%20Nightly?branchName=master&jobName=Windows&configuration=Windows%20RelWithDebInfo)](https://dev.azure.com/ProjectVeronaCI/Project%20Verona/_build/latest?definitionId=6&branchName=master) |
+Darwin | [![Build Status](https://dev.azure.com/ProjectVeronaCI/Project%20Verona/_apis/build/status/Verona%20Nightly?branchName=master&jobName=macOS&configuration=macOS%20Release)](https://dev.azure.com/ProjectVeronaCI/Project%20Verona/_build/latest?definitionId=6&branchName=master) | [![Build Status](https://dev.azure.com/ProjectVeronaCI/Project%20Verona/_apis/build/status/Verona%20Nightly?branchName=master&jobName=macOS&configuration=macOS%20Debug)](https://dev.azure.com/ProjectVeronaCI/Project%20Verona/_build/latest?definitionId=6&branchName=master) |
 
 # [Building](docs/building.md)
 


### PR DESCRIPTION
As mentioned in #181 we don't need to have different pipelines to show different badges for each build type.