### PR TITLE
Add cast on return

### DIFF
--- a/testsuite/mlir/mlir-parse/call.verona
+++ b/testsuite/mlir/mlir-parse/call.verona
@@ -11,7 +11,7 @@ foo(a: N, b: U64 & imm): R
   {
     return foo(x, y);
   }
-  x + y;
+  return x + y;
 }
 
 ()


### PR DESCRIPTION
This makes sure the returned value is of the same type as the region
needs it to be. This is a copy of the implicit function return, and we
need to common them up, but they come from different AST nodes, where
one is implicit.

Given we're not yet completely sure on what we'll do with returns, this
refactory can be done later, with the risk of being irrelevant soon.