### PR TITLE
Add bool type in grammar, constants in MLIR

### DIFF
--- a/src/ast/grammar.peg
+++ b/src/ast/grammar.peg
@@ -64,7 +64,7 @@ guard <- ('if' '(' seq ')')?
 
 atom <-
   break / continue / return / yield / let / new / lambda /
-  hex / binary / float / int / interp_string / string / true / false /
+  hex / binary / float / int / interp_string / string / bool /
   id / sym / tuple / typeargs
 
 break <- 'break'
@@ -90,8 +90,7 @@ int <- <digits>
 digits <- [0-9][_0-9]*
 hex <- <'0x' [_0-9a-fA-F]*>
 binary <- <'0b' [_01]*>
-true <- 'true'
-false <- 'false'
+bool <- 'true' / 'false'
 
 string <- ["] <('\\"' / !'"' .)*> '"'
 interp_string <- ["][{] (unquote / quote)* '}"'

--- a/src/mlir/ast-utils.h
+++ b/src/mlir/ast-utils.h
@@ -65,6 +65,9 @@ namespace mlir::verona
       Type = peg::str2tag("type"), // = 4058008
       TypeRef = peg::str2tag("type_ref"), // = 2115269750
       TypeBody = peg::str2tag("typebody"), // = 2117081800
+      Bool = peg::str2tag("bool"), // = 3565102
+      Hex = peg::str2tag("hex"), // = 110293
+      Binary = peg::str2tag("binary"), // = 3884723791
       Params = peg::str2tag("params"), // = 4271185724
       NamedParam = peg::str2tag("namedparam"), // = 1544471404
       ID = peg::str2tag("id"), // = 3565
@@ -82,7 +85,7 @@ namespace mlir::verona
       If = peg::str2tag("if"), // = 3567
       Else = peg::str2tag("else"), // = 3742303
       While = peg::str2tag("while"), // = 140358143
-      For = peg::str2tag("for"), // = 140358143
+      For = peg::str2tag("for"), // = 112155
       Continue = peg::str2tag("continue"), // = 2929012833
       Break = peg::str2tag("break"), // = 117842911
     };
@@ -151,7 +154,13 @@ namespace mlir::verona
     /// Return true if node is a value
     static bool isConstant(::ast::WeakAst ast)
     {
-      return isValue(ast) && isAny(ast, {NodeKind::Integer, NodeKind::Float});
+      return isValue(ast) &&
+        isAny(ast,
+              {NodeKind::Integer,
+               NodeKind::Float,
+               NodeKind::Bool,
+               NodeKind::Hex,
+               NodeKind::Binary});
     }
 
     /// Return true if node is a local variable reference

--- a/src/mlir/generator.cc
+++ b/src/mlir/generator.cc
@@ -252,13 +252,9 @@ namespace mlir::verona
   {
     switch (AST::getKind(ast))
     {
-      case AST::NodeKind::Localref:
-        return parseValue(ast);
       case AST::NodeKind::Block:
       case AST::NodeKind::Seq:
         return parseBlock(ast);
-      case AST::NodeKind::ID:
-        return parseValue(ast);
       case AST::NodeKind::Assign:
         return parseAssign(ast);
       case AST::NodeKind::Call:

--- a/testsuite/mlir/mlir-parse/constant.verona
+++ b/testsuite/mlir/mlir-parse/constant.verona
@@ -5,4 +5,13 @@ f()
 {
   let a = 42;
   let b = 3.1415;
+  let c = true;
+  let d = 0xAE;
+  let e = 0b11011;
+
+  let f : S32 = 42;
+  let g : F32 = 3.1415;
+  let h : bool = false;
+  let i : U32 = 0xDEADBEEF;
+  let j : bool = 0b1;
 }

--- a/testsuite/mlir/mlir-parse/constant/mlir.txt
+++ b/testsuite/mlir/mlir-parse/constant/mlir.txt
@@ -8,6 +8,30 @@ module {
     %3 = "verona.alloca"() : () -> !type.alloca
     %4 = "verona.constant(3.1415)"() : () -> !type.float
     %5 = "verona.store"(%4, %3) : (!type.float, !type.alloca) -> !type.unk
+    %6 = "verona.alloca"() : () -> !type.alloca
+    %7 = "verona.constant(true)"() : () -> !type.bool
+    %8 = "verona.store"(%7, %6) : (!type.bool, !type.alloca) -> !type.unk
+    %9 = "verona.alloca"() : () -> !type.alloca
+    %10 = "verona.constant(0xAE)"() : () -> !type.hex
+    %11 = "verona.store"(%10, %9) : (!type.hex, !type.alloca) -> !type.unk
+    %12 = "verona.alloca"() : () -> !type.alloca
+    %13 = "verona.constant(0b11011)"() : () -> !type.binary
+    %14 = "verona.store"(%13, %12) : (!type.binary, !type.alloca) -> !type.unk
+    %15 = "verona.alloca"() : () -> !type.alloca
+    %16 = "verona.constant(42)"() : () -> !type.int
+    %17 = "verona.store"(%16, %15) : (!type.int, !type.alloca) -> !type.unk
+    %18 = "verona.alloca"() : () -> !type.alloca
+    %19 = "verona.constant(3.1415)"() : () -> !type.float
+    %20 = "verona.store"(%19, %18) : (!type.float, !type.alloca) -> !type.unk
+    %21 = "verona.alloca"() : () -> !type.alloca
+    %22 = "verona.constant(false)"() : () -> !type.bool
+    %23 = "verona.store"(%22, %21) : (!type.bool, !type.alloca) -> !type.unk
+    %24 = "verona.alloca"() : () -> !type.alloca
+    %25 = "verona.constant(0xDEADBEEF)"() : () -> !type.hex
+    %26 = "verona.store"(%25, %24) : (!type.hex, !type.alloca) -> !type.unk
+    %27 = "verona.alloca"() : () -> !type.alloca
+    %28 = "verona.constant(0b1)"() : () -> !type.binary
+    %29 = "verona.store"(%28, %27) : (!type.binary, !type.alloca) -> !type.unk
     return
   }
 }

--- a/testsuite/parse/ast-parse/literal.verona
+++ b/testsuite/parse/ast-parse/literal.verona
@@ -3,6 +3,9 @@
 
 f()
 {
+  // Type inferred
+  let bool1 = true;
+  let bool2 = false;
   let int1 = 00_42;
   let int2 = 0xc0_FFeE;
   let int3 = 0b10_10_10;
@@ -11,4 +14,12 @@ f()
   let precedence2 = 1 + (2 + 3);
   let object1 = new { x : U64 = 0; };
   let object2 = new Foo { x : U64 = 0; };
+
+  // Type declared
+  let bool3 : bool = true;
+  let bool4 : bool = false;
+  let int4 : U16 = 00_420;
+  let int5 : S32 = 0xc0_FFeE;
+  let int6 : U8 = 0b100_10_10;
+  let float2 : F32 = 207.18e-1;
 }

--- a/testsuite/parse/ast-parse/literal/ast.txt
+++ b/testsuite/parse/ast-parse/literal/ast.txt
@@ -17,6 +17,16 @@
         + seq
           + assign
             + let
+              - local (bool1)
+              + oftype
+            - bool (true)
+          + assign
+            + let
+              - local (bool2)
+              + oftype
+            - bool (false)
+          + assign
+            + let
               - local (int1)
               + oftype
             - int (00_42)
@@ -103,3 +113,57 @@
                           - id (U64)
                   + initexpr
                     - int (0)
+          + assign
+            + let
+              - local (bool3)
+              + oftype
+                + type
+                  + type_one/1
+                    + type_ref
+                      - id (bool)
+            - bool (true)
+          + assign
+            + let
+              - local (bool4)
+              + oftype
+                + type
+                  + type_one/1
+                    + type_ref
+                      - id (bool)
+            - bool (false)
+          + assign
+            + let
+              - local (int4)
+              + oftype
+                + type
+                  + type_one/1
+                    + type_ref
+                      - id (U16)
+            - int (00_420)
+          + assign
+            + let
+              - local (int5)
+              + oftype
+                + type
+                  + type_one/1
+                    + type_ref
+                      - id (S32)
+            - hex (0xc0_FFeE)
+          + assign
+            + let
+              - local (int6)
+              + oftype
+                + type
+                  + type_one/1
+                    + type_ref
+                      - id (U8)
+            - binary (0b100_10_10)
+          + assign
+            + let
+              - local (float2)
+              + oftype
+                + type
+                  + type_one/1
+                    + type_ref
+                      - id (F32)
+            - float (207.18e-1)


### PR DESCRIPTION
This makes the bool type like the others for constants, changing the AST
node from "true (true)" to "bool (true)", which makes more sense.

Also adding parsing rules to the MLIR generator to accept those constant
types.

Fixes #253