### PR TITLE
Add a diagnostic handler for prettier error messages.

### DIFF
--- a/src/mlir/driver.cc
+++ b/src/mlir/driver.cc
@@ -16,7 +16,8 @@
 
 namespace mlir::verona
 {
-  Driver::Driver(unsigned optLevel) : passManager(&context)
+  Driver::Driver(unsigned optLevel)
+  : passManager(&context), diagnosticHandler(sourceManager, &context)
   {
     // Opaque operations and types can only exist if we allow
     // unregistered dialects to co-exist. Full conversions later will
@@ -65,11 +66,10 @@ namespace mlir::verona
       return runtimeError(
         "Cannot open file " + filename + ": " + err.message());
 
-    // Setup source manager and parse the input.
+    // Add the input to the source manager and parse it.
     // `parseSourceFile` already includes verification of the IR.
-    llvm::SourceMgr sourceMgr;
-    sourceMgr.AddNewSourceBuffer(std::move(*srcOrErr), llvm::SMLoc());
-    module = mlir::parseSourceFile(sourceMgr, &context);
+    sourceManager.AddNewSourceBuffer(std::move(*srcOrErr), llvm::SMLoc());
+    module = mlir::parseSourceFile(sourceManager, &context);
     if (!module)
       return runtimeError("Can't load MLIR file");
 

--- a/src/mlir/driver.h
+++ b/src/mlir/driver.h
@@ -8,6 +8,8 @@
 #include "mlir/IR/Module.h"
 #include "mlir/Pass/PassManager.h"
 
+#include "llvm/Support/SourceMgr.h"
+
 namespace mlir::verona
 {
   /**
@@ -51,5 +53,13 @@ namespace mlir::verona
     /// MLIR Pass Manager
     /// It gets configured by the constructor based on the provided arguments.
     mlir::PassManager passManager;
+
+    /// Source manager.
+    llvm::SourceMgr sourceManager;
+
+    /// Diagnostic handler that pretty-prints MLIR errors.
+    /// The handler registers itself with the MLIR context and gets invoked
+    /// automatically. We only need to keep it alive by storing it here.
+    SourceMgrDiagnosticHandler diagnosticHandler;
   };
 }


### PR DESCRIPTION
This gives us a bit of colour, prints the relevant piece of code, and
displays notes attached to diagnostics.