### PR TITLE
Move RNG and Scrambler to systematic namespace

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -57,7 +57,7 @@ This has two compile options that can aid debugging:
 * BUILD_TRACING  - this outputs tracing during parsing the string
 * BUILD_AST_TRACING  - this outputs the construction of the AST nodes
 
-These can be set by passing cmake `-DBUILD_TRACING=On` and `-DBUILD_AST_TRACING=On` respectively.
+These can be set by passing cmake `-DBUILD_TRACING=ON` and `-DBUILD_AST_TRACING=ON` respectively.
 
 ## Debugging the interpreter
 
@@ -67,7 +67,7 @@ Every option that you can pass to the interpreter, can also be passed to the com
 ```
 interpreter foo.bc --verbose
 ```
-or 
+or
 ```
 veronac foo.verona --run --run-verbose
 ```
@@ -110,19 +110,19 @@ The majority of tests of the runtime cover a large number of pseudo-random trace
 
 highlights all of the features for running with the various logging and random seed approaches.
 
-To compile the run-time with systematic testing you can pass CMake `-DUSE_SYSTEMATIC_TESTING=On`, 
+To compile the run-time with systematic testing you can pass CMake `-DUSE_SYSTEMATIC_TESTING=ON`,
 and then in your program call
 ```C++
 Systematic::enable_logging();
 ```
 to print the logging, and
 ```C++
-Scheduler::get().set_seed(seed);
+Systematic::set_seed(seed);
 ```
 specifies the seed for the pseudo-random interleaving.
 The seed to interleaving should be consistent across platforms.
 
-To enable crash logging you can pass CMake `-DUSE_CRASH_LOGGING=On`
+To enable crash logging you can pass CMake `-DUSE_CRASH_LOGGING=ON`
 and in your program call
 ```C++
 Systematic::enable_crash_logging();
@@ -165,5 +165,5 @@ should be erased when compiling the runtime.
 ### ASAN
 
 The runtime is inherently unsafe.  Systematic testing gives good coverage of corner case, but cannot in itself detect memory corruption.
-In CI, we use ASAN to find memory safety violations. 
-ASAN can be enabled on Clang builds by passing CMake `-DUSE_ASAN=On`.
+In CI, we use ASAN to find memory safety violations.
+ASAN can be enabled on Clang builds by passing CMake `-DUSE_ASAN=ON`.

--- a/src/interpreter/interpreter.cc
+++ b/src/interpreter/interpreter.cc
@@ -31,11 +31,11 @@ namespace verona::interpreter
   void
   instantiate(size_t cores, const Code& code, bool verbose, size_t seed = 1234)
   {
+#ifdef USE_SYSTEMATIC_TESTING
+    Systematic::set_seed(seed);
+#endif
     rt::Scheduler& sched = rt::Scheduler::get();
     sched.init(cores);
-#ifdef USE_SYSTEMATIC_TESTING
-    sched.set_seed(seed);
-#endif
 
     size_t ip = code.entrypoint();
 

--- a/src/rt/ds/morebits.h
+++ b/src/rt/ds/morebits.h
@@ -40,9 +40,9 @@ namespace verona::rt
       return a & static_cast<T>(~(b >> shift));
     }
 
-    inline static size_t hash(const void* p)
+    inline static size_t hash(uintptr_t p)
     {
-      size_t x = static_cast<size_t>(snmalloc::address_cast(p));
+      size_t x = static_cast<size_t>(p);
 
       if (snmalloc::bits::is64())
       {

--- a/src/rt/ds/scramble.h
+++ b/src/rt/ds/scramble.h
@@ -32,6 +32,17 @@ namespace verona
 
     uintptr_t keys[ROUNDS];
 
+  public:
+    Scramble() {}
+
+    void setup(xoroshiro::p128r32& r)
+    {
+      for (size_t i = 0; i < ROUNDS; i++)
+      {
+        keys[i] = (uintptr_t)r.next();
+      }
+    }
+
     uintptr_t perm(uintptr_t p)
     {
       uintptr_t l = p & MASK_BOTTOM;
@@ -45,17 +56,6 @@ namespace verona
       }
 
       return l + ((uintptr_t)r << PTR_HALF_SHIFT);
-    }
-
-  public:
-    Scramble() {}
-
-    void setup(xoroshiro::p128r32& r)
-    {
-      for (size_t i = 0; i < ROUNDS; i++)
-      {
-        keys[i] = (uintptr_t)r.next();
-      }
     }
 
     /**

--- a/src/rt/ds/scramble.h
+++ b/src/rt/ds/scramble.h
@@ -57,14 +57,5 @@ namespace verona
 
       return l + ((uintptr_t)r << PTR_HALF_SHIFT);
     }
-
-    /**
-     * This operator provides a comparison using the builtin scrambling from the
-     * underlying feisel network.
-     **/
-    bool operator()(const void* p1, const void* p2)
-    {
-      return perm((uintptr_t)p1) < perm((uintptr_t)p2);
-    }
   };
 }

--- a/src/rt/object/object.h
+++ b/src/rt/object/object.h
@@ -198,7 +198,7 @@ namespace verona::rt
 #ifdef USE_SYSTEMATIC_TESTING
     // Used to give objects unique identifiers for systematic testing.
     inline static size_t id_source = 0;
-    size_t sys_id;
+    uintptr_t sys_id;
 #endif
 
   public:
@@ -222,7 +222,7 @@ namespace verona::rt
     inline const void* id() const
     {
 #ifdef USE_SYSTEMATIC_TESTING
-      return (void const*)sys_id;
+      return (const void*)Systematic::get_scrambler().perm(sys_id);
 #else
       return this;
 #endif

--- a/src/rt/object/object.h
+++ b/src/rt/object/object.h
@@ -219,12 +219,12 @@ namespace verona::rt
     }
 #endif
 
-    inline const void* id() const
+    inline uintptr_t id() const
     {
 #ifdef USE_SYSTEMATIC_TESTING
-      return (const void*)Systematic::get_scrambler().perm(sys_id);
+      return Systematic::get_scrambler().perm(sys_id);
 #else
-      return this;
+      return (uintptr_t)this;
 #endif
     }
 

--- a/src/rt/sched/base_noticeboard.h
+++ b/src/rt/sched/base_noticeboard.h
@@ -105,7 +105,7 @@ namespace verona::rt
         return;
       }
       auto n = update_buffer.size();
-      auto r = Scheduler::rand_get_next();
+      auto r = Systematic::get_rng().next();
       auto pick = (size_t)(r % (n + 1));
       if (pick == 0)
       {

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -737,7 +737,7 @@ namespace verona::rt
 
 #ifdef USE_SYSTEMATIC_TESTING
       std::sort(&sort[0], &sort[count], [](Cown*& a, Cown*& b) {
-        return Systematic::get_scrambler()(a->id(), b->id());
+        return a->id() < b->id();
       });
 #else
       std::sort(&sort[0], &sort[count]);

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -18,14 +18,6 @@ namespace verona::rt
   using CownThread = SchedulerThread<Cown>;
   using Scheduler = ThreadPool<CownThread>;
 
-#ifdef USE_SYSTEMATIC_TESTING
-  /// 1/2^range_bits likelyhood of coin saying true
-  inline bool coin(size_t range_bits)
-  {
-    return Scheduler::coin(range_bits);
-  }
-#endif
-
   static void yield()
   {
 #ifdef USE_SYSTEMATIC_TESTING
@@ -745,7 +737,7 @@ namespace verona::rt
 
 #ifdef USE_SYSTEMATIC_TESTING
       std::sort(&sort[0], &sort[count], [](Cown*& a, Cown*& b) {
-        return Scheduler::get_scrambler()(a->id(), b->id());
+        return Systematic::get_scrambler()(a->id(), b->id());
       });
 #else
       std::sort(&sort[0], &sort[count]);
@@ -811,7 +803,7 @@ namespace verona::rt
         yield();
       } while (
 #ifdef USE_SYSTEMATIC_TESTING
-        coin(9) ||
+        Systematic::coin(9) ||
 #endif
         !backpressure.compare_exchange_weak(
           bp, bp_unmuted, std::memory_order_acq_rel));
@@ -844,7 +836,7 @@ namespace verona::rt
         if (
           !sender->backpressure.load(std::memory_order_relaxed).overloaded()
 #ifdef USE_SYSTEMATIC_TESTING
-          && !coin(3)
+          && !Systematic::coin(3)
 #endif
         )
           continue;
@@ -881,7 +873,7 @@ namespace verona::rt
         if (
           bp.triggers_muting()
 #ifdef USE_SYSTEMATIC_TESTING
-          || coin(5)
+          || Systematic::coin(5)
 #endif
         )
         {
@@ -950,7 +942,7 @@ namespace verona::rt
         // cown to unmutable.
       } while (
 #ifdef USE_SYSTEMATIC_TESTING
-        coin(9) ||
+        Systematic::coin(9) ||
 #endif
         !backpressure.compare_exchange_weak(
           bp, bp_update, std::memory_order_acq_rel));

--- a/src/rt/sched/epoch.h
+++ b/src/rt/sched/epoch.h
@@ -4,16 +4,13 @@
 
 #include "../ds/asymlock.h"
 #include "../ds/queue.h"
+#include "../test/systematic.h"
 #include "region/immutable.h"
 
 #include <snmalloc.h>
 
 namespace verona::rt
 {
-#ifdef USE_SYSTEMATIC_TESTING
-  bool coin(size_t range_bits = 1);
-#endif
-
   static constexpr uint64_t EJECTED_BIT = 0x8000000000000000;
 
   static uint64_t inc_epoch_by(uint64_t epoch, uint64_t i)
@@ -201,7 +198,7 @@ namespace verona::rt
     bool advance_is_sensible()
     {
 #ifdef USE_SYSTEMATIC_TESTING
-      return coin(4);
+      return Systematic::coin(4);
 #else
       return *get_pressure(2) > 128;
 #endif
@@ -210,7 +207,7 @@ namespace verona::rt
     bool advance_is_urgent()
     {
 #ifdef USE_SYSTEMATIC_TESTING
-      return coin(7);
+      return Systematic::coin(7);
 #else
       return *get_pressure(2) > 1024;
 #endif

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -225,7 +225,7 @@ namespace verona::rt
 
         if (
 #ifdef USE_SYSTEMATIC_TESTING
-          coin(9) ||
+          Systematic::coin(9) ||
 #endif
           !cown->backpressure.compare_exchange_weak(
             bp, bp_muted, std::memory_order_acq_rel))
@@ -310,7 +310,7 @@ namespace verona::rt
         if (
           (total_cowns < (free_cowns << 1))
 #ifdef USE_SYSTEMATIC_TESTING
-          || Scheduler::coin()
+          || Systematic::coin()
 #endif
         )
           collect_cown_stubs();

--- a/src/rt/test/func/diningphilosophers/diningphil.cc
+++ b/src/rt/test/func/diningphilosophers/diningphil.cc
@@ -1,7 +1,6 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
 #include <ds/scramble.h>
-#include <random>
 #include <test/harness.h>
 
 struct Fork : public VCown<Fork>
@@ -157,7 +156,8 @@ void test_dining(
     std::vector<Cown*> my_forks;
 
     std::sort(forks.begin(), forks.end(), [&scrambler](Fork*& a, Fork*& b) {
-      return scrambler(((Cown*)a)->id(), ((Cown*)b)->id());
+      return scrambler.perm(((Cown*)a)->id()) <
+        scrambler.perm(((Cown*)b)->id());
     });
 
     for (size_t j = 0; j < fork_count; j++)

--- a/src/rt/test/func/ext_ref_freeze/ext_ref_freeze.cc
+++ b/src/rt/test/func/ext_ref_freeze/ext_ref_freeze.cc
@@ -154,13 +154,12 @@ struct Loop : public VAction<Loop>
 // 5. Clean up resource, and exit.
 void run_test(size_t cores = 4, size_t seed = 100)
 {
-  Scheduler& sched = Scheduler::get();
 #ifdef USE_SYSTEMATIC_TESTING
-  sched.set_seed(seed);
+  Systematic::set_seed(seed);
 #else
   UNUSED(seed);
 #endif
-
+  Scheduler& sched = Scheduler::get();
   sched.init(cores);
 
   auto* alloc = ThreadAlloc::get();

--- a/src/rt/test/func/scramble/scramble.cc
+++ b/src/rt/test/func/scramble/scramble.cc
@@ -9,17 +9,17 @@ int main()
   bool failed = false;
   for (size_t i = 0; i < 100; i++)
   {
-    verona::Scramble perm;
-    perm.setup(r);
+    verona::Scramble s1;
+    s1.setup(r);
 
-    verona::Scramble perm2;
-    perm2.setup(r);
+    verona::Scramble s2;
+    s2.setup(r);
 
     size_t count = 0;
 
-    for (uint8_t* p = nullptr; p < (void*)1000; p++)
+    for (uintptr_t p = 0; p < 1000; p++)
     {
-      if (perm(p, p + 1) == perm2(p, p + 1))
+      if ((s1.perm(p) < s1.perm(p + 1)) == (s2.perm(p) < s2.perm(p + 1)))
         count++;
     }
 

--- a/src/rt/test/harness.h
+++ b/src/rt/test/harness.h
@@ -89,7 +89,7 @@ public:
 
       Scheduler& sched = Scheduler::get();
 #ifdef USE_SYSTEMATIC_TESTING
-      sched.set_seed(seed);
+      Systematic::set_seed(seed);
       if (seed % 2 == 1)
       {
         sched.set_fair(true);
@@ -101,7 +101,6 @@ public:
 #else
       UNUSED(seed);
 #endif
-
       sched.init(cores);
 
       f(std::forward<Args>(args)...);

--- a/src/rt/test/perf/backpressure1/backpressure1.cc
+++ b/src/rt/test/perf/backpressure1/backpressure1.cc
@@ -143,14 +143,14 @@ int main(int argc, char** argv)
                  << ", receivers: " << receivers << ", duration: " << duration
                  << "ms" << std::endl;
 
-  auto& sched = Scheduler::get();
-  Scheduler::set_detect_leaks(true);
 #ifdef USE_SYSTEMATIC_TESTING
   Systematic::enable_logging();
-  sched.set_seed(seed);
+  Systematic::set_seed(seed);
 #else
   UNUSED(seed);
 #endif
+  Scheduler::set_detect_leaks(true);
+  auto& sched = Scheduler::get();
   sched.set_fair(true);
   sched.init(cores);
 

--- a/src/rt/test/perf/backpressure2/backpressure2.cc
+++ b/src/rt/test/perf/backpressure2/backpressure2.cc
@@ -131,12 +131,12 @@ int main(int argc, char** argv)
                  << ", receivers: " << receivers << ", duration: " << duration
                  << "ms" << std::endl;
 
-  auto& sched = Scheduler::get();
-  Scheduler::set_detect_leaks(true);
 #ifdef USE_SYSTEMATIC_TESTING
   Systematic::enable_logging();
-  sched.set_seed(seed);
+  Systematic::set_seed(seed);
 #endif
+  Scheduler::set_detect_leaks(true);
+  auto& sched = Scheduler::get();
   sched.set_fair(true);
   sched.init(cores);
 

--- a/src/rt/test/perf/backpressure3/backpressure3.cc
+++ b/src/rt/test/perf/backpressure3/backpressure3.cc
@@ -123,12 +123,12 @@ int main(int argc, char** argv)
   logger::cout() << "cores: " << cores << ", senders: " << senders
                  << ", duration: " << duration.count() << "ms" << std::endl;
 
-  auto& sched = Scheduler::get();
-  Scheduler::set_detect_leaks(true);
 #ifdef USE_SYSTEMATIC_TESTING
   Systematic::enable_logging();
-  sched.set_seed(seed);
+  Systematic::set_seed(seed);
 #endif
+  Scheduler::set_detect_leaks(true);
+  auto& sched = Scheduler::get();
   sched.set_fair(true);
   sched.init(cores);
 

--- a/src/rt/test/perf/ubench/ubench.cc
+++ b/src/rt/test/perf/ubench/ubench.cc
@@ -237,13 +237,13 @@ int main(int argc, char** argv)
                  << std::endl;
 
   auto* alloc = sn::ThreadAlloc::get();
-  auto& sched = rt::Scheduler::get();
 #ifdef USE_SYSTEMATIC_TESTING
   Systematic::enable_logging();
-  sched.set_seed(seed);
+  Systematic::set_seed(seed);
 #else
   UNUSED(seed);
 #endif
+  auto& sched = rt::Scheduler::get();
   sched.set_fair(true);
   sched.init(cores);
 


### PR DESCRIPTION
This change is made primarily to allow Object IDs to be a scrambled
permutation when systematic testing is enabled.