### PR TITLE
WIP Refactor of C++ API for RT unit tests.

### DIFF
--- a/src/rt/object/object.h
+++ b/src/rt/object/object.h
@@ -165,6 +165,8 @@ namespace verona::rt
       COWN = 0x7
     };
 
+    Object() {}
+
     inline friend std::ostream& operator<<(std::ostream& os, RegionMD md)
     {
       switch (md)

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -50,11 +50,6 @@ namespace verona::rt
       YesTryFast
     };
 
-    Cown(const Descriptor* desc) : Object(desc)
-    {
-      this->init(ThreadAlloc::get(), desc, Scheduler::alloc_epoch());
-    }
-
   private:
     friend class DLList<Cown>;
     friend class MultiMessage;
@@ -162,6 +157,7 @@ namespace verona::rt
     static Cown* alloc(Alloc* alloc, const Descriptor* desc, EpochMark epoch)
     {
       Cown* a = (Cown*)alloc->alloc<size>();
+      new (a) Cown();
       a->init(alloc, desc, epoch);
       return a;
     }
@@ -169,6 +165,7 @@ namespace verona::rt
     static Cown* alloc(Alloc* alloc, const Descriptor* desc, EpochMark epoch)
     {
       Cown* a = (Cown*)alloc->alloc(desc->size);
+      new (a) Cown();
       a->init(alloc, desc, epoch);
       return a;
     }
@@ -313,7 +310,7 @@ namespace verona::rt
      **/
     void weak_release(Alloc* alloc)
     {
-      Systematic::cout() << "Weak release " << this << std::endl;
+      Systematic::cout() << "Weak release " << this << " (" << weak_count << ")" << std::endl;
       if (weak_count.fetch_sub(1) == 1)
       {
         auto* t = owning_thread();


### PR DESCRIPTION
The C++ unit tests were using `new` to allocate Verona objects, but
were partially initialising the object using the Verona RT, and then
letting the C++ constructor fill in the rest.  On GCC, this was
triggering dead-store elimination for the Verona RT initialisation and
causing crashes.

This change makes a collection of static methods that build the Verona
object, with an embedded C++ object.

This commit only updates one of the unit tests as an experiment to see
how it looks with this alternative API.