### PR TITLE
Generator refactory, splitting AST parsers from MLIR generators

### DIFF
--- a/src/mlir/abi.h
+++ b/src/mlir/abi.h
@@ -1,0 +1,75 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+/**
+ * Language ABI and Lowering rules.
+ *
+ * This is a temporary handler for holding on to ABI specific ideas like how
+ * to lower an iterator or a lambda or constants. Due to the current nature
+ * of the AST, we need those ideas here. If we improve the AST, or create an
+ * improved veneer of ABI related lowering, we should move this logic there
+ * and remove these handlers.
+ *
+ * FIXME: For now, we're using strings to determine the types, but we'll need
+ * to plug in a builder/context pair to create them correctly. If we keep the
+ * names here in sync with the generator (unstable requirement), it can work for
+ * now.
+ *
+ * The aim is to have objects that can generate structures, functions and other
+ * objects in the right place (within the right lexical context, etc.), and
+ * teach the generator to create those patterns on demand or to find the right
+ * implementation (for ex. user-defined containers and functors).
+ */
+namespace mlir::verona::ABI
+{
+  /**
+   * Loop iterator for producers expected to conform to the following pattern:
+   * $iter = container;
+   * while ($iter.has_value())
+   * {
+   *   item = $iter.apply();
+   *   // use `item`
+   *   $iter.next();
+   * }
+   *
+   * This is the expected implementation of the following `for` loop:
+   * for (item in container)
+   * {
+   *   // use `item`
+   * }
+   */
+  struct LoopIterator
+  {
+    /// Iteration handler, using `$` as a compiler-generated symbol
+    constexpr static const char* const handler = "$iter";
+
+    /// Iteration value check, to be performed before taking a value.
+    struct check
+    {
+      constexpr static const char* const name = "has_value";
+      constexpr static const char* const args[]{handler};
+      constexpr static const char* const types[]{"unk"};
+      constexpr static const char* const retTy{"bool"};
+    };
+
+    /// Iteration value copy, should only be called if `has_value` is true.
+    struct apply
+    {
+      constexpr static const char* const name = "apply";
+      constexpr static const char* const args[]{handler};
+      constexpr static const char* const types[]{"unk"};
+      constexpr static const char* const retTy{"unk"};
+    };
+
+    /// Iteration pointer increment, moves on to the next element in the list.
+    struct next
+    {
+      constexpr static const char* const name = "next";
+      constexpr static const char* const args[]{handler};
+      constexpr static const char* const types[]{"unk"};
+      constexpr static const char* const retTy{};
+    };
+  };
+}

--- a/src/mlir/generator.cc
+++ b/src/mlir/generator.cc
@@ -447,7 +447,7 @@ namespace mlir::verona
         "Return operation without parent function", getLocation(ast));
     }
 
-    // Either retrurns empty or auto-cast'ed value
+    // Either returns empty or auto-cast'ed value
     if (expr.hasValue())
     {
       assert(retTy && "Return value from a void function");

--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -179,6 +179,11 @@ namespace mlir::verona
     /// Get location of an ast node
     mlir::Location getLocation(const ::ast::Ast& ast);
 
+    // ================================================================= Parsers
+    // These methods parse the AST into MLIR constructs, then either return the
+    // expected MLIR value or call the generators (see below) to do that for
+    // them.
+
     /// Parses a module, the global context.
     llvm::Error parseModule(const ::ast::Ast& ast);
 
@@ -221,7 +226,26 @@ namespace mlir::verona
     /// Parses a 'return' statement.
     llvm::Expected<ReturnValue> parseReturn(const ::ast::Ast& ast);
 
+    // ============================================================== Generators
+    // These methods build complex MLIR constructs from parameters either
+    // acquired from the AST or built by the compiler as to mimic the AST.
+
+    /// Generate a prototype, populating the symbol table
+    llvm::Expected<mlir::FuncOp> generateProto(
+      mlir::Location loc,
+      llvm::StringRef name,
+      llvm::ArrayRef<mlir::Type> types,
+      llvm::ArrayRef<mlir::Type> retTy);
+    /// Generates an empty function (with the first basic block)
+    llvm::Expected<mlir::FuncOp> generateEmptyFunction(
+      mlir::Location loc,
+      llvm::StringRef name,
+      llvm::ArrayRef<llvm::StringRef> args,
+      llvm::ArrayRef<mlir::Type> types,
+      llvm::ArrayRef<mlir::Type> retTy);
+
     // =============================================================== Temporary
+    // These methods should disappear once the Verona dialect is more advanced.
 
     /// Wrapper for opaque operators before we use actual Verona dialect.
     llvm::Expected<ReturnValue> genOperation(

--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -46,6 +46,10 @@ namespace mlir::verona
     /// Default constructor, builds an empty return value.
     ReturnValue() {}
     /// Single value constructor.
+    ReturnValue(mlir::Value value)
+    {
+      values.push_back(value);
+    }
     ReturnValue(mlir::Value& value)
     {
       values.push_back(value);
@@ -103,27 +107,6 @@ namespace mlir::verona
   };
 
   /**
-   * Language ABI (temporary).
-   *
-   * This is a temporary list of constants for holding on to ABI specific
-   * ideas like how to lower an iterator or a lambda or constants. Due to
-   * the current nature of the AST, we need those ideas here. If we improve
-   * the AST, or create an improved veneer of ABI related lowering, we should
-   * move this logic there and remove these constants.
-   */
-  namespace ABI
-  {
-    /// Iteration handler, to call `has_value`, `apply` and `next`.
-    const char* const iteratorHandler = "$iter";
-    /// Iteration value check, to be performed before taking a value.
-    const char* const iteratorHasValue = "has_value";
-    /// Iteration value copy, should only be called if `has_value` is true.
-    const char* const iteratorApply = "apply";
-    /// Iteration pointer increment, moves on to the next element in the list.
-    const char* const iteratorNext = "next";
-  }
-
-  /**
    * MLIR Generator.
    */
   struct Generator
@@ -140,7 +123,8 @@ namespace mlir::verona
     lower(MLIRContext* context, const ::ast::Ast& ast);
 
   private:
-    Generator(MLIRContext* context) : context(context), builder(context)
+    Generator(MLIRContext* context)
+    : context(context), builder(context), unkLoc(builder.getUnknownLoc())
     {
       // Initialise known opaque types, for comparison.
       // TODO: Use Verona dialect types directly and isA<>.
@@ -160,6 +144,9 @@ namespace mlir::verona
     /// MLIR builder.
     mlir::OpBuilder builder;
 
+    /// Unknown location, for compiler generated stuff.
+    mlir::Location unkLoc;
+
     /// Symbol tables for variables.
     SymbolTableT symbolTable;
     /// Symbol tables for functions.
@@ -176,8 +163,22 @@ namespace mlir::verona
     /// MLIR boolean type (int1).
     mlir::Type boolTy;
 
-    /// Get location of an ast node
+    // ===================================================== Helpers
+    // Methods for symbols, location and other helpers for building
+    // MLIR nodes.
+
+    /// Get location of an ast node.
     mlir::Location getLocation(const ::ast::Ast& ast);
+
+    /// Declares a new variable.
+    void declareVariable(llvm::StringRef name, mlir::Value val);
+    /// Updates an existing variable in the local context.
+    void updateVariable(llvm::StringRef name, mlir::Value val);
+    /// Declare a (compiler generated) function.
+    void declareFunction(
+      llvm::StringRef name,
+      llvm::ArrayRef<llvm::StringRef> types,
+      llvm::StringRef retTy);
 
     // ================================================================= Parsers
     // These methods parse the AST into MLIR constructs, then either return the
@@ -187,19 +188,12 @@ namespace mlir::verona
     /// Parses a module, the global context.
     llvm::Error parseModule(const ::ast::Ast& ast);
 
-    /// Parses the prototype (signature) of a function.
-    llvm::Expected<mlir::FuncOp> parseProto(const ::ast::Ast& ast);
     /// Parses a function, from a top-level (module) view.
     llvm::Expected<mlir::FuncOp> parseFunction(const ::ast::Ast& ast);
 
     /// Recursive type parser, gathers all available information on the type
     /// and sub-types, modifiers, annotations, etc.
     mlir::Type parseType(const ::ast::Ast& ast);
-
-    /// Declares a new variable.
-    void declareVariable(llvm::StringRef name, mlir::Value val);
-    /// Updates am existing variable.
-    void updateVariable(llvm::StringRef name, mlir::Value val);
 
     /// Generic node parser, calls other parse functions to handle each
     /// individual type.
@@ -243,12 +237,44 @@ namespace mlir::verona
       llvm::ArrayRef<llvm::StringRef> args,
       llvm::ArrayRef<mlir::Type> types,
       llvm::ArrayRef<mlir::Type> retTy);
+    /// Generates a conditional branch, casting to i1 if necessary
+    llvm::Error generateCondBranch(
+      mlir::Location loc,
+      mlir::Value cond,
+      mlir::Block* ifBB,
+      mlir::ValueRange ifArgs,
+      mlir::Block* elseBB,
+      mlir::ValueRange elseArgs);
+    /// Generates an unconditional loop branch (continue, creak)
+    llvm::Error
+    generateLoopBranch(mlir::Location loc, llvm::StringRef blockName);
+
+    // ======================================================= Generator Helpers
+    // These are helpers for the generators, creating simple recurrent patterns
+    // for basic constructs (casts, load/store, constants, etc).
+    // They return mlir::Values because they're not supposed to fail.
+
+    /// Generates a cast, trusting the AST did the right thing
+    mlir::Value
+    generateAutoCast(mlir::Location loc, mlir::Value value, mlir::Type type);
+    /// Generates a verona constant with opaque type
+    mlir::Value generateConstant(
+      mlir::Location loc, llvm::StringRef value, llvm::StringRef typeName);
+    /// Generates a verona alloca with special type (or allocaTy if none)
+    // TODO: use defining operation instead of a special type, default to unkTy
+    mlir::Value
+    generateAlloca(mlir::Location loc, llvm::StringRef typeName = "");
+    /// Generates a verona load (using address' type, or unkTy)
+    mlir::Value generateLoad(mlir::Location loc, mlir::Value addr);
+    /// Generates a verona store (using value's type, or unkTy)
+    mlir::Value
+    generateStore(mlir::Location loc, mlir::Value value, mlir::Value addr);
 
     // =============================================================== Temporary
     // These methods should disappear once the Verona dialect is more advanced.
 
     /// Wrapper for opaque operators before we use actual Verona dialect.
-    llvm::Expected<ReturnValue> genOperation(
+    mlir::Value genOperation(
       mlir::Location loc,
       llvm::StringRef name,
       llvm::ArrayRef<mlir::Value> ops,

--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -50,10 +50,6 @@ namespace mlir::verona
     {
       values.push_back(value);
     }
-    ReturnValue(mlir::Value& value)
-    {
-      values.push_back(value);
-    }
     /// Multiple value constructor.
     ReturnValue(mlir::ResultRange& range)
     {

--- a/testsuite/mlir/mlir-parse/for.verona
+++ b/testsuite/mlir/mlir-parse/for.verona
@@ -1,9 +1,6 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
 
-apply(x) : S32;
-has_value(x) : bool;
-next(x);
 foo(a : S32);
 
 f(x)

--- a/testsuite/mlir/mlir-parse/for/mlir.txt
+++ b/testsuite/mlir/mlir-parse/for/mlir.txt
@@ -1,10 +1,10 @@
 
 
 module {
-  func @apply(!type.unk) -> !type.S32
-  func @has_value(!type.unk) -> i1
-  func @next(!type.unk)
   func @foo(!type.S32)
+  func @has_value(!type.unk) -> !type.bool
+  func @apply(!type.unk) -> !type.unk
+  func @next(!type.unk)
   func @f(%arg0: !type.unk) {
     %0 = "verona.alloca"() : () -> !type.alloca
     %1 = "verona.store"(%arg0, %0) : (!type.unk, !type.alloca) -> !type.unk
@@ -14,12 +14,14 @@ module {
     %5 = "verona.load"(%0) : (!type.alloca) -> !type.unk
     br ^bb1
   ^bb1:  // 2 preds: ^bb0, ^bb2
-    %6 = call @has_value(%5) : (!type.unk) -> i1
-    cond_br %6, ^bb2, ^bb3
+    %6 = call @has_value(%5) : (!type.unk) -> !type.bool
+    %7 = "verona.cast"(%6) : (!type.bool) -> i1
+    cond_br %7, ^bb2, ^bb3
   ^bb2:  // pred: ^bb1
-    %7 = call @apply(%5) : (!type.unk) -> !type.S32
+    %8 = call @apply(%5) : (!type.unk) -> !type.unk
     call @next(%5) : (!type.unk) -> ()
-    call @foo(%7) : (!type.S32) -> ()
+    %9 = "verona.cast"(%8) : (!type.unk) -> !type.S32
+    call @foo(%9) : (!type.S32) -> ()
     br ^bb1
   ^bb3:  // pred: ^bb1
     return


### PR DESCRIPTION
This is a large change, moving a lot of code from repeated patterns in the parsers into more generic functions creating the MLIR nodes. But the functionality is still identical, and therefore, no new tests. The only change in the output is the unnecessary declaration of "for" loop iteration methods that are now automatically declared.

The purpose of this change is to:
 * Allow code reuse for compiler generated sequences, like `for` loops, `lambda`s, etc.
 * Allow code reuse across AST parsers (ex. `break` & `continue`, `load` and `store`, `constant`s, etc).
 * Introduce an ABI+Lowering layer to carry language-specific concepts independent of the lowering.

The ABI side isn't complete, by far. It's just a prototype of what we want to do. When we have a more complete Verona dialect (with types), we can start looking at defining the constructs with real types. We'll also need to encode the interaction between the concepts somehow (see #259).

Fixes #258.