### PR TITLE
Implement for loops in MLIR

### DIFF
--- a/src/mlir/ast-utils.h
+++ b/src/mlir/ast-utils.h
@@ -496,7 +496,7 @@ namespace mlir::verona::ASTInterface
   }
 
   // ================================================= Condition Helpers
-  /// Return the condition form an if statement
+  /// Return the condition from an if statement
   bool hasElse(::ast::WeakAst ast)
   {
     // Else nodes always exist inside `if` nodes, but if there was no `else`
@@ -505,7 +505,7 @@ namespace mlir::verona::ASTInterface
       hasSubs(findNode(ast, NodeKind::Else));
   }
 
-  /// Return the block form an if statement
+  /// Return the block from an if statement
   ::ast::WeakAst getCond(::ast::WeakAst ast)
   {
     // These are the nodes that could have conditions as subnodes
@@ -522,7 +522,7 @@ namespace mlir::verona::ASTInterface
     return findNode(ast, NodeKind::Block);
   }
 
-  /// Return the else block form an if statement
+  /// Return the else block from an if statement
   ::ast::WeakAst getElseBlock(::ast::WeakAst ast)
   {
     assert(hasElse(ast) && "Bad node");
@@ -532,21 +532,21 @@ namespace mlir::verona::ASTInterface
   }
 
   // ================================================= Loop Helpers
-  /// Return the block form a loop
+  /// Return the block from a loop
   ::ast::WeakAst getLoopBlock(::ast::WeakAst ast)
   {
     assert(isLoop(ast) && "Bad node");
     return findNode(ast, NodeKind::Block);
   }
 
-  /// Return the sequence generator form a `for` loop
+  /// Return the sequence generator from a `for` loop
   ::ast::WeakAst getLoopSeq(::ast::WeakAst ast)
   {
     assert(isFor(ast) && "Bad node");
     return findNode(findNode(ast, NodeKind::Seq), NodeKind::Localref);
   }
 
-  /// Return the induction variable form a `for` loop
+  /// Return the induction variable from a `for` loop
   ::ast::WeakAst getLoopInd(::ast::WeakAst ast)
   {
     assert(isFor(ast) && "Bad node");

--- a/src/mlir/ast-utils.h
+++ b/src/mlir/ast-utils.h
@@ -127,6 +127,12 @@ namespace mlir::verona::ASTInterface
            }) != nodes.end();
   }
 
+  /// Return true if node has subnodes
+  bool hasSubs(::ast::WeakAst ast)
+  {
+    return !ast.lock()->nodes.empty();
+  }
+
   /// Return true if node is a value
   bool isValue(::ast::WeakAst ast)
   {
@@ -357,12 +363,8 @@ namespace mlir::verona::ASTInterface
   {
     assert(isFunction(ast) && "Bad node");
 
-    // Empty function name is "apply"
     auto funcname = findNode(ast, NodeKind::FuncName).lock();
-    assert(!funcname->nodes.empty() && "Bad function");
-
-    // Else, get function name
-    assert(funcname->nodes.size() == 1);
+    assert(hasSubs(funcname) && "Bad function");
     return getTokenValue(funcname->nodes[0]);
   }
 
@@ -500,7 +502,7 @@ namespace mlir::verona::ASTInterface
     // Else nodes always exist inside `if` nodes, but if there was no `else`
     // block, they're empty. We should only return true if they're not.
     return isA(ast, NodeKind::If) && hasA(ast, NodeKind::Else) &&
-      !findNode(ast, NodeKind::Else).lock()->nodes.empty();
+      hasSubs(findNode(ast, NodeKind::Else));
   }
 
   /// Return the block form an if statement
@@ -523,7 +525,7 @@ namespace mlir::verona::ASTInterface
   /// Return the else block form an if statement
   ::ast::WeakAst getElseBlock(::ast::WeakAst ast)
   {
-    assert(isIf(ast) && "Bad node");
+    assert(hasElse(ast) && "Bad node");
     // Else has either a single node or a seq
     auto node = findNode(ast, NodeKind::Else);
     return node.lock()->nodes[0];

--- a/src/mlir/ast-utils.h
+++ b/src/mlir/ast-utils.h
@@ -73,6 +73,7 @@ namespace mlir::verona::ASTInterface
     If = peg::str2tag("if"), // = 3567
     Else = peg::str2tag("else"), // = 3742303
     While = peg::str2tag("while"), // = 140358143
+    For = peg::str2tag("for"), // = 140358143
     Continue = peg::str2tag("continue"), // = 2929012833
     Break = peg::str2tag("break"), // = 117842911
   };
@@ -216,11 +217,16 @@ namespace mlir::verona::ASTInterface
     return isA(ast, NodeKind::While);
   }
 
+  /// Return true if node is a for loop
+  bool isFor(::ast::WeakAst ast)
+  {
+    return isA(ast, NodeKind::For);
+  }
+
   /// Return true if node is any kind of loop
   bool isLoop(::ast::WeakAst ast)
   {
-    // Add isFor when we support it
-    return isWhile(ast);
+    return isWhile(ast) || isFor(ast);
   }
 
   /// Return true if node is a loop continue
@@ -529,5 +535,19 @@ namespace mlir::verona::ASTInterface
   {
     assert(isLoop(ast) && "Bad node");
     return findNode(ast, NodeKind::Block);
+  }
+
+  /// Return the sequence generator form a `for` loop
+  ::ast::WeakAst getLoopSeq(::ast::WeakAst ast)
+  {
+    assert(isFor(ast) && "Bad node");
+    return findNode(findNode(ast, NodeKind::Seq), NodeKind::Localref);
+  }
+
+  /// Return the induction variable form a `for` loop
+  ::ast::WeakAst getLoopInd(::ast::WeakAst ast)
+  {
+    assert(isFor(ast) && "Bad node");
+    return findNode(ast, NodeKind::Localref);
   }
 }

--- a/src/mlir/generator.cc
+++ b/src/mlir/generator.cc
@@ -388,12 +388,19 @@ namespace mlir::verona
 
         // Types are incomplete here, so add casts (will be cleaned later)
         auto argTy = std::get<1>(val_ty);
-        auto cast =
-          genOperation(getLocation(arg), "verona.cast", {val->get()}, argTy);
-        if (auto err = cast.takeError())
-          return std::move(err);
+        if (argTy != val->get().getType())
+        {
+          auto cast =
+            genOperation(getLocation(arg), "verona.cast", {val->get()}, argTy);
+          if (auto err = cast.takeError())
+            return std::move(err);
 
-        args.push_back(cast->get());
+          args.push_back(cast->get());
+        }
+        else
+        {
+          args.push_back(val->get());
+        }
       }
 
       auto call = builder.create<mlir::CallOp>(getLocation(ast), func, args);

--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -191,6 +191,8 @@ namespace mlir::verona
     llvm::Expected<ReturnValue> parseCondition(const ::ast::Ast& ast);
     /// Parses a 'while' loop block.
     llvm::Expected<ReturnValue> parseWhileLoop(const ::ast::Ast& ast);
+    /// Parses a 'for' loop block.
+    llvm::Expected<ReturnValue> parseForLoop(const ::ast::Ast& ast);
     /// Parses a 'continue' statement.
     llvm::Expected<ReturnValue> parseContinue(const ::ast::Ast& ast);
     /// Parses a 'break' statement.

--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -103,6 +103,27 @@ namespace mlir::verona
   };
 
   /**
+   * Language ABI (temporary).
+   *
+   * This is a temporary list of constants for holding on to ABI specific
+   * ideas like how to lower an iterator or a lambda or constants. Due to
+   * the current nature of the AST, we need those ideas here. If we improve
+   * the AST, or create an improved veneer of ABI related lowering, we should
+   * move this logic there and remove these constants.
+   */
+  namespace ABI
+  {
+    /// Iteration handler, to call `has_value`, `apply` and `next`.
+    const char* const iteratorHandler = "$iter";
+    /// Iteration value check, to be performed before taking a value.
+    const char* const iteratorHasValue = "has_value";
+    /// Iteration value copy, should only be called if `has_value` is true.
+    const char* const iteratorApply = "apply";
+    /// Iteration pointer increment, moves on to the next element in the list.
+    const char* const iteratorNext = "next";
+  }
+
+  /**
    * MLIR Generator.
    */
   struct Generator

--- a/testsuite/mlir/mlir-parse/for.verona
+++ b/testsuite/mlir/mlir-parse/for.verona
@@ -1,0 +1,15 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+apply(x) : S32;
+has_value(x) : bool;
+next(x);
+foo(a : S32) { }
+
+f(x)
+{
+  let a : S32 = 0;
+  for (a in x) {
+    foo(a);
+  }
+}

--- a/testsuite/mlir/mlir-parse/for.verona
+++ b/testsuite/mlir/mlir-parse/for.verona
@@ -4,7 +4,7 @@
 apply(x) : S32;
 has_value(x) : bool;
 next(x);
-foo(a : S32) { }
+foo(a : S32);
 
 f(x)
 {

--- a/testsuite/mlir/mlir-parse/for/mlir.txt
+++ b/testsuite/mlir/mlir-parse/for/mlir.txt
@@ -19,8 +19,7 @@ module {
   ^bb2:  // pred: ^bb1
     %7 = call @apply(%5) : (!type.unk) -> !type.S32
     call @next(%5) : (!type.unk) -> ()
-    %8 = "verona.cast"(%7) : (!type.S32) -> !type.S32
-    call @foo(%8) : (!type.S32) -> ()
+    call @foo(%7) : (!type.S32) -> ()
     br ^bb1
   ^bb3:  // pred: ^bb1
     return

--- a/testsuite/mlir/mlir-parse/for/mlir.txt
+++ b/testsuite/mlir/mlir-parse/for/mlir.txt
@@ -4,11 +4,7 @@ module {
   func @apply(!type.unk) -> !type.S32
   func @has_value(!type.unk) -> i1
   func @next(!type.unk)
-  func @foo(%arg0: !type.S32) {
-    %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.store"(%arg0, %0) : (!type.S32, !type.alloca) -> !type.unk
-    return
-  }
+  func @foo(!type.S32)
   func @f(%arg0: !type.unk) {
     %0 = "verona.alloca"() : () -> !type.alloca
     %1 = "verona.store"(%arg0, %0) : (!type.unk, !type.alloca) -> !type.unk

--- a/testsuite/mlir/mlir-parse/for/mlir.txt
+++ b/testsuite/mlir/mlir-parse/for/mlir.txt
@@ -1,0 +1,32 @@
+
+
+module {
+  func @apply(!type.unk) -> !type.S32
+  func @has_value(!type.unk) -> i1
+  func @next(!type.unk)
+  func @foo(%arg0: !type.S32) {
+    %0 = "verona.alloca"() : () -> !type.alloca
+    %1 = "verona.store"(%arg0, %0) : (!type.S32, !type.alloca) -> !type.unk
+    return
+  }
+  func @f(%arg0: !type.unk) {
+    %0 = "verona.alloca"() : () -> !type.alloca
+    %1 = "verona.store"(%arg0, %0) : (!type.unk, !type.alloca) -> !type.unk
+    %2 = "verona.alloca"() : () -> !type.alloca
+    %3 = "verona.constant(0)"() : () -> !type.int
+    %4 = "verona.store"(%3, %2) : (!type.int, !type.alloca) -> !type.unk
+    %5 = "verona.load"(%0) : (!type.alloca) -> !type.unk
+    br ^bb1
+  ^bb1:  // 2 preds: ^bb0, ^bb2
+    %6 = call @has_value(%5) : (!type.unk) -> i1
+    cond_br %6, ^bb2, ^bb3
+  ^bb2:  // pred: ^bb1
+    %7 = call @apply(%5) : (!type.unk) -> !type.S32
+    call @next(%5) : (!type.unk) -> ()
+    %8 = "verona.cast"(%7) : (!type.S32) -> !type.S32
+    call @foo(%8) : (!type.S32) -> ()
+    br ^bb1
+  ^bb3:  // pred: ^bb1
+    return
+  }
+}

--- a/testsuite/mlir/mlir-parse/function.verona
+++ b/testsuite/mlir/mlir-parse/function.verona
@@ -7,6 +7,11 @@ single_arg(x : S16);
 
 args_and_ret(a : U32, b : S32) : F64;
 
+empty_return()
+{
+  return;
+}
+
 foo(a: N, b: U64 & imm): R
   where N: imm
   where R: U64 & imm

--- a/testsuite/mlir/mlir-parse/function/mlir.txt
+++ b/testsuite/mlir/mlir-parse/function/mlir.txt
@@ -4,6 +4,9 @@ module {
   func @empty_declaration()
   func @single_arg(!type.S16)
   func @args_and_ret(!type.U32, !type.S32) -> !type.F64
+  func @empty_return() {
+    return
+  }
   func @foo(%arg0: !type.imm, %arg1: !type<"U64&imm">) -> !type<"U64&imm"> {
     %0 = "verona.alloca"() : () -> !type.alloca
     %1 = "verona.store"(%arg0, %0) : (!type.imm, !type.alloca) -> !type.unk


### PR DESCRIPTION
This introduces `for` loops as MLIR constructs, similar to `while` but with the additional iteration handling.

A few following commits fix some issues found when calling functions (extra casts, no return values, arg types without args).

Depends on #252.

Fixes #203.