### PR TITLE
Generating verona types from AST

### DIFF
--- a/src/mlir/dialect/VeronaDialect.cc
+++ b/src/mlir/dialect/VeronaDialect.cc
@@ -27,6 +27,8 @@ void VeronaDialect::initialize()
     IntegerType,
     CapabilityType,
     ClassType,
+    FloatType,
+    BoolType,
     ViewpointType>();
 
   allowUnknownOperations();

--- a/src/mlir/dialect/VeronaTypes.h
+++ b/src/mlir/dialect/VeronaTypes.h
@@ -40,6 +40,7 @@ namespace mlir::verona
     struct MeetTypeStorage;
     struct JoinTypeStorage;
     struct IntegerTypeStorage;
+    struct FloatTypeStorage;
     struct CapabilityTypeStorage;
     struct ClassTypeStorage;
     struct ViewpointTypeStorage;
@@ -72,6 +73,23 @@ namespace mlir::verona
 
     size_t getWidth() const;
     bool getSign() const;
+  };
+
+  struct FloatType
+  : public Type::TypeBase<FloatType, Type, detail::FloatTypeStorage>
+  {
+    using Base::Base;
+
+    static FloatType get(MLIRContext* context, size_t width);
+
+    size_t getWidth() const;
+  };
+
+  struct BoolType : public Type::TypeBase<BoolType, Type, TypeStorage>
+  {
+    using Base::Base;
+
+    static BoolType get(MLIRContext* context);
   };
 
   enum class Capability

--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -220,6 +220,8 @@ namespace mlir::verona
     // These methods build complex MLIR constructs from parameters either
     // acquired from the AST or built by the compiler as to mimic the AST.
 
+    /// Generate a Verona type from parsing its name.
+    mlir::Type generateType(llvm::StringRef name);
     /// Generate a prototype, populating the symbol table
     llvm::Expected<mlir::FuncOp> generateProto(
       mlir::Location loc,

--- a/testsuite/mlir/mlir-parse/call/mlir.txt
+++ b/testsuite/mlir/mlir-parse/call/mlir.txt
@@ -1,11 +1,11 @@
 
 
 module {
-  func @foo(%arg0: !type.imm, %arg1: !type<"U64&imm">) -> !type<"U64&imm"> {
+  func @foo(%arg0: !verona.imm, %arg1: !verona.meet<U64, imm>) -> !verona.meet<U64, imm> {
     %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.store"(%arg0, %0) : (!type.imm, !type.alloca) -> !type.unk
+    %1 = "verona.store"(%arg0, %0) : (!verona.imm, !type.alloca) -> !type.unk
     %2 = "verona.alloca"() : () -> !type.alloca
-    %3 = "verona.store"(%arg1, %2) : (!type<"U64&imm">, !type.alloca) -> !type.unk
+    %3 = "verona.store"(%arg1, %2) : (!verona.meet<U64, imm>, !type.alloca) -> !type.unk
     %4 = "verona.alloca"() : () -> !type.alloca
     %5 = "verona.load"(%0) : (!type.alloca) -> !type.unk
     %6 = "verona.load"(%2) : (!type.alloca) -> !type.unk
@@ -22,17 +22,17 @@ module {
     cond_br %16, ^bb1, ^bb2
   ^bb1:  // pred: ^bb0
     %17 = "verona.load"(%4) : (!type.alloca) -> !type.unk
-    %18 = "verona.cast"(%17) : (!type.unk) -> !type.imm
+    %18 = "verona.cast"(%17) : (!type.unk) -> !verona.imm
     %19 = "verona.load"(%9) : (!type.alloca) -> !type.unk
-    %20 = "verona.cast"(%19) : (!type.unk) -> !type<"U64&imm">
-    %21 = call @foo(%18, %20) : (!type.imm, !type<"U64&imm">) -> !type<"U64&imm">
-    return %21 : !type<"U64&imm">
+    %20 = "verona.cast"(%19) : (!type.unk) -> !verona.meet<U64, imm>
+    %21 = call @foo(%18, %20) : (!verona.imm, !verona.meet<U64, imm>) -> !verona.meet<U64, imm>
+    return %21 : !verona.meet<U64, imm>
   ^bb2:  // pred: ^bb0
     %22 = "verona.load"(%4) : (!type.alloca) -> !type.unk
     %23 = "verona.load"(%9) : (!type.alloca) -> !type.unk
     %24 = "verona.add"(%22, %23) : (!type.unk, !type.unk) -> !type.unk
-    %25 = "verona.cast"(%24) : (!type.unk) -> !type<"U64&imm">
-    return %25 : !type<"U64&imm">
+    %25 = "verona.cast"(%24) : (!type.unk) -> !verona.meet<U64, imm>
+    return %25 : !verona.meet<U64, imm>
   }
   func @apply() {
     %0 = "verona.alloca"() : () -> !type.alloca
@@ -42,10 +42,10 @@ module {
     %4 = "verona.constant(20)"() : () -> !type.int
     %5 = "verona.store"(%4, %3) : (!type.int, !type.alloca) -> !type.unk
     %6 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %7 = "verona.cast"(%6) : (!type.unk) -> !type.imm
+    %7 = "verona.cast"(%6) : (!type.unk) -> !verona.imm
     %8 = "verona.load"(%3) : (!type.alloca) -> !type.unk
-    %9 = "verona.cast"(%8) : (!type.unk) -> !type<"U64&imm">
-    %10 = call @foo(%7, %9) : (!type.imm, !type<"U64&imm">) -> !type<"U64&imm">
+    %9 = "verona.cast"(%8) : (!type.unk) -> !verona.meet<U64, imm>
+    %10 = call @foo(%7, %9) : (!verona.imm, !verona.meet<U64, imm>) -> !verona.meet<U64, imm>
     return
   }
 }

--- a/testsuite/mlir/mlir-parse/conditional/mlir.txt
+++ b/testsuite/mlir/mlir-parse/conditional/mlir.txt
@@ -1,9 +1,9 @@
 
 
 module {
-  func @f(%arg0: !type.U16) -> !type.S16 {
+  func @f(%arg0: !verona.U16) -> !verona.S16 {
     %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.store"(%arg0, %0) : (!type.U16, !type.alloca) -> !type.unk
+    %1 = "verona.store"(%arg0, %0) : (!verona.U16, !type.alloca) -> !type.unk
     %2 = "verona.load"(%0) : (!type.alloca) -> !type.unk
     %3 = "verona.constant(2)"() : () -> !type.int
     %4 = "verona.lt"(%2, %3) : (!type.unk, !type.int) -> i1
@@ -20,7 +20,7 @@ module {
     br ^bb3
   ^bb3:  // 2 preds: ^bb1, ^bb2
     %11 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %12 = "verona.cast"(%11) : (!type.unk) -> !type.S16
-    return %12 : !type.S16
+    %12 = "verona.cast"(%11) : (!type.unk) -> !verona.S16
+    return %12 : !verona.S16
   }
 }

--- a/testsuite/mlir/mlir-parse/dialect.mlir
+++ b/testsuite/mlir/mlir-parse/dialect.mlir
@@ -8,6 +8,9 @@
 // class D {
 //   f: U64 & imm;
 //   g: S32 & mut;
+//   h: F32;
+//   i: F64;
+//   j: bool;
 // }
 //
 // bar(x: U64 & imm, y: U64 & imm) {
@@ -30,6 +33,9 @@ module {
   verona.class @D {
     verona.field "f" : !verona.meet<U64, imm>
     verona.field "g" : !verona.meet<class<"C">, mut>
+    verona.field "h" : !verona.F32
+    verona.field "i" : !verona.F64
+    verona.field "j" : !verona.bool
   }
 
   func @bar(%x: !verona.meet<U64, imm>, %y: !verona.meet<U64, imm>) {

--- a/testsuite/mlir/mlir-parse/dialect/mlir.txt
+++ b/testsuite/mlir/mlir-parse/dialect/mlir.txt
@@ -6,6 +6,9 @@ module {
   verona.class @D {
     verona.field "f" : !verona.meet<U64, imm>
     verona.field "g" : !verona.meet<class<"C">, mut>
+    verona.field "h" : !verona.F32
+    verona.field "i" : !verona.F64
+    verona.field "j" : !verona.bool
   }
   func @bar(%arg0: !verona.meet<U64, imm>, %arg1: !verona.meet<U64, imm>) {
     %0 = verona.new_region @C [] : !verona.meet<class<"C">, iso>

--- a/testsuite/mlir/mlir-parse/for.verona
+++ b/testsuite/mlir/mlir-parse/for.verona
@@ -3,7 +3,7 @@
 
 foo(a : S32);
 
-f(x)
+f(x : U64)
 {
   let a : S32 = 0;
   for (a in x) {

--- a/testsuite/mlir/mlir-parse/for/mlir.txt
+++ b/testsuite/mlir/mlir-parse/for/mlir.txt
@@ -1,13 +1,13 @@
 
 
 module {
-  func @foo(!type.S32)
+  func @foo(!verona.S32)
   func @has_value(!type.unk) -> !type.bool
   func @apply(!type.unk) -> !type.unk
   func @next(!type.unk)
-  func @f(%arg0: !type.unk) {
+  func @f(%arg0: !verona.U64) {
     %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.store"(%arg0, %0) : (!type.unk, !type.alloca) -> !type.unk
+    %1 = "verona.store"(%arg0, %0) : (!verona.U64, !type.alloca) -> !type.unk
     %2 = "verona.alloca"() : () -> !type.alloca
     %3 = "verona.constant(0)"() : () -> !type.int
     %4 = "verona.store"(%3, %2) : (!type.int, !type.alloca) -> !type.unk
@@ -20,8 +20,8 @@ module {
   ^bb2:  // pred: ^bb1
     %8 = call @apply(%5) : (!type.unk) -> !type.unk
     call @next(%5) : (!type.unk) -> ()
-    %9 = "verona.cast"(%8) : (!type.unk) -> !type.S32
-    call @foo(%9) : (!type.S32) -> ()
+    %9 = "verona.cast"(%8) : (!type.unk) -> !verona.S32
+    call @foo(%9) : (!verona.S32) -> ()
     br ^bb1
   ^bb3:  // pred: ^bb1
     return

--- a/testsuite/mlir/mlir-parse/function/mlir.txt
+++ b/testsuite/mlir/mlir-parse/function/mlir.txt
@@ -2,16 +2,16 @@
 
 module {
   func @empty_declaration()
-  func @single_arg(!type.S16)
-  func @args_and_ret(!type.U32, !type.S32) -> !type.F64
+  func @single_arg(!verona.S16)
+  func @args_and_ret(!verona.U32, !verona.S32) -> !verona.F64
   func @empty_return() {
     return
   }
-  func @foo(%arg0: !type.imm, %arg1: !type<"U64&imm">) -> !type<"U64&imm"> {
+  func @foo(%arg0: !verona.imm, %arg1: !verona.meet<U64, imm>) -> !verona.meet<U64, imm> {
     %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.store"(%arg0, %0) : (!type.imm, !type.alloca) -> !type.unk
+    %1 = "verona.store"(%arg0, %0) : (!verona.imm, !type.alloca) -> !type.unk
     %2 = "verona.alloca"() : () -> !type.alloca
-    %3 = "verona.store"(%arg1, %2) : (!type<"U64&imm">, !type.alloca) -> !type.unk
+    %3 = "verona.store"(%arg1, %2) : (!verona.meet<U64, imm>, !type.alloca) -> !type.unk
     %4 = "verona.alloca"() : () -> !type.alloca
     %5 = "verona.load"(%0) : (!type.alloca) -> !type.unk
     %6 = "verona.load"(%2) : (!type.alloca) -> !type.unk
@@ -21,8 +21,8 @@ module {
     %10 = "verona.load"(%4) : (!type.alloca) -> !type.unk
     %11 = "verona.store"(%10, %9) : (!type.unk, !type.alloca) -> !type.unk
     %12 = "verona.load"(%4) : (!type.alloca) -> !type.unk
-    %13 = "verona.cast"(%12) : (!type.unk) -> !type<"U64&imm">
-    return %13 : !type<"U64&imm">
+    %13 = "verona.cast"(%12) : (!type.unk) -> !verona.meet<U64, imm>
+    return %13 : !verona.meet<U64, imm>
   }
   func @apply() {
     return

--- a/testsuite/mlir/mlir-parse/nested-conditional/mlir.txt
+++ b/testsuite/mlir/mlir-parse/nested-conditional/mlir.txt
@@ -1,9 +1,9 @@
 
 
 module {
-  func @f(%arg0: !type.U32) -> !type.U32 {
+  func @f(%arg0: !verona.U32) -> !verona.U32 {
     %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.store"(%arg0, %0) : (!type.U32, !type.alloca) -> !type.unk
+    %1 = "verona.store"(%arg0, %0) : (!verona.U32, !type.alloca) -> !type.unk
     %2 = "verona.load"(%0) : (!type.alloca) -> !type.unk
     %3 = "verona.constant(2)"() : () -> !type.int
     %4 = "verona.lt"(%2, %3) : (!type.unk, !type.int) -> i1
@@ -21,8 +21,8 @@ module {
     cond_br %11, ^bb4, ^bb5
   ^bb3:  // 2 preds: ^bb1, ^bb6
     %12 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %13 = "verona.cast"(%12) : (!type.unk) -> !type.U32
-    return %13 : !type.U32
+    %13 = "verona.cast"(%12) : (!type.unk) -> !verona.U32
+    return %13 : !verona.U32
   ^bb4:  // pred: ^bb2
     %14 = "verona.load"(%0) : (!type.alloca) -> !type.unk
     %15 = "verona.constant(1)"() : () -> !type.int

--- a/testsuite/mlir/mlir-parse/nested-while/mlir.txt
+++ b/testsuite/mlir/mlir-parse/nested-while/mlir.txt
@@ -1,9 +1,9 @@
 
 
 module {
-  func @f(%arg0: !type.S64) -> !type.S64 {
+  func @f(%arg0: !verona.S64) -> !verona.S64 {
     %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.store"(%arg0, %0) : (!type.S64, !type.alloca) -> !type.unk
+    %1 = "verona.store"(%arg0, %0) : (!verona.S64, !type.alloca) -> !type.unk
     br ^bb1
   ^bb1:  // 2 preds: ^bb0, ^bb6
     %2 = "verona.load"(%0) : (!type.alloca) -> !type.unk
@@ -17,8 +17,8 @@ module {
     br ^bb4
   ^bb3:  // pred: ^bb1
     %8 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %9 = "verona.cast"(%8) : (!type.unk) -> !type.S64
-    return %9 : !type.S64
+    %9 = "verona.cast"(%8) : (!type.unk) -> !verona.S64
+    return %9 : !verona.S64
   ^bb4:  // 2 preds: ^bb2, ^bb5
     %10 = "verona.load"(%5) : (!type.alloca) -> !type.unk
     %11 = "verona.constant(10)"() : () -> !type.int

--- a/testsuite/mlir/mlir-parse/types.verona
+++ b/testsuite/mlir/mlir-parse/types.verona
@@ -1,0 +1,9 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+// TODO: `where` variables are still not `verona` variables, so we can't
+// use them in join/meet because they won't pass `isVeronaType` check.
+foo(a: S32 & iso, b: U64 & imm): (S32 & iso) | (U64 & imm) | (U32 & mut)
+{
+  a + b;
+}

--- a/testsuite/mlir/mlir-parse/types/mlir.txt
+++ b/testsuite/mlir/mlir-parse/types/mlir.txt
@@ -1,0 +1,15 @@
+
+
+module {
+  func @foo(%arg0: !verona.meet<S32, iso>, %arg1: !verona.meet<U64, imm>) -> !verona.join<meet<S32, iso>, meet<U64, imm>, meet<U32, mut>> {
+    %0 = "verona.alloca"() : () -> !type.alloca
+    %1 = "verona.store"(%arg0, %0) : (!verona.meet<S32, iso>, !type.alloca) -> !type.unk
+    %2 = "verona.alloca"() : () -> !type.alloca
+    %3 = "verona.store"(%arg1, %2) : (!verona.meet<U64, imm>, !type.alloca) -> !type.unk
+    %4 = "verona.load"(%0) : (!type.alloca) -> !type.unk
+    %5 = "verona.load"(%2) : (!type.alloca) -> !type.unk
+    %6 = "verona.add"(%4, %5) : (!type.unk, !type.unk) -> !type.unk
+    %7 = "verona.cast"(%6) : (!type.unk) -> !verona.join<meet<S32, iso>, meet<U64, imm>, meet<U32, mut>>
+    return %7 : !verona.join<meet<S32, iso>, meet<U64, imm>, meet<U32, mut>>
+  }
+}

--- a/testsuite/mlir/mlir-parse/while-cont-brk/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while-cont-brk/mlir.txt
@@ -1,11 +1,11 @@
 
 
 module {
-  func @f(%arg0: !type.U32, %arg1: !type.S32) -> !type.F16 {
+  func @f(%arg0: !verona.U32, %arg1: !verona.S32) -> !verona.F16 {
     %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.store"(%arg0, %0) : (!type.U32, !type.alloca) -> !type.unk
+    %1 = "verona.store"(%arg0, %0) : (!verona.U32, !type.alloca) -> !type.unk
     %2 = "verona.alloca"() : () -> !type.alloca
-    %3 = "verona.store"(%arg1, %2) : (!type.S32, !type.alloca) -> !type.unk
+    %3 = "verona.store"(%arg1, %2) : (!verona.S32, !type.alloca) -> !type.unk
     br ^bb1
   ^bb1:  // 3 preds: ^bb0, ^bb4, ^bb7
     %4 = "verona.load"(%0) : (!type.alloca) -> !type.unk
@@ -23,8 +23,8 @@ module {
     cond_br %13, ^bb4, ^bb5
   ^bb3:  // 2 preds: ^bb1, ^bb6
     %14 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %15 = "verona.cast"(%14) : (!type.unk) -> !type.F16
-    return %15 : !type.F16
+    %15 = "verona.cast"(%14) : (!type.unk) -> !verona.F16
+    return %15 : !verona.F16
   ^bb4:  // pred: ^bb2
     br ^bb1
   ^bb5:  // pred: ^bb2

--- a/testsuite/mlir/mlir-parse/while-context/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while-context/mlir.txt
@@ -1,9 +1,9 @@
 
 
 module {
-  func @f(%arg0: !type.F32) -> !type.F64 {
+  func @f(%arg0: !verona.F32) -> !verona.F64 {
     %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.store"(%arg0, %0) : (!type.F32, !type.alloca) -> !type.unk
+    %1 = "verona.store"(%arg0, %0) : (!verona.F32, !type.alloca) -> !type.unk
     %2 = "verona.alloca"() : () -> !type.alloca
     %3 = "verona.constant(1)"() : () -> !type.int
     %4 = "verona.store"(%3, %2) : (!type.int, !type.alloca) -> !type.unk
@@ -29,7 +29,7 @@ module {
     br ^bb1
   ^bb3:  // pred: ^bb1
     %20 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %21 = "verona.cast"(%20) : (!type.unk) -> !type.F64
-    return %21 : !type.F64
+    %21 = "verona.cast"(%20) : (!type.unk) -> !verona.F64
+    return %21 : !verona.F64
   }
 }

--- a/testsuite/mlir/mlir-parse/while-if/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while-if/mlir.txt
@@ -1,11 +1,11 @@
 
 
 module {
-  func @f(%arg0: !type.U32, %arg1: !type.S32) -> !type.U32 {
+  func @f(%arg0: !verona.U32, %arg1: !verona.S32) -> !verona.U32 {
     %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.store"(%arg0, %0) : (!type.U32, !type.alloca) -> !type.unk
+    %1 = "verona.store"(%arg0, %0) : (!verona.U32, !type.alloca) -> !type.unk
     %2 = "verona.alloca"() : () -> !type.alloca
-    %3 = "verona.store"(%arg1, %2) : (!type.S32, !type.alloca) -> !type.unk
+    %3 = "verona.store"(%arg1, %2) : (!verona.S32, !type.alloca) -> !type.unk
     br ^bb1
   ^bb1:  // 2 preds: ^bb0, ^bb5
     %4 = "verona.load"(%0) : (!type.alloca) -> !type.unk
@@ -19,8 +19,8 @@ module {
     cond_br %9, ^bb4, ^bb5
   ^bb3:  // pred: ^bb1
     %10 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %11 = "verona.cast"(%10) : (!type.unk) -> !type.U32
-    return %11 : !type.U32
+    %11 = "verona.cast"(%10) : (!type.unk) -> !verona.U32
+    return %11 : !verona.U32
   ^bb4:  // pred: ^bb2
     %12 = "verona.load"(%0) : (!type.alloca) -> !type.unk
     %13 = "verona.constant(1)"() : () -> !type.int

--- a/testsuite/mlir/mlir-parse/while/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while/mlir.txt
@@ -1,9 +1,9 @@
 
 
 module {
-  func @f(%arg0: !type.U32) -> !type.U32 {
+  func @f(%arg0: !verona.U32) -> !verona.U32 {
     %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.store"(%arg0, %0) : (!type.U32, !type.alloca) -> !type.unk
+    %1 = "verona.store"(%arg0, %0) : (!verona.U32, !type.alloca) -> !type.unk
     br ^bb1
   ^bb1:  // 2 preds: ^bb0, ^bb2
     %2 = "verona.load"(%0) : (!type.alloca) -> !type.unk
@@ -18,7 +18,7 @@ module {
     br ^bb1
   ^bb3:  // pred: ^bb1
     %9 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %10 = "verona.cast"(%9) : (!type.unk) -> !type.U32
-    return %10 : !type.U32
+    %10 = "verona.cast"(%9) : (!type.unk) -> !verona.U32
+    return %10 : !verona.U32
   }
 }


### PR DESCRIPTION
Not yet converting `where` types to proper Verona types, but all others (integer, float, join, meet) including nested operations.

Added Float and Bool types in the dialect to complete the support needed for this change.

Fixes #274