### PR TITLE
disable -Werror outside of CI

### DIFF
--- a/src/rt/CMakeLists.txt
+++ b/src/rt/CMakeLists.txt
@@ -56,6 +56,12 @@ endif()
 
 if(VERONA_CI_BUILD)
   target_compile_definitions(verona_rt INTERFACE -DCI_BUILD)
+else()
+  if(MSVC)
+    target_compile_options(verona_rt INTERFACE /WX-)
+  else()
+    target_compile_options(verona_rt INTERFACE -Wno-error)
+  endif()
 endif()
 
 target_link_libraries(verona_rt INTERFACE snmalloc_lib)


### PR DESCRIPTION
This sets the `-Wno-error` compiler option when not compiling for CI. This is something I always do while debugging so that I don't spend so much time dealing with `warning: unused parameter` preventing the program from compiling.