### PR TITLE
WIP: Initial implementation of the region checker.

### DIFF
--- a/src/mlir/Query.h
+++ b/src/mlir/Query.h
@@ -1,0 +1,556 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "llvm/ADT/ArrayRef.h"
+
+#include <optional>
+#include <tuple>
+
+namespace mlir::verona
+{
+  /// Index provides a comparator that orders tuples in lexicographical order,
+  /// but following a given field sequence. For example, when applied to pairs,
+  /// `Index<_, 1, 0>` will first compare the second elements, and only if they
+  /// match will it compare the first ones. This is used to provide custom
+  /// orderings for tuples stored in Relations.
+  ///
+  /// The first type parameter, `Compare`, is used as the underlying comparator
+  /// for elements of the tuples. The same comparator type must be compatible
+  /// with all constituent types.
+  ///
+  /// Index supports both `std::tuple` and any class which defines a
+  /// `data() const` which returns a tuple. This allows wrappers around tuples
+  /// to be used with Relation.
+  template<typename Compare, size_t... Keys>
+  struct Index;
+
+  /// This is the base case, for when no key is provided. Since there is nothing
+  /// to compare, all values are considered equal, ie. (left < right) == false.
+  template<typename Compare>
+  struct Index<Compare>
+  {
+    template<typename T>
+    bool operator()(const T& left, const T& right) const
+    {
+      return false;
+    }
+  };
+
+  template<typename Compare, size_t Head, size_t... Tail>
+  struct Index<Compare, Head, Tail...>
+  {
+    template<typename... Ts>
+    bool
+    operator()(const std::tuple<Ts...>& left, const std::tuple<Ts...>& right)
+    {
+      const auto& left_value = std::get<Head>(left);
+      const auto& right_value = std::get<Head>(right);
+      if (Compare()(left_value, right_value))
+        return true;
+      else if (Compare()(right_value, left_value))
+        return false;
+      else
+        return Index<Compare, Tail...>()(left, right);
+    }
+
+    /// Retrieve the "primary" element of the tuple, that is the one that is
+    /// used first during comparisons.
+    template<typename... Ts>
+    static const auto& get_primary(const std::tuple<Ts...>& value)
+    {
+      return std::get<Head>(value);
+    }
+
+    template<typename T>
+    bool operator()(const T& left, const T& right)
+    {
+      return (*this)(left.data(), right.data());
+    }
+
+    template<typename T>
+    static const auto& get_primary(const T& value)
+    {
+      return get_primary(value.data());
+    }
+
+    /// Underlying comparator used on the contents of the tuple.
+    using value_compare = Compare;
+  };
+
+  namespace detail
+  {
+    /// Type trait used to identify instantiations of `Index`.
+    template<typename T>
+    struct is_index : std::false_type
+    {};
+
+    template<typename Compare, size_t... Keys>
+    struct is_index<Index<Compare, Keys...>> : std::true_type
+    {};
+
+    template<typename T>
+    static constexpr bool is_index_v = is_index<T>::value;
+  }
+
+  struct QueryEngine;
+
+  /// Type-erased version of a Relation, used to be stored in a QueryEngine.
+  struct AbstractRelation
+  {
+    AbstractRelation(QueryEngine& engine);
+    virtual bool iterate() = 0;
+    virtual ~AbstractRelation(){};
+
+    // We don't allow copying nor moving an AbstractRelation, because the
+    // QueryEngine holds a pointer to it.
+    AbstractRelation(const AbstractRelation&) = delete;
+    AbstractRelation& operator=(const AbstractRelation&) = delete;
+  };
+
+  /// A relation represents an ordered collection of tuples.
+  ///
+  /// Tuples in the relation are classified as "stable" or "recent". Every time
+  /// the `iterate` method is called, all "recent" tuples become "stable". This
+  /// distinction is used to compute incremental updates of relations which
+  /// depend on this one: only recent tuples need to be considered.
+  ///
+  /// Additionally, the Relation keeps a list of pending tuples. When `iterate`
+  /// is called, all these pending tuples are added to the "recent" set. Tuples
+  /// can be added to the pending list either manually, using the `add` method,
+  /// or through "Horn clauses", in the form of the `from_XXX` methods.
+  ///
+  /// The choice of ordering, as determined by the `Compare` template type
+  /// parameter, is critical: relations can only be joined on their "primary"
+  /// element, i.e. the one that is sorted on first.
+  ///
+  /// For instance, given a binary relation `R(_, _)`, if sorted using the first
+  /// element, we can compute the join `R(x, y), R(x, z)`. If on the other hand,
+  /// the relation is sorted using the second element, we can compute the join
+  /// `R(x, z), R(y, z)`.
+  ///
+  /// If, for example, one wishes to compute the transitive closure of R,
+  /// i.e. `R(x, y), R(y, z)`, then it must be indexed by both its first and
+  /// second element. This can be achieved by using two Relation instances R and
+  /// S, each with the same contents but with different orderings. If R is
+  /// ordered using the first element and S is ordered using the second, the
+  /// transitive closure is computed as `S(x, y), R(y, z)`. Of course, any tuple
+  /// added to R must also be added to S, hence `S(x, y) :- R(x, y)`.
+  //
+  /// The `Index` classes provide a convenient way of setting up the right
+  /// orderings. The relations `R` and `S` described above can be respectively
+  /// represented using types `Relation<tuple<T, T>, Index<_, 0, 1>>` and
+  /// `Relation<tuple<T, T>, Index<_, 1, 0>>`.
+  template<typename T, typename Compare>
+  struct Relation : public AbstractRelation
+  {
+    using tuple_type = T;
+    using tuple_compare = Compare;
+
+    /// Create a new relation that is registered with the given engine: calling
+    /// `iterate` on the engine will iterate this relation.
+    Relation(QueryEngine& engine) : AbstractRelation(engine) {}
+
+    /// Get all tuples that have been added to the relation.
+    ///
+    /// Unlike `stable_values` and `recent_values`, the slice returned by this
+    /// method may not be fully sorted.
+    ArrayRef<T> values() const
+    {
+      return values_;
+    }
+
+    /// Get tuples that have been added more than one iteration ago.
+    ArrayRef<T> stable_values() const
+    {
+      return ArrayRef<T>(values_).take_front(stable_count);
+    }
+
+    /// Get tuples that have been added in the most recent iteration.
+    ArrayRef<T> recent_values() const
+    {
+      return ArrayRef<T>(values_).drop_front(stable_count);
+    }
+
+    /// Check whether a given value is present in the relation.
+    bool contains(const T& value) const
+    {
+      auto search = [&](const auto& c) {
+        return std::binary_search(c.begin(), c.end(), value, tuple_compare());
+      };
+
+      // Because the two parts are sorted independently, we must perform two
+      // separate binary searches.
+      return search(stable_values()) || search(recent_values());
+    }
+
+    /// Returns true if the relation has new tuples.
+    bool iterate() final
+    {
+      assert(llvm::is_sorted(stable_values(), tuple_compare()));
+      assert(llvm::is_sorted(recent_values(), tuple_compare()));
+
+      // Move all recent tuples into the stable section.
+      std::inplace_merge(
+        values_.begin(),
+        values_.begin() + stable_count,
+        values_.end(),
+        tuple_compare());
+      stable_count = values_.size();
+
+      // Move all pending tuples into the recent section, if they do not yet
+      // exist in the relation.
+      llvm::copy_if(pending, std::back_inserter(values_), [&](const T& value) {
+        return !contains(value);
+      });
+      std::sort(values_.begin() + stable_count, values_.end(), tuple_compare());
+      pending.clear();
+
+      return !recent_values().empty();
+    }
+
+    /// Add a new tuple to the relation.
+    void add(T tuple)
+    {
+      this->pending.push_back(tuple);
+    }
+
+    /// Copy all tuples from another relation.
+    ///
+    /// The other relation must have the same tuple type, but does not need to
+    /// be ordered in the same way. This method is useful to reindex a relation.
+    template<typename R>
+    void from_copy(const R& other)
+    {
+      static_assert(std::is_same_v<typename R::tuple_type, tuple_type>);
+      llvm::copy(other.recent_values(), std::back_inserter(this->pending));
+    }
+
+    /// The `from_XXX` methods accept a function used to produce tuples to be
+    /// added to the relation. We allow the function to return either `T` or
+    /// `optional<T>`: if a nullopt value is returned, nothing is added to the
+    /// relation. This predicate is used to static_assert that the callback's
+    /// signature is correct.
+    template<typename F, typename... Args>
+    static constexpr bool is_tuple_producer = llvm::
+      is_one_of<std::invoke_result_t<F, Args...>, T, std::optional<T>>::value;
+
+    /// Apply a transformation to tuples from another relation, adding the
+    /// result to this one.
+    ///
+    /// The transformation function may produce either a `T` or an
+    /// `optional<T>`.
+    template<typename R, typename F>
+    void from_map(const R& other, F&& f)
+    {
+      static_assert(is_tuple_producer<F&, const typename R::tuple_type&>);
+
+      for (const auto& entry : other.recent_values())
+      {
+        if (std::optional<T> result = f(entry))
+          this->pending.push_back(result.value());
+      }
+    }
+
+    /// Combine two relations together by applying a function to every element
+    /// of their cartesian product. The result of the function is added to the
+    /// current relation.
+    ///
+    /// This can be used to model conjunctions with no overlapping variables,
+    /// such as the following:
+    ///
+    ///   A(x, y) :- B(x), C(y).
+    ///
+    template<typename R1, typename R2, typename F>
+    void from_cross(const R1& left, const R2& right, F&& f)
+    {
+      using T1 = typename R1::tuple_type;
+      using T2 = typename R2::tuple_type;
+      static_assert(is_tuple_producer<F&, const T1&, const T2&>);
+
+      auto on_join = [&](const T1& l, const T2& r) {
+        if (std::optional<T> result = f(l, r))
+          this->pending.push_back(result.value());
+      };
+
+      cross_tuples(left.stable_values(), right.recent_values(), on_join);
+      cross_tuples(left.recent_values(), right.stable_values(), on_join);
+      cross_tuples(left.recent_values(), right.recent_values(), on_join);
+    }
+
+    /// Combine two relations together by applying a function to every element
+    /// of their cartesian product that satisfy a join requirement. The result
+    /// of the function is added to the current relation.
+    ///
+    /// This can be used to model conjunctions with one overlapping variable,
+    /// such as the following:
+    ///
+    ///   A(x, z) :- B(x, y), C(y, z).
+    ///
+    /// For each relation being joined on, a "key function" must be provided.
+    /// This function projects from each tuple the element being joined on.
+    /// In the example above, `kfB = (x, y) -> y` and `kfC = (y, z) -> y`.
+    /// The return type of both key functions must be the same. Additionally, a
+    /// comparison function operating on the key type must be provided.
+    ///
+    /// The ordering used by each relation must be compatible with the ordering
+    /// used by the keys. Formally, the two orderings, respectively denoted `<R`
+    /// and `<k` must satisfy the following property:
+    ///
+    ///   ∀ t1, t2 ∈ R. kf(t1) <k kf(t2) => t1 <R t2
+    ///
+    template<
+      typename R1,
+      typename R2,
+      typename KF1,
+      typename KF2,
+      typename KeyComp,
+      typename F>
+    void from_join(
+      const R1& left,
+      const R2& right,
+      KF1&& kf1,
+      KF2&& kf2,
+      KeyComp&& less,
+      F&& f)
+    {
+      using T1 = typename R1::tuple_type;
+      using T2 = typename R2::tuple_type;
+
+      static_assert(is_tuple_producer<F&, const T1&, const T2&>);
+
+      auto on_join = [&](const T1& l, const T2& r) {
+        if (std::optional<T> result = f(l, r))
+          this->pending.push_back(result.value());
+      };
+      auto execute = [&](const ArrayRef<T1>& l, const ArrayRef<T2>& r) {
+        join_tuples(l, r, kf1, kf2, less, on_join);
+      };
+
+      execute(left.stable_values(), right.recent_values());
+      execute(left.recent_values(), right.stable_values());
+      execute(left.recent_values(), right.recent_values());
+    }
+
+    /// Convenience overload that joins on the "primary key" of tuples. This
+    /// requires the relation to be ordered using an instantiation of the
+    /// `Index` template. For example, joining on a relation `R(x, y, z)`
+    /// ordered by `Index<_, 1, 0, 2>` will use `y` as its join key.
+    template<typename R1, typename R2, typename F>
+    void from_join(const R1& left, const R2& right, F&& f)
+    {
+      // Both relations should be ordered by an `Index` type, which, in addition
+      // to being a comparator, exposes a `get_primary` method to retrieve a
+      // tuple's primary key.
+      using Idx1 = typename R1::tuple_compare;
+      using Idx2 = typename R2::tuple_compare;
+      static_assert(
+        detail::is_index_v<Idx1> && detail::is_index_v<Idx1>,
+        "Relations must be ordered by an `Index` instantiation");
+
+      // Use the underlying comparator used by `Index`. We make sure both
+      // relations' comparators actually are the same.
+      using KeyComp = typename Idx1::value_compare;
+      static_assert(
+        std::is_same_v<KeyComp, typename Idx2::value_compare>,
+        "Both relations should use the same underlying comparator");
+
+      from_join(
+        left,
+        right,
+        [](const auto& v) { return Idx1::get_primary(v); },
+        [](const auto& v) { return Idx2::get_primary(v); },
+        KeyComp{},
+        f);
+    }
+
+    SmallVector<T, 0> finish() &&
+    {
+      assert(pending.empty());
+      assert(stable_count == values_.size());
+      return std::move(values_);
+    }
+
+  private:
+    /// Advance an iterator until the result of the key-function changes.
+    /// Returns the first iterator that exposes a different value, or `end` if
+    /// no such position exists.
+    ///
+    /// TODO: Take advantage of the fact that the lists are sorted to scan in
+    /// increasingly bigger steps, eg. by 1, 2, 4, ... and backtrack when we've
+    /// overshot.
+    template<typename I, typename KF>
+    static I advance(I it, I end, KF&& key)
+    {
+      assert(it != end);
+      const auto& current = key(*it);
+      do
+      {
+        ++it;
+      } while (it != end && key(*it) == current);
+      return it;
+    }
+
+    /// Perform the join between two slices. Functions KF1 and KF2 are used to
+    /// project the values on which to join, respectively from T1 and T2. For
+    /// each pair in the join, the callback `on_join` will be called.
+    ///
+    /// The general idea is to perform a simultaneous traversal of the two
+    /// slices, moving forward the iterator that has the smallest key. Once we
+    /// identify a key value present in both lists, we use `cross_tuples` to
+    /// yield all elements in the cartesian product of entries with that key.
+    ///
+    /// For example, given lists [ 1, 3, 3', 4 ] and [ 2, 3*, 5 ], the two
+    /// iterators will, in turn, reference entries (1, 2), (3, 2), (3, 3*) and
+    /// (4, 5). The callback will be called with arguments (3, 3*) and (3', 3*).
+    /// We use ' and * to distinguish between the entries with the same key.
+    ///
+    template<
+      typename T1,
+      typename T2,
+      typename KF1,
+      typename KF2,
+      typename KeyComp,
+      typename OnJoin>
+    static void join_tuples(
+      ArrayRef<T1> left,
+      ArrayRef<T2> right,
+      const KF1& kf1,
+      const KF2& kf2,
+      const KeyComp& less,
+      const OnJoin& on_join)
+    {
+      using K1 = std::invoke_result_t<const KF1&, const T1&>;
+      using K2 = std::invoke_result_t<const KF2&, const T2&>;
+
+      // This requirement could be relaxed; all we care is that keys can be
+      // compared by KeyComp and operator==. We could even remove the later
+      // requirement and only use KeyComp. On the other hand, it makes sense
+      // to be joining on things that have the same type.
+      static_assert(
+        std::is_same_v<K1, K2>,
+        "Elements being joined on must have the same type");
+
+      assert(llvm::is_sorted(
+        left, [&](const T1& l, const T1& r) { return less(kf1(l), kf1(r)); }));
+      assert(llvm::is_sorted(
+        right, [&](const T2& l, const T2& r) { return less(kf2(l), kf2(r)); }));
+
+      const T1* left_it = left.begin();
+      const T2* right_it = right.begin();
+
+      while (left_it != left.end() && right_it != right.end())
+      {
+        const K1& left_key = kf1(*left_it);
+        const K2& right_key = kf2(*right_it);
+
+        if (left_key == right_key)
+        {
+          // Select all the values, both on the left and on the right, that
+          // share that same key.
+          const T1* left_last = advance(left_it, left.end(), kf1);
+          const T2* right_last = advance(right_it, right.end(), kf2);
+          ArrayRef<T1> left_values(left_it, left_last);
+          ArrayRef<T2> right_values(right_it, right_last);
+
+          cross_tuples(left_values, right_values, on_join);
+
+          left_it = left_last;
+          right_it = right_last;
+        }
+        else if (less(left_key, right_key))
+        {
+          // TODO: advance only moves to the first position with a different
+          // key. We could go faster and skip to the first position that is not
+          // less than right_key.
+          left_it = advance(left_it, left.end(), kf1);
+        }
+        else
+        {
+          assert(less(right_key, left_key));
+          right_it = advance(right_it, right.end(), kf2);
+        }
+      }
+    }
+
+    /// Perform the cross join between two slices. The object `f` will be called
+    /// for every pair of elements in the cartesian product of `left` and
+    /// `right`.
+    template<typename T1, typename T2, typename F>
+    static void cross_tuples(ArrayRef<T1> left, ArrayRef<T2> right, F&& f)
+    {
+      for (const T1& l : left)
+      {
+        for (const T2& r : right)
+        {
+          f(l, r);
+        }
+      }
+    }
+
+  private:
+    // The first `stable_count` elements of `values_` are the "stable" ones, the
+    // rest are the "recent". Each segment is sorted independently.
+    //
+    // Using a single vector allows us to use `std::inplace_merge` whenever we
+    // want to merge the recent elements into the stable ones.
+    SmallVector<T, 0> values_;
+    size_t stable_count = 0;
+
+    SmallVector<T, 0> pending;
+  };
+
+  /// A QueryEngine holds a set of mutally dependent Relations. It is used the
+  /// drive the process of iterating the Relations. Typical usage looks as
+  /// follows:
+  ///
+  ///    // Setup the engine and register Relation objects into it.
+  ///    QueryEngine engine;
+  ///    Relation<...> r1(engine);
+  ///    Relation<...> r2(engine);
+  ///    Relation<...> r3(engine);
+  ///
+  ///    // Seed the relations with known values.
+  ///    r1.add(...);
+  ///    r1.add(...);
+  ///
+  //     // Apply rules until a fixpoint is reached.
+  ///    while (engine.iterate()) {
+  ///      r1.from_join(r1, r1, ...);
+  ///      r2.from_map(r1, ...);
+  ///      r3.from_join(r1, r2, ...)
+  ///    }
+  ///
+  ///    // Query the result
+  ///    for (auto v : r1.values()) { print(v); }
+  ///    if (r2.contains(x)) { ... }
+  ///
+  struct QueryEngine
+  {
+    bool iterate()
+    {
+      bool result = false;
+      for (auto& it : relations)
+      {
+        result |= it->iterate();
+      }
+      return result;
+    }
+
+  private:
+    void add(AbstractRelation* relation)
+    {
+      relations.push_back(relation);
+    }
+
+    SmallVector<AbstractRelation*, 0> relations;
+
+    friend AbstractRelation;
+  };
+
+  inline AbstractRelation::AbstractRelation(QueryEngine& engine)
+  {
+    engine.add(this);
+  }
+}

--- a/src/mlir/dialect/CMakeLists.txt
+++ b/src/mlir/dialect/CMakeLists.txt
@@ -3,6 +3,7 @@ add_mlir_doc(VeronaDialect -gen-dialect-doc VeronaDialect Verona/)
 add_mlir_doc(VeronaOps -gen-op-doc VeronaOps Verona/)
 
 add_mlir_interface(TypecheckInterface)
+add_mlir_interface(RegionChecker)
 
 add_mlir_dialect_library(MLIRVerona
     VeronaDialect.cc
@@ -10,6 +11,7 @@ add_mlir_dialect_library(MLIRVerona
     VeronaTypes.cc
     Typechecker.cc
     TypecheckInterface.cc
+    RegionChecker.cc
 
     DEPENDS
     MLIRVeronaOpsIncGen

--- a/src/mlir/dialect/RegionChecker.cc
+++ b/src/mlir/dialect/RegionChecker.cc
@@ -1,0 +1,480 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include "dialect/RegionChecker.h"
+
+#include "Query.h"
+#include "dialect/TopologicalFacts.h"
+#include "dialect/Typechecker.h"
+#include "dialect/VeronaOps.h"
+#include "dialect/VeronaTypes.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/AsmState.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/Value.h"
+
+#include "llvm/ADT/SetVector.h"
+
+/// The set of facts F(b) available in a block b is defined as follows:
+///
+///   F(b) = local-facts(b)
+///        ∪ derived-facts(F(b))
+///        ∪ (intersect { rename(p, b, F(p)) | p ∈ predecessors(b) })
+///
+/// - Local facts are those introduced by operations within the block. For
+///   instance, given `%x = verona.copy %y`, the local facts would contain
+///   `alias(%x, %y)`. This is easily computed, by walking over the list of
+///   operations and invoking custom per-operation logic.
+///
+/// - Derived facts are inferred from one or more existing facts. For instance,
+///   if `alias(%x, %y)` and `alias(%y, %z)` are known (they are local facts for
+///   example), then `alias(%x, %z)` is true. These facts are defined by a set
+///   of datalog-like rules over other facts. The result is obtained by applying
+///   the rules until a (least) fixed point is reached.
+///
+/// - If a fact is available in all predecessors of b, then it is available in b
+///   as well. There are however a few twists:
+///
+///   + If a fact refers to variables that are used as block arguments in the
+///     transition, the appropriate renaming is applied to the fact's contents.
+///
+///   + If a fact refers to variables that are not defined in the target block
+///     (ie. the variable does not dominate the target block), the fact is not
+///     propagated.
+///
+///   + Because of loops, we may arrive in a situation where
+///     `F(b) = F(a) ∩ F(b)`, that is a fact is available in `b` only if it is
+///     available in `b`. In these circumstances, we consider the fact to be
+///     available (assuming it is also available in block a), resulting in a
+///     greatest fixed point.
+///
+///   Propagated facts are computed by iterating over the control-flow graph,
+///   using a worklist of blocks to consider. Initially we assume all facts to
+///   be true in all blocks. We apply the flow equation for F(b) in a forward
+///   analysis style. On every iteration, the set of available facts can only
+///   shrink, until the fixed-point is reached.
+///
+/// Both iterative processes, the datalog evaluation of derived facts and the
+/// propagation throughthe CFG, contribute to one another. Any time the CFG
+/// propagation takes a step, it fully re-evaluates all derived facts.
+/// TODO: look into whether this can be done incrementally instead. Non-trivial
+/// since one iterative process grows the size of the relation whereas the
+/// other one shrinks it.
+///
+namespace mlir::verona
+{
+  struct FactEvaluator;
+
+  struct StableFacts
+  {
+    SmallVector<Alias, 0> aliases;
+
+    StableFacts() {}
+    explicit StableFacts(SmallVector<Alias, 0>&& aliases) : aliases(aliases) {}
+
+    /// Compute the set of facts that are propagated from one block to the
+    /// other. This takes into account block parameter induced renamings, and
+    /// filters out variables that are undefined in the target block.
+    ///
+    /// The function F is invoked on every fact that is propagated to the
+    /// target.
+    template<typename F>
+    void getOutgoingFacts(
+      const DominanceInfo& dominance,
+      Block* origin,
+      unsigned successorIndex,
+      Block* target,
+      F&& f) const;
+
+    /// Returns true is `this` is "smaller" than `other`. This method is used to
+    /// decide when a fixed-point is reached.
+    bool refines(const StableFacts& other) const
+    {
+      assert(aliases.size() <= other.aliases.size());
+      return aliases.size() < other.aliases.size();
+    }
+  };
+
+  struct FactEvaluator
+  {
+    FactEvaluator() : defined(engine), aliases(engine) {}
+
+    void add(Alias fact)
+    {
+      aliases.add(fact);
+    }
+
+    // TODO: we don't currently support evaluating these facts.
+    void add(In fact) {}
+    void add(From fact) {}
+
+    /// Add facts derived from a basic block's operations.
+    ///
+    /// For example, if `block` contains a `%x = copy %y` operation, the fact
+    /// `alias(%x, %y)` is added to the evaluator. The RegionCheckInterface
+    /// implementation of each operation is used to determine what facts to add.
+    ///
+    void addLocalFacts(Block* block)
+    {
+      for (Value v : block->getArguments())
+      {
+        if (isaVeronaType(v.getType()))
+          defined.add(Defined(v));
+      }
+      for (Operation& op : *block)
+      {
+        for (Value v : op.getResults())
+        {
+          if (isaVeronaType(v.getType()))
+            defined.add(Defined(v));
+        }
+        if (auto iface = llvm::dyn_cast<RegionCheckInterface>(op))
+        {
+          iface.add_facts(*this);
+        }
+      }
+    }
+
+    /// Add facts coming from the predecessors of `block`. Only facts available
+    /// in all predecessors are added. The `factsMap` is used to look up the
+    /// facts of each block.
+    void addIncomingFacts(
+      const DominanceInfo& dominance,
+      const DenseMap<Block*, StableFacts>& factsMap,
+      Block* block);
+
+    /// Compute derived facts by iterating over the set of rules until a fixed
+    /// point is reached.
+    void process()
+    {
+      while (engine.iterate())
+      {
+        iterate();
+      }
+    }
+
+    /// Extract facts from this evaluator into an equivalent StableFacts.
+    StableFacts finish() &&
+    {
+      return StableFacts(std::move(aliases).finish());
+    }
+
+  private:
+    /// Apply all the fact derivation rules once.
+    void iterate()
+    {
+      // alias(x, x) :-
+      //   defined(x).
+      aliases.from_map(defined, [](const auto& r) -> Alias {
+        return Alias(r.value, r.value);
+      });
+
+      // alias(x, y) :-
+      //   alias(y, x).
+      aliases.from_map(
+        aliases, [](const auto& r) -> Alias { return Alias(r.right, r.left); });
+
+      // alias(y, z) :-
+      //   alias(x, y),
+      //   alias(x, z).
+      //
+      // This isn't quite the usual formulation of transitivity; you would
+      // generally expect `alias(x, z) :- alias(x, y), alias(y, z).`
+      // However, because `alias` is symmetric the two are equvalent and the one
+      // used here doesn't need joining on the second variable (and a separate
+      // index).
+      aliases.from_join(
+        aliases, aliases, [](const auto& r1, const auto& r2) -> Alias {
+          assert(r1.left == r2.left);
+          return Alias(r1.right, r2.right);
+        });
+    }
+
+    /// Compator type made to operate on Value and Type.
+    ///
+    /// The QueryEngine needs facts to be ordered, but Value and Type do not
+    /// provide operator< implementations. We provide our own ordering by using
+    /// their opaque pointer representiation, which should be totally ordered.
+    struct ValueCmp
+    {
+      bool operator()(Value left, Value right) const
+      {
+        return std::less()(
+          left.getAsOpaquePointer(), right.getAsOpaquePointer());
+      }
+
+      bool operator()(Type left, Type right) const
+      {
+        return std::less()(
+          left.getAsOpaquePointer(), right.getAsOpaquePointer());
+      }
+
+      bool operator()(ArrayRef<Type> left, ArrayRef<Type> right) const
+      {
+        return std::lexicographical_compare(
+          left.begin(), left.end(), right.begin(), right.end(), *this);
+      }
+    };
+
+    QueryEngine engine;
+    Relation<Defined, Index<ValueCmp, 0>> defined;
+    Relation<Alias, Index<ValueCmp, 0, 1>> aliases;
+  };
+
+  /// A BranchMap transforms SSA values along an edge of the control flow graph,
+  /// taking into account renamings and undefined values.
+  ///
+  /// Once constructed, its `withValue` method can be used to determine all
+  /// names a value has after the edge is followed. In the following example,
+  /// along the edge between ^bb0 and ^bb1, assuming ^bb0 dominates ^bb1, then
+  /// `withValue(%x)` would yield values %x, %y and %z. If ^bb0 does not
+  /// dominates ^bb1, then `withValue(%x)` would only yield values %y and %z.
+  ///
+  ///  ^bb0:
+  ///   %x = ....
+  ///   br ^bb1(%x, %x)
+  ///
+  ///  ^bb1(%y, %z):
+  ///   ...
+  ///
+  /// This class operates as a "best-effort"; not all terminators provide enough
+  /// information about what values are passed on, hence not all target values
+  /// may be yielded. This is sound in its application to propagate facts. If a
+  /// target variable is missed, the set of available facts will only be smaller
+  /// than what it could have been.
+  struct BranchMap
+  {
+    BranchMap(
+      const DominanceInfo& dominance,
+      Block* origin,
+      unsigned successorIndex,
+      Block* target)
+    : dominance(dominance), target(target)
+    {
+      assert(origin->getSuccessor(successorIndex) == target);
+
+      Optional<OperandRange> branchOperands;
+      if (auto branch = dyn_cast<BranchOpInterface>(origin->getTerminator()))
+        branchOperands = branch.getSuccessorOperands(successorIndex);
+
+      if (branchOperands.hasValue())
+      {
+        ArrayRef<BlockArgument> blockArguments = target->getArguments();
+
+        assert(branchOperands->size() == blockArguments.size());
+        for (const auto& [operand, argument] :
+             llvm::zip(*branchOperands, blockArguments))
+        {
+          valueMap[operand].push_back(argument);
+        }
+      }
+    }
+
+    template<typename F>
+    void withValue(Value value, F&& f)
+    {
+      // We propagate the variable un-renamed only if it is defined in the
+      // target block, ie. its definition dominates the block.
+      //
+      // We're interested in knowing whether the variable is defined at the very
+      // beginning of the block, before block arguments are even defined, hence
+      // the use of proper dominance.
+      if (dominance.properlyDominates(value.getParentBlock(), target))
+        f(value);
+
+      auto it = valueMap.find(value);
+      if (it != valueMap.end())
+      {
+        for (Value argument : it->second)
+        {
+          f(argument);
+        }
+      }
+    }
+
+  private:
+    /// Map from one value to the list of values that receive it.
+    ///
+    /// For example given `br ^bb(%x, %x)` where `^bb` is defined as
+    /// `^bb(%y, %z)`, then `valueMap(%x) = [%y, %z]`.
+    DenseMap<Value, SmallVector<Value, 1>> valueMap;
+
+    const DominanceInfo& dominance;
+    Block* target;
+  };
+
+  /// Utility class used to take the intersection of facts from many incoming
+  /// edges.
+  ///
+  /// Each fact produced by a predecessor block is added to the intersector. At
+  /// the end, any fact which was added as many times to the intersector as
+  /// there are predecessors is kept.
+  class FactIntersector
+  {
+  public:
+    FactIntersector() {}
+
+    void operator()(const Alias& fact)
+    {
+      auto [it, inserted] =
+        aliases.insert({fact, std::make_pair(0, predecessors)});
+      assert(it->second.second <= predecessors);
+
+      if (inserted || it->second.second < predecessors)
+      {
+        it->second.first += 1;
+      }
+    }
+
+    void next()
+    {
+      predecessors++;
+    }
+
+    size_t count() const
+    {
+      return predecessors;
+    }
+
+    template<typename F>
+    void finish(F f) const
+    {
+      for (const auto& [fact, entry] : aliases)
+      {
+        assert(entry.first <= predecessors);
+        if (entry.first == predecessors)
+          f(fact);
+      }
+    }
+
+    FactIntersector(const FactIntersector&) = delete;
+    FactIntersector& operator=(const FactIntersector&) = delete;
+
+  private:
+    size_t predecessors = 0;
+
+    // For each fact, we keep track of 1) the number of predecessors that have
+    // added it and 2) the index of the last predecessor that has. The latter
+    // allows us to avoid spurious increments if a precessor has multiple copies
+    // of a fact.
+    DenseMap<Alias, std::pair<size_t, size_t>> aliases;
+  };
+
+  template<typename F>
+  void StableFacts::getOutgoingFacts(
+    const DominanceInfo& dominance,
+    Block* origin,
+    unsigned successorIndex,
+    Block* target,
+    F&& f) const
+  {
+    BranchMap branchMap(dominance, origin, successorIndex, target);
+
+    for (const Alias& r : aliases)
+    {
+      branchMap.withValue(r.left, [&](Value left) {
+        branchMap.withValue(
+          r.right, [&](Value right) { f(Alias(left, right)); });
+      });
+    }
+  }
+
+  void FactEvaluator::addIncomingFacts(
+    const DominanceInfo& dominance,
+    const DenseMap<Block*, StableFacts>& factsMap,
+    Block* block)
+  {
+    // We add all incoming facts by taking the intersection of all the
+    // predecessors' outgoing facts.
+    FactIntersector intersector;
+    for (auto it = block->pred_begin(); it != block->pred_end(); it++)
+    {
+      // If a predecessor is missing from the factsMap, its set of facts has not
+      // been evaluated yet. We assume "all facts" are available in the block,
+      // thus we do not need to include it in the intersection.
+      auto facts_it = factsMap.find(*it);
+      if (facts_it != factsMap.end())
+      {
+        facts_it->second.getOutgoingFacts(
+          dominance, *it, it.getSuccessorIndex(), block, intersector);
+        intersector.next();
+      }
+    }
+
+    // If the block has any predecessors, we must have found at least one for
+    // which we have evaluated facts already, to the fact that we process basic
+    // blocks top-down.
+    //
+    // If this weren't true - if the block has predecessors but none of them had
+    // been evaluated yet - we would need "all facts" to be available in this
+    // block (since they are in all predecessors), which we can't represent.
+    assert(block->hasNoPredecessors() || intersector.count() > 0);
+
+    intersector.finish([&](auto fact) { add(fact); });
+  }
+
+  void RegionCheckerPass::runOnFunction()
+  {
+    llvm::SetVector<Block*> worklist;
+    DenseMap<Block*, StableFacts> facts;
+
+    DominanceInfo dominance(getOperation());
+
+    worklist.insert(&getOperation().getCallableRegion()->front());
+    while (!worklist.empty())
+    {
+      Block* current = worklist.pop_back_val();
+      SmallVector<StableFacts, 2> incoming_facts;
+
+      FactEvaluator evaluator;
+      evaluator.addLocalFacts(current);
+      evaluator.addIncomingFacts(dominance, facts, current);
+      evaluator.process();
+      StableFacts result = std::move(evaluator).finish();
+
+      auto [it, inserted] = facts.insert({current, StableFacts()});
+      if (inserted || result.refines(it->second))
+      {
+        it->second = result;
+        worklist.insert(current->succ_begin(), current->succ_end());
+      }
+    }
+
+    // TODO: find a more appropriate way to print the results.
+    AsmState state(getOperation());
+    for (Block& block : getOperation())
+    {
+      const StableFacts& data = facts[&block];
+      block.printAsOperand(llvm::errs(), state);
+      llvm::errs() << "\n";
+      for (const auto& it : data.aliases)
+      {
+        llvm::errs() << "  ";
+        it.print(llvm::errs(), state);
+        llvm::errs() << "\n";
+      }
+    }
+  }
+
+  void CopyOp::add_facts(FactEvaluator& facts)
+  {
+    facts.add(Alias(output(), input()));
+  }
+
+  void ViewOp::add_facts(FactEvaluator& facts)
+  {
+    facts.add(Alias(output(), input()));
+  }
+
+  void FieldReadOp::add_facts(FactEvaluator& facts)
+  {
+    facts.add(In(output(), origin(), getFieldType()));
+  }
+
+  void FieldWriteOp::add_facts(FactEvaluator& facts)
+  {
+    facts.add(From(output(), origin(), {}));
+  }
+
+#include "dialect/RegionChecker.cpp.inc"
+}

--- a/src/mlir/dialect/RegionChecker.h
+++ b/src/mlir/dialect/RegionChecker.h
@@ -1,0 +1,18 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::verona
+{
+  class RegionCheckerPass : public PassWrapper<RegionCheckerPass, FunctionPass>
+  {
+    void runOnFunction() override;
+  };
+
+  struct FactEvaluator;
+
+#include "dialect/RegionChecker.h.inc"
+}

--- a/src/mlir/dialect/RegionChecker.h
+++ b/src/mlir/dialect/RegionChecker.h
@@ -7,9 +7,24 @@
 
 namespace mlir::verona
 {
-  class RegionCheckerPass : public PassWrapper<RegionCheckerPass, FunctionPass>
+  class PrintRegionAnalysisPass
+  : public PassWrapper<PrintRegionAnalysisPass, OperationPass<ModuleOp>>
   {
-    void runOnFunction() override;
+    void runOnOperation() override;
+  };
+
+  struct StableFacts;
+  struct RegionAnalysis
+  {
+    RegionAnalysis(FuncOp operation);
+    void print(llvm::raw_ostream& os);
+
+    RegionAnalysis(const RegionAnalysis& other) = delete;
+    RegionAnalysis& operator=(const RegionAnalysis& other) = delete;
+
+  private:
+    DenseMap<Block*, StableFacts> facts;
+    FuncOp operation;
   };
 
   struct FactEvaluator;

--- a/src/mlir/dialect/RegionChecker.td
+++ b/src/mlir/dialect/RegionChecker.td
@@ -1,0 +1,14 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+include "mlir/IR/OpBase.td"
+
+def RegionCheckInterface : OpInterface<"RegionCheckInterface"> {
+  let methods = [
+    InterfaceMethod<
+      "Add facts", "void", "add_facts", (ins "FactEvaluator&":$facts)
+    >,
+  ];
+}
+
+def RegionCheck : DeclareOpInterfaceMethods<RegionCheckInterface>;

--- a/src/mlir/dialect/TopologicalFacts.h
+++ b/src/mlir/dialect/TopologicalFacts.h
@@ -1,0 +1,178 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "Query.h"
+#include "dialect/VeronaTypes.h"
+
+/// Topological Facts are a static approximation on the runtime shape of the
+/// heap.
+///
+/// We use these facts to determine whether certain operations are safe. For
+/// example, in the statement `x.f = y` (where f is a mut field), we require
+/// that x and y are in the same region, or in other words, `In(y, x, nil)`.
+namespace mlir::verona
+{
+  /// Values `left` and `right` point the the same object.
+  struct Alias
+  {
+    Alias(Value left, Value right) : left(left), right(right) {}
+
+    Value left;
+    Value right;
+
+    auto data() const
+    {
+      return std::tie(left, right);
+    }
+
+    void print(llvm::raw_ostream& os, AsmState& state) const
+    {
+      os << "alias(";
+      Value(left).printAsOperand(os, state);
+      os << ", ";
+      Value(right).printAsOperand(os, state);
+      os << ")";
+    }
+  };
+
+  /// The region of `left` is the same as or a child of the region of `right`.
+  /// The precise nature of the relationship between `left` and `right` depends
+  /// on `types`:
+  ///
+  /// - If all elements in `types` are subtypes of mut, left and right are in
+  ///   the same region. This includes the case where `types` is empty.
+  ///
+  /// - If at least one element in `type` is a subtype of iso, `left` is in a
+  ///   strict sub-region of `right`'s region.
+  ///
+  /// - Otherwise the relationship is unknown, and we can only assume that
+  ///   `left`'s region is somewhere in the region tree dominated by `right`.
+  struct In
+  {
+    In(Value left, Value right, ArrayRef<Type> types)
+    : left(left), right(right), types(types.begin(), types.end())
+    {
+      assert(areVeronaTypes(types));
+    }
+
+    Value left;
+    Value right;
+    SmallVector<Type, 1> types;
+
+    auto data() const
+    {
+      return std::tie(left, right, types);
+    }
+
+    void print(llvm::raw_ostream& os, AsmState& state) const
+    {
+      os << "in(";
+      Value(left).printAsOperand(os, state);
+      os << ", ";
+      Value(right).printAsOperand(os, state);
+      os << ", [";
+      llvm::interleaveComma(types, os, [&](const auto& type) { os << type; });
+      os << "])";
+    }
+  };
+
+  /// The value `left` was extracted from either the same region as right's
+  /// region, or from a sub-region of it.
+  ///
+  /// - If the `left` value is owned, then its region is free and unrelated to
+  ///   `right`.
+  /// - If the `left` value is unowned, this fact has the same semantics as
+  ///   `In`.
+  //
+  /// We may not know statically whether `left` is owned or not; it may have a
+  /// generic type or be a disjunction. In those cases, we may assume one of the
+  /// two cases is true, but not which one.
+  struct From
+  {
+    From(Value left, Value right, ArrayRef<Type> types)
+    : left(left), right(right), types(types.begin(), types.end())
+    {
+      assert(areVeronaTypes(types));
+    }
+
+    Value left;
+    Value right;
+    SmallVector<Type, 0> types;
+
+    auto data() const
+    {
+      return std::tie(left, right, types);
+    }
+
+    void print(llvm::raw_ostream& os, AsmState& state) const
+    {
+      os << "in(";
+      Value(left).printAsOperand(os, state);
+      os << ", ";
+      Value(right).printAsOperand(os, state);
+      os << ", [";
+      llvm::interleaveComma(types, os, [&](const auto& type) { os << type; });
+      os << "])";
+    }
+  };
+
+  /// This fact is true in basic blocks that define the Value. Not really a
+  /// topological fact per-se, but useful to implement rules that range over all
+  /// variables (eg. reflexivity).
+  struct Defined
+  {
+    Defined(Value value) : value(value)
+    {
+      assert(isaVeronaType(value.getType()));
+    }
+
+    Value value;
+
+    auto data() const
+    {
+      return std::tie(value);
+    }
+
+    void print(llvm::raw_ostream& os, AsmState& state) const
+    {
+      os << "defined(";
+      Value(value).printAsOperand(os, state);
+      os << " : " << value.getType() << ")";
+    }
+  };
+
+}
+
+namespace llvm
+{
+  template<>
+  struct DenseMapInfo<mlir::verona::Alias>
+  {
+    static inline mlir::verona::Alias getEmptyKey()
+    {
+      return mlir::verona::Alias(
+        DenseMapInfo<mlir::Value>::getEmptyKey(),
+        DenseMapInfo<mlir::Value>::getEmptyKey());
+    }
+
+    static inline mlir::verona::Alias getTombstoneKey()
+    {
+      return mlir::verona::Alias(
+        DenseMapInfo<mlir::Value>::getTombstoneKey(),
+        DenseMapInfo<mlir::Value>::getTombstoneKey());
+    }
+
+    static unsigned getHashValue(const mlir::verona::Alias& value)
+    {
+      return hash_value(value.data());
+    }
+
+    static bool
+    isEqual(const mlir::verona::Alias& lhs, const mlir::verona::Alias& rhs)
+    {
+      return lhs.data() == rhs.data();
+    }
+  };
+}

--- a/src/mlir/dialect/TypecheckInterface.h
+++ b/src/mlir/dialect/TypecheckInterface.h
@@ -1,7 +1,8 @@
 // Copyright Microsoft and Project Verona Contributors.
-// // SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT
 
 #pragma once
+
 #include "mlir/IR/OpDefinition.h"
 
 namespace mlir::verona

--- a/src/mlir/dialect/VeronaOps.h
+++ b/src/mlir/dialect/VeronaOps.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "dialect/RegionChecker.h"
 #include "dialect/TypecheckInterface.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/Function.h"

--- a/src/mlir/dialect/VeronaOps.td
+++ b/src/mlir/dialect/VeronaOps.td
@@ -6,11 +6,12 @@
 
 include "VeronaDialect.td"
 include "TypecheckInterface.td"
+include "RegionChecker.td"
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
-def Verona_CopyOp : Verona_Op<"copy", [ Typecheckable ]> {
+def Verona_CopyOp : Verona_Op<"copy", [ Typecheckable, RegionCheck ]> {
     let summary = "Copy a reference";
     let description = [{
       Make a copy of the given reference.
@@ -23,7 +24,7 @@ def Verona_CopyOp : Verona_Op<"copy", [ Typecheckable ]> {
     let verifier = [{ return success(); }];
 }
 
-def Verona_ViewOp : Verona_Op<"view"> {
+def Verona_ViewOp : Verona_Op<"view", [ RegionCheck ]> {
     let summary = "Get an unowned reference to the specified object.";
     let description = [{
       Get an unowned reference to the specified object. This operation can be
@@ -40,7 +41,7 @@ def Verona_ViewOp : Verona_Op<"view"> {
     let verifier = [{ return success(); }];
 }
 
-def Verona_FieldReadOp : Verona_Op<"field_read", [ Typecheckable ]> {
+def Verona_FieldReadOp : Verona_Op<"field_read", [ Typecheckable, RegionCheck ]> {
     let summary = "Read a field from a reference";
     let description = [{
       Read the value of a field from a reference. The result value is always an
@@ -71,7 +72,7 @@ def Verona_FieldReadOp : Verona_Op<"field_read", [ Typecheckable ]> {
     }];
 }
 
-def Verona_FieldWriteOp : Verona_Op<"field_write", [ Typecheckable ]> {
+def Verona_FieldWriteOp : Verona_Op<"field_write", [ Typecheckable, RegionCheck ]> {
     let summary = "Write to a field through a reference";
     let description = [{
       Write a new value to a field. The field's old value is returned.

--- a/src/mlir/dialect/VeronaTypes.h
+++ b/src/mlir/dialect/VeronaTypes.h
@@ -188,6 +188,10 @@ namespace mlir::verona
   {
     return JoinType::get(ctx, {getIso(ctx), getMut(ctx)});
   }
+  inline Type getSendable(MLIRContext* ctx)
+  {
+    return JoinType::get(ctx, {getIso(ctx), getImm(ctx)});
+  }
   inline Type getAnyCapability(MLIRContext* ctx)
   {
     return JoinType::get(ctx, {getIso(ctx), getMut(ctx), getImm(ctx)});

--- a/src/mlir/driver.cc
+++ b/src/mlir/driver.cc
@@ -3,6 +3,7 @@
 
 #include "driver.h"
 
+#include "dialect/RegionChecker.h"
 #include "dialect/Typechecker.h"
 #include "generator.h"
 #include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVMPass.h"
@@ -35,6 +36,7 @@ namespace mlir::verona
 
     // TODO: make the set of passes configurable from the command-line
     passManager.addPass(std::make_unique<TypecheckerPass>());
+    passManager.addPass(std::make_unique<RegionCheckerPass>());
 
     if (optLevel > 0)
     {

--- a/src/mlir/driver.cc
+++ b/src/mlir/driver.cc
@@ -36,7 +36,7 @@ namespace mlir::verona
 
     // TODO: make the set of passes configurable from the command-line
     passManager.addPass(std::make_unique<TypecheckerPass>());
-    passManager.addPass(std::make_unique<RegionCheckerPass>());
+    passManager.addPass(std::make_unique<PrintRegionAnalysisPass>());
 
     if (optLevel > 0)
     {

--- a/testsuite/mlir/mlir-parse/facts.mlir
+++ b/testsuite/mlir/mlir-parse/facts.mlir
@@ -1,0 +1,43 @@
+module {
+  func @test_alias_reflexive(%x: !verona.mut) {
+    return
+  }
+
+  func @test_alias_copy(%x: !verona.mut) {
+    %y = verona.copy %x : !verona.mut -> !verona.mut
+    return
+  }
+
+  func @test_alias_view(%x: !verona.mut) {
+    %y = verona.view %x : !verona.mut -> !verona.mut
+    return
+  }
+
+  func @test_alias_transitive(%x: !verona.mut) {
+    %y = verona.view %x : !verona.mut -> !verona.mut
+    %z = verona.view %y : !verona.mut -> !verona.mut
+    return
+  }
+
+  func @test_alias_block_argument(%x: !verona.mut) {
+    br ^bb1(%x, %x: !verona.mut, !verona.mut)
+
+  ^bb1(%y: !verona.mut, %z: !verona.mut):
+    return
+  }
+
+  func @test_alias_intersect(%b : i1, %x: !verona.mut) {
+     cond_br %b, ^bb1, ^bb2
+ 
+   ^bb1:
+     %y0 = verona.copy %x : !verona.mut -> !verona.mut
+     br ^end(%y0 : !verona.mut)
+ 
+   ^bb2:
+     %y1 = verona.view %x : !verona.mut -> !verona.mut
+     br ^end(%y1 : !verona.mut)
+ 
+   ^end(%y: !verona.mut):
+     return
+  }
+}


### PR DESCRIPTION
Still pretty early days. At the moment it only computes the `alias` relation, and doesn't use the result at all.

It introduces a pretty generics datalog-like engine in `Query.h`.
The engine is used in `RegionChecker.cc` to implement the fact derivation rules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/verona/278)
<!-- Reviewable:end -->
