### PR TITLE
Normalize types before applying subtyping rules.

### DIFF
--- a/src/mlir/dialect/Typechecker.h
+++ b/src/mlir/dialect/Typechecker.h
@@ -23,9 +23,10 @@ namespace mlir::verona
   };
 
   /// Returns true if `lhs` is a subtype of `rhs`.
+  /// `lhs` and `rhs` should be in normal form already.
   bool isSubtype(Type lhs, Type rhs);
 
   /// Check whether `lhs` is a subtype of `rhs`. If it isn't, an error is
-  /// emitted using location `loc`, and a failure is returned.
-  LogicalResult checkSubtype(Location loc, Type lhs, Type rhs);
+  /// emitted and a failure is returned.
+  LogicalResult checkSubtype(Operation* op, Type lhs, Type rhs);
 }

--- a/src/mlir/dialect/VeronaOps.cc
+++ b/src/mlir/dialect/VeronaOps.cc
@@ -163,7 +163,7 @@ namespace mlir::verona
 {
   LogicalResult CopyOp::typecheck()
   {
-    return checkSubtype(getLoc(), input().getType(), output().getType());
+    return checkSubtype(getOperation(), input().getType(), output().getType());
   }
 
 #define GET_OP_CLASSES

--- a/src/mlir/dialect/VeronaTypes.cc
+++ b/src/mlir/dialect/VeronaTypes.cc
@@ -433,6 +433,11 @@ namespace mlir::verona
     return JoinType::get(ctx, result);
   }
 
+  // TODO: The amount of normalization done is quite limited. In particular it
+  // does not always flatten types (eg. changing `join<A, join<B, C>>` into
+  // `join<A, B, C>`), nor does it do any simplification (eg. `join<A, A, B>`
+  // into `join<A, B>`). These normalizations aren't necessary for subtyping,
+  // but could help with other places in the compiler.
   Type normalizeType(Type type)
   {
     MLIRContext* ctx = type.getContext();
@@ -451,7 +456,7 @@ namespace mlir::verona
         return normalizeMeet(ctx, type.cast<MeetType>().getElements());
 
       default:
-        abort();
+        llvm_unreachable("invalid Verona type");
     }
   }
 }

--- a/src/mlir/dialect/VeronaTypes.h
+++ b/src/mlir/dialect/VeronaTypes.h
@@ -16,6 +16,18 @@ namespace mlir::verona
   /// dialect.
   bool areVeronaTypes(llvm::ArrayRef<Type> types);
 
+  /// Normalize a type by distributing unions and intersections, putting the
+  /// type in disjunctive normal form. This is a necessary step in order for
+  /// subtyping to recognise certain relations.
+  ///
+  /// The amount of normalization done is quite limited. In particular it does
+  /// not do any flattening (eg. `join<A, join<B, C>>` into `join<A, B, C>`),
+  /// nor does it do any simplification (eg. `join<A, A, B>` into `join<A, B>`).
+  ///
+  /// TODO: normalizing types is a potentially expensive operation, so we should
+  /// try to cache the results.
+  Type normalizeType(Type type);
+
   namespace detail
   {
     struct MeetTypeStorage;

--- a/src/mlir/dialect/VeronaTypes.h
+++ b/src/mlir/dialect/VeronaTypes.h
@@ -20,10 +20,6 @@ namespace mlir::verona
   /// type in disjunctive normal form. This is a necessary step in order for
   /// subtyping to recognise certain relations.
   ///
-  /// The amount of normalization done is quite limited. In particular it does
-  /// not do any flattening (eg. `join<A, join<B, C>>` into `join<A, B, C>`),
-  /// nor does it do any simplification (eg. `join<A, A, B>` into `join<A, B>`).
-  ///
   /// TODO: normalizing types is a potentially expensive operation, so we should
   /// try to cache the results.
   Type normalizeType(Type type);

--- a/testsuite/mlir/mlir-parse/subsumption.mlir
+++ b/testsuite/mlir/mlir-parse/subsumption.mlir
@@ -33,4 +33,11 @@ module {
 
     return
   }
+
+  func @test_distributivity(%a: !verona.meet<U64, join<iso, mut>>) {
+    // We allow distributivity of join over meets.
+    %b = verona.copy %a: !verona.meet<U64, join<iso, mut>> -> !verona.join<meet<U64, iso>, meet<U64, mut>> 
+
+    return
+  }
 }

--- a/testsuite/mlir/mlir-parse/subsumption/out.mlir
+++ b/testsuite/mlir/mlir-parse/subsumption/out.mlir
@@ -14,4 +14,8 @@ module {
     %0 = verona.copy %arg0 : !verona.bottom -> !verona.U64
     return
   }
+  func @test_distributivity(%arg0: !verona.meet<U64, join<iso, mut>>) {
+    %0 = verona.copy %arg0 : !verona.meet<U64, join<iso, mut>> -> !verona.join<meet<U64, iso>, meet<U64, mut>>
+    return
+  }
 }


### PR DESCRIPTION
This helps recognise distributivity of joins over meets, such as:

  meet<A, join<B, C>> <: join<meet<A, B>, meet<A, C>>

While distributivity of joins over meets alone is quite niche, and
many languages get away without supporting it, distributivity over
viewpoint types (which will be added soon) is a lot more critical.
This PR lays the ground work for that.