### PR TITLE
Prevent teardown with external event source count

### DIFF
--- a/src/rt/sched/threadpool.h
+++ b/src/rt/sched/threadpool.h
@@ -107,18 +107,20 @@ namespace verona::rt
         s.external_event_sources.fetch_add(1, std::memory_order_seq_cst);
       Systematic::cout() << "Add external event source (now "
                          << (prev_count + 1) << ")" << std::endl;
-      s.unpause();
     }
 
     /// Decrement the external event source count. This will allow runtime
     /// teardown if the count drops to zero.
     static void remove_external_event_source()
     {
+      auto& s = get();
       auto prev_count =
-        get().external_event_sources.fetch_sub(1, std::memory_order_seq_cst);
+        s.external_event_sources.fetch_sub(1, std::memory_order_seq_cst);
       assert(prev_count != 0);
       Systematic::cout() << "Remove external event source (now "
                          << (prev_count - 1) << ")" << std::endl;
+      if (prev_count == 1)
+        s.unpause();
     }
 
     static void set_fair(bool fair)

--- a/src/rt/sched/threadpool.h
+++ b/src/rt/sched/threadpool.h
@@ -45,7 +45,9 @@ namespace verona::rt
     T* running_thread = nullptr;
 #endif
 
-    bool allow_teardown = true;
+    /// Count of external event sources, such as I/O, that will prevent
+    /// quiescence.
+    std::atomic<size_t> external_event_sources = 0;
     // Pausing if value is odd.
     // Is not atomic, since updates are only made while a lock is held.
     // We are assuming that no partial write will be observed.
@@ -96,13 +98,27 @@ namespace verona::rt
       return get().inflight_count == 0;
     }
 
-    static void set_allow_teardown(bool allow)
+    /// Increment the external event source count. A non-zero count will prevent
+    /// runtime teardown.
+    static void add_external_event_source()
     {
-      Systematic::cout() << "Set allow teardown: " << allow << std::endl;
       auto& s = get();
-      s.allow_teardown = allow;
-      if (allow)
-        s.unpause();
+      auto prev_count =
+        s.external_event_sources.fetch_add(1, std::memory_order_seq_cst);
+      Systematic::cout() << "Add external event source (now "
+                         << (prev_count + 1) << ")" << std::endl;
+      s.unpause();
+    }
+
+    /// Decrement the external event source count. This will allow runtime
+    /// teardown if the count drops to zero.
+    static void remove_external_event_source()
+    {
+      auto prev_count =
+        get().external_event_sources.fetch_sub(1, std::memory_order_seq_cst);
+      assert(prev_count != 0);
+      Systematic::cout() << "Remove external event source (now "
+                         << (prev_count - 1) << ")" << std::endl;
     }
 
     static void set_fair(bool fair)
@@ -461,7 +477,7 @@ namespace verona::rt
           t = t->next;
         } while (t != first_thread);
 
-        if (!allow_teardown)
+        if (external_event_sources.load(std::memory_order_seq_cst) != 0)
         {
           assert((runtime_pausing & 1) == 0);
           runtime_pausing++;

--- a/src/rt/test/func/runtimepause/runtimepause.cc
+++ b/src/rt/test/func/runtimepause/runtimepause.cc
@@ -32,7 +32,7 @@ void test_runtime_pause(size_t cores, size_t pauses)
 {
   Scheduler& sched = Scheduler::get();
   sched.init(cores);
-  Scheduler::set_allow_teardown(false);
+  Scheduler::add_external_event_source();
 
   auto a = new A;
 
@@ -50,7 +50,7 @@ void test_runtime_pause(size_t cores, size_t pauses)
     auto pause_time = std::chrono::nanoseconds(dist(rng));
     std::this_thread::sleep_for(pause_time);
 
-    Scheduler::set_allow_teardown(true);
+    Scheduler::remove_external_event_source();
   });
 
   sched.run();

--- a/src/rt/test/perf/backpressure1/backpressure1.cc
+++ b/src/rt/test/perf/backpressure1/backpressure1.cc
@@ -162,7 +162,7 @@ int main(int argc, char** argv)
   for (size_t p = 0; p < proxies; p++)
     proxy_chain.push_back(new (alloc) Proxy(p));
 
-  Scheduler::set_allow_teardown(false);
+  Scheduler::add_external_event_source();
   auto thr = std::thread([=] {
     for (size_t i = 0; i < senders; i++)
     {
@@ -190,7 +190,7 @@ int main(int argc, char** argv)
         Cown::release(alloc, r);
     }
 
-    Scheduler::set_allow_teardown(true);
+    Scheduler::remove_external_event_source();
   });
 
   sched.run();

--- a/src/rt/test/perf/ubench/ubench.cc
+++ b/src/rt/test/perf/ubench/ubench.cc
@@ -115,11 +115,11 @@ struct Report;
 static void start_timer(Monitor* monitor, std::chrono::milliseconds timeout)
 {
   rt::Cown::acquire(monitor);
-  rt::Scheduler::set_allow_teardown(false);
+  rt::Scheduler::add_external_event_source();
   std::thread([=]() mutable {
     std::this_thread::sleep_for(timeout);
     rt::Cown::schedule<Stop, rt::YesTransfer>((rt::Cown*)monitor, monitor);
-    rt::Scheduler::set_allow_teardown(true);
+    rt::Scheduler::remove_external_event_source();
   }).detach();
 }
 


### PR DESCRIPTION
This change replaces the boolean that enables runtime teardown with an
atomic counter of external event sources. This is necessary to support
asynchronous I/O events in the runtime.