### PR TITLE
Fixes to CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,16 @@
 cmake_minimum_required(VERSION 3.10.0)
 
-option (VERONA_DOWNLOAD_LLVM "Download cached version of LLVM" ON)
-option (VERBOSE_LLVM_DOWNLOAD "Verbose LLVM/MLIR download step" OFF)
+# CMAKE_HOME_DIRECTORY should not be passed down to another project.
+set (VERONA_DONT_PASS CMAKE_HOME_DIRECTORY)
+macro (option_top VAR HELP DEFAULT)
+  option (${VAR} ${HELP} ${DEFAULT})
+  list (APPEND VERONA_DONT_PASS ${VAR})
+endmacro ()
 
+option_top (VERONA_DOWNLOAD_LLVM "Download cached version of LLVM" ON)
+option_top (VERBOSE_LLVM_DOWNLOAD "Verbose LLVM/MLIR download step" OFF)
+
+message (STATUS "Download LLVM: ${VERONA_DOWNLOAD_LLVM}")
 # Lifted from snmalloc. Hard to include with external projects, so copied
 macro(clangformat_targets)
   # The clang-format tool is installed under a variety of different names.  Try
@@ -33,26 +41,14 @@ endmacro()
 
 clangformat_targets()
 
-# This is used to create options that are passed through to the main Verona
-# build
-if (NOT DEFINED VERONA_EXTRA_CMAKE_ARGS)
-  set (VERONA_EXTRA_CMAKE_ARGS)
-endif ()
-macro(verona_option variable message default)
-  option(variable message default)
-  list (APPEND VERONA_EXTRA_CMAKE_ARGS
-    "-D${variable}=${${variable}}"
-  )
-endmacro()
-
-verona_option(ENABLE_ASSERTS "Enable asserts even in release builds" OFF)
-verona_option(RT_TESTS "Including unit tests for the runtime" OFF)
-verona_option(USE_SCHED_STATS "Track scheduler stats" OFF)
-verona_option(USE_ASAN "Use address sanitizer" OFF)
-verona_option(VERONA_CI_BUILD "Disable features not sensible for CI" OFF)
-verona_option(USE_SYSTEMATIC_TESTING "Enable systematic testing in the runtime" OFF)
-verona_option(VERONA_EXPENSIVE_SYSTEMATIC_TESTING "Increase the range of seeds covered by systematic testing" OFF)
-verona_option(USE_CRASH_LOGGING "Enable crash logging in the runtime" OFF)
+option(ENABLE_ASSERTS "Enable asserts even in release builds" OFF)
+option(RT_TESTS "Including unit tests for the runtime" OFF)
+option(USE_SCHED_STATS "Track scheduler stats" OFF)
+option(USE_ASAN "Use address sanitizer" OFF)
+option(VERONA_CI_BUILD "Disable features not sensible for CI" OFF)
+option(USE_SYSTEMATIC_TESTING "Enable systematic testing in the runtime" OFF)
+option(VERONA_EXPENSIVE_SYSTEMATIC_TESTING "Increase the range of seeds covered by systematic testing" OFF)
+option(USE_CRASH_LOGGING "Enable crash logging in the runtime" OFF)
 
 # This is to trick the CMake into building LLVM before Verona.
 # We use two External Projects, so that the LLVM build can complete and install
@@ -68,19 +64,46 @@ if (NOT DEFINED VERONA_LLVM_LOCATION)
   endif()
 
   set (MLIR_INSTALL ${CMAKE_BINARY_DIR}/$<CONFIG>/mlir)
+
+  set (EXTERNAL_EXTRA_CMAKE_ARGS)
+  list (APPEND EXTERNAL_EXTRA_CMAKE_ARGS 
+    -DVERONA_DOWNLOAD_LLVM=${VERONA_DOWNLOAD_LLVM}
+    -DMLIR_INSTALL=${MLIR_INSTALL}
+    -DCMAKE_BUILD_TYPE=$<CONFIG>)
+
+  if (VERONA_DOWNLOAD_LLVM AND DEFINED LLVM_EXTRA_CMAKE_ARGS)
+    message (WARNING "Ignoring LLVM_EXTRA_CMAKE_ARGS as cached LLVM.")
+  endif ()
+
+  if (NOT VERONA_DOWNLOAD_LLVM)
+    if (NOT DEFINED LLVM_EXTRA_CMAKE_ARGS)
+      set (LLVM_EXTRA_CMAKE_ARGS)
+    endif ()
+
+    list (APPEND EXTERNAL_EXTRA_CMAKE_ARGS
+      -DLLVM_EXTRA_CMAKE_ARGS=${LLVM_EXTRA_CMAKE_ARGS}
+    )
+  else ()
+    list (APPEND EXTERNAL_EXTRA_CMAKE_ARGS
+      -DVERBOSE_LLVM_DOWNLOAD=${VERBOSE_LLVM_DOWNLOAD}
+    )
+  endif ()
+
+
   ExternalProject_Add(external
     SOURCE_DIR ${CMAKE_SOURCE_DIR}/external
-    CMAKE_ARGS 
-      ${LLVM_EXTRA_CMAKE_ARGS} 
-      -DVERONA_DOWNLOAD_LLVM=${VERONA_DOWNLOAD_LLVM}
-      -DMLIR_INSTALL=${MLIR_INSTALL}
-      -DCMAKE_BUILD_TYPE=$<CONFIG>
+    CMAKE_ARGS ${EXTERNAL_EXTRA_CMAKE_ARGS} 
     BUILD_ALWAYS true
     INSTALL_COMMAND ""
     TEST_COMMAND ""
     USES_TERMINAL_BUILD true
     USES_TERMINAL_CONFIGURE true
   )
+
+  if (DEFINED VERONA_EXTRA_CMAKE_ARGS)
+    message (WARNING "Do not use VERONA_EXTRA_CMAKE_ARGS! Value ignored")
+  endif ()
+  set (VERONA_EXTRA_CMAKE_ARGS)
 
   # Point Verona at the MLIR
   list (APPEND VERONA_EXTRA_CMAKE_ARGS
@@ -89,19 +112,30 @@ if (NOT DEFINED VERONA_LLVM_LOCATION)
 
   if (NOT MSVC)
     list (APPEND VERONA_EXTRA_CMAKE_ARGS
-      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
       -DCMAKE_EXPORT_COMPILE_COMMANDS=1
     )
-  else ()
-    list (APPEND VERONA_EXTRA_CMAKE_ARGS
-      -DCMAKE_CONFIGURATION_TYPES=Release;Debug;RelWithDebInfo
-    )
   endif ()
+
+  # Define project level defaults
+  list (APPEND VERONA_EXTRA_CMAKE_ARGS
+    -DCMAKE_CXX_STANDARD=17)
 
   # Use top-level install directory when building
   # as a subproject.
   list (APPEND VERONA_EXTRA_CMAKE_ARGS
     -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/dist)
+  list (APPEND VERONA_DONT_PASS CMAKE_INSTALL_PREFIX)
+
+  get_cmake_property(CACHE_VARS CACHE_VARIABLES)
+  foreach (CACHE_VAR ${CACHE_VARS})
+    message (STATUS "list (FIND ${VERONA_DONT_PASS} ${CACHE_VAR} INDEX)")
+    list (FIND VERONA_DONT_PASS ${CACHE_VAR} INDEX)
+    if (${INDEX} EQUAL -1)
+      list(APPEND VERONA_EXTRA_CMAKE_ARGS
+        -D${CACHE_VAR}=${${CACHE_VAR}}
+      )
+    endif()
+  endforeach ()
 
   # Current the ExternalProject_Add_StepTargets seems to be generating something
   # that is breaking CI for MSVC. So on MSVC with have a single build and test
@@ -111,10 +145,6 @@ if (NOT DEFINED VERONA_LLVM_LOCATION)
   else ()
     set (SEPARATE_TEST_TARGET true)
   endif()
-
-  # Define project level defaults
-  list (APPEND VERONA_EXTRA_CMAKE_ARGS
-    -DCMAKE_CXX_STANDARD=17)
 
   # We use ctest directly as test command, pass it -j
   include(ProcessorCount)
@@ -144,6 +174,8 @@ endif()
 project(verona-lang CXX)
 
 message(STATUS "Build Type for Verona ${CMAKE_BUILD_TYPE}")
+set(CMAKE_CONFIGURATION_TYPES  Release Debug RelWithDebInfo)
+message(STATUS "Build types ${CMAKE_CONFIGURATION_TYPES}")
 
 if (VERONA_CI_BUILD)
   set (SNMALLOC_CI_BUILD ON)

--- a/devops/ci.yml
+++ b/devops/ci.yml
@@ -78,7 +78,7 @@ jobs:
     displayName: 'CMake'
     inputs:
       cmakeArgs: |
-        .. -GNinja -DCMAKE_BUILD_TYPE=$(BuildType) -DVERONA_EXTRA_CMAKE_FLAGS="-DCMAKE_C_COMPILER=$(CC);-DCMAKE_CXX_COMPILER=$(CXX);-DCMAKE_CXX_FLAGS=$(CXXFLAGS)" -DENABLE_ASSERTS=ON -DUSE_ASAN=$(Asan) -DVERONA_CI_BUILD=On -DRT_TESTS=$(RTTests)
+        .. -GNinja -DCMAKE_BUILD_TYPE=$(BuildType) -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_COMPILER=$(CXX) -DCMAKE_CXX_FLAGS=$(CXXFLAGS) -DENABLE_ASSERTS=ON -DUSE_ASAN=$(Asan) -DVERONA_CI_BUILD=On -DRT_TESTS=$(RTTests)
 
   - script: |
       set -eo pipefail

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -80,7 +80,7 @@ jobs:
     displayName: 'CMake'
     inputs:
       cmakeArgs: |
-        .. -GNinja -DCMAKE_BUILD_TYPE=$(BuildType) -DVERONA_EXTRA_CMAKE_ARGS="-DCMAKE_C_COMPILER=$(CC);-DCMAKE_CXX_COMPILER=$(CXX);-DCMAKE_CXX_FLAGS=$(CXXFLAGS)" -DENABLE_ASSERTS=ON -DUSE_ASAN=$(Asan) -DVERONA_CI_BUILD=On -DRT_TESTS=ON
+        .. -GNinja -DCMAKE_BUILD_TYPE=$(BuildType) -DCMAKE_CXX_FLAGS=$(CXXFLAGS) -DENABLE_ASSERTS=ON -DUSE_ASAN=$(Asan) -DVERONA_CI_BUILD=On -DRT_TESTS=ON
 
   - script: |
       set -eo pipefail

--- a/docs/building.md
+++ b/docs/building.md
@@ -87,14 +87,6 @@ will build Release or Release with debug info.
 We currently use an install target to layout the standard library and the
 compiler in a well defined way so that it can automatically be found.
 
-Due to the complex interaction with LLVM/MLIR builds, to pass flags to the
-verona build require using the `VERONA_EXTRA_CMAKE_ARGS`, e.g.
-```
-cmake .. -G Ninja -DVERONA_EXTRA_CMAKE_ARGS="-DCMAKE_CXX_COMPILER=clang-cl;-DCMAKE_C_COMPILER=clang-cl"
-```
-This example specifies to build Verona with `clang-cl`. Note: the options must be
-separated by `;`.
-
 ## Subsequent builds
 
 For subsequent builds, you do not need to rerun `cmake`. From the `build`
@@ -163,17 +155,6 @@ cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release
 cmake .. -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo
 ```
 to provide the other configurations.
-
-Due to the complex interaction with LLVM/MLIR builds, to pass flags to the
-verona build require using the `VERONA_EXTRA_CMAKE_ARGS`, e.g.
-```
-cmake .. -DVERONA_EXTRA_CMAKE_ARGS="-DCMAKE_CXX_COMPILER=/usr/bin/clang++;-DCMAKE_C_COMPILER=/usr/bin/clang"
-```
-This example specifies to build Verona with `clang`. Note: the options must be
-separated by `;`.
-This can be helpful as sometimes `cmake` detects `gcc` instead of `clang`.
-This may require you to remove your CMakeCache.txt file from the build
-directory.
 
 ## Subsequent builds
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -10,6 +10,8 @@ cmake_minimum_required(VERSION 3.10.0)
 project(verona_external CXX)
 include(ExternalProject)
 
+message (STATUS "Install MLIR to ${MLIR_INSTALL}")
+
 if (VERONA_DOWNLOAD_LLVM)
   find_package(Git)
   execute_process(
@@ -18,6 +20,7 @@ if (VERONA_DOWNLOAD_LLVM)
     OUTPUT_VARIABLE LLVM_PACKAGE_GIT_VERSION
   )
   string(STRIP ${LLVM_PACKAGE_GIT_VERSION} LLVM_PACKAGE_GIT_VERSION)
+  message (STATUS "Detected GIT commit: ${LLVM_PACKAGE_GIT_VERSION}")
 
   string(TOLOWER ${CMAKE_SYSTEM_NAME} PLATFORM)
   # Need loop to download all types for possible configurations
@@ -42,18 +45,10 @@ if (VERONA_DOWNLOAD_LLVM)
   file(STRINGS ${CMAKE_BINARY_DIR}/${MD5_NAME} LLVM_MD5_SUM REGEX [0-9a-f]+)
   string(STRIP ${LLVM_MD5_SUM} LLVM_MD5_SUM)
 
-  # Quiet downloads are the default. Note that the download flag is reversed
-  # so we created a more meaningful variable "verbose=true" -> "no progress=false"
-  if (NOT DEFINED VERBOSE_LLVM_DOWNLOAD OR NOT ${VERBOSE_LLVM_DOWNLOAD})
-    set(LLVM_DOWNLOAD_NO_PROGRESS ON)
-  else()
-    set(LLVM_DOWNLOAD_NO_PROGRESS OFF)
-  endif()
-
   ExternalProject_Add(mlir
     URL ${LLVM_URL}/${PKG_NAME}
     URL_MD5 ${LLVM_MD5_SUM}
-    DOWNLOAD_NO_PROGRESS ${LLVM_DOWNLOAD_NO_PROGRESS}
+    DOWNLOAD_NO_PROGRESS NOT ${VERBOSE_LLVM_DOWNLOAD}
     CONFIGURE_COMMAND ""
     PREFIX mlir-${LLVM_BUILD_TYPE}
     SOURCE_DIR ${MLIR_INSTALL}
@@ -64,9 +59,6 @@ if (VERONA_DOWNLOAD_LLVM)
   )
 
 else()
-  if (NOT DEFINED LLVM_EXTRA_CMAKE_ARGS)
-    set (LLVM_EXTRA_CMAKE_ARGS)
-  endif ()
   list (APPEND LLVM_EXTRA_CMAKE_ARGS
     -DCMAKE_INSTALL_PREFIX=${MLIR_INSTALL}/install
     -DLLVM_ENABLE_PROJECTS=mlir


### PR DESCRIPTION
Address some sub-issues in #198.

* Automatically pass compiler to subprojects
* Fixes bug introduced in #233 that didn't correctly generate subprojects for Verona (RelWithDebInfo, Debug).