### PR TITLE
Backpressure: set unmutable on fast_send

### DIFF
--- a/src/rt/sched/backpressure.h
+++ b/src/rt/sched/backpressure.h
@@ -66,7 +66,7 @@
  * State Properties:
  * - Normal: The inital state of all cowns.
  * - Muted: A muted cown may not be scheduled or deallocated.
- * - Unmutable: An nnmutable cown may not be muted.
+ * - Unmutable: An unmutable cown may not be muted.
  *
  * State Transition Rules:
  * - Cowns sending to overload/muted cowns may be muted.
@@ -166,7 +166,7 @@ namespace verona::rt
      */
     uint32_t _has_token : 1;
     /**
-     * Indicates if a cown is currently muted (1), unmutable (2), or
+     * Indicates if a cown is currently normal (0), muted (1), unmutable (2), or
      * unmutable-dirty (3).
      */
     uint32_t _response_state : 2;

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -253,6 +253,7 @@ namespace verona::rt
           continue;
         }
         Systematic::cout() << "Mute " << cown << std::endl;
+        assert(!bp.unmutable());
       }
 
       alloc->dealloc(cowns, count * sizeof(T*));


### PR DESCRIPTION
On `fast_send` the unacquired cowns required for a multi-message are made unmutable if any are overloaded. This continues to cover cases where an overloaded cown, `a`, mutes another cown, `b`, and then requires `b` in a future message. But now cowns are set unmutable only prior to a fast acquire loop.