### PR TITLE
Refactor to store meta-data before Object*

### DIFF
--- a/devops/ci.yml
+++ b/devops/ci.yml
@@ -44,12 +44,12 @@ jobs:
   timeoutInMinutes: 120
   strategy:
     matrix:
-      # GCC Release:
-      #   CC: gcc
-      #   CXX: g++
-      #   CXXFLAGS:
-      #   BuildType: Release
-      #   Asan: Off
+      GCC Release:
+        CC: gcc
+        CXX: g++
+        CXXFLAGS:
+        BuildType: Release
+        Asan: Off
       Clang RelDbg+ASAN:
         CC: clang
         CXX: clang++

--- a/devops/ci.yml
+++ b/devops/ci.yml
@@ -14,11 +14,11 @@ jobs:
   steps:
   - script: |
       echo " - PR Build"
-      if  git diff origin/master --name-only | grep -v "^doc" | grep -v "^experiments" | grep -v "\.md$"; then
+      if  git diff --ignore-submodules=dirty origin/master --name-only | grep -v "^doc" | grep -v "^experiments" | grep -v "\.md$"; then
         echo Src changes;
         echo "##vso[task.setvariable variable=docOnly;isOutput=true]false" #set variable to testRuntime to On
         echo "Determine if runtime changed."
-        if git diff --quiet origin/master -- src/rt; then
+        if git diff --ignore-submodules=dirty --quiet origin/master -- src/rt; then
           echo " - Runtime unchanged!"
           echo "##vso[task.setvariable variable=testRuntime;isOutput=true]Off" #set variable to testRuntime to Off
         else
@@ -219,7 +219,7 @@ jobs:
   - script: |
       set -eo pipefail
       make clangformat
-      git diff --exit-code $(Build.SourceVersion)
+      git diff --ignore-submodules=dirty --exit-code $(Build.SourceVersion)
     workingDirectory: build
     displayName: 'Clang-Format'
 

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -22,18 +22,18 @@ jobs:
   timeoutInMinutes: 120
   strategy:
     matrix:
-      # GCC Debug:
-      #   CC: gcc
-      #   CXX: g++
-      #   CXXFLAGS:
-      #   BuildType: Debug
-      #   Asan: Off
-      # GCC Release:
-      #   CC: gcc
-      #   CXX: g++
-      #   CXXFLAGS:
-      #   Asan: Off
-      #   BuildType: Release
+      GCC Debug:
+        CC: gcc
+        CXX: g++
+        CXXFLAGS:
+        BuildType: Debug
+        Asan: Off
+      GCC Release:
+        CC: gcc
+        CXX: g++
+        CXXFLAGS:
+        Asan: Off
+        BuildType: Release
       Clang Debug:
         CC: clang
         CXX: clang++

--- a/src/interpreter/object.cc
+++ b/src/interpreter/object.cc
@@ -39,7 +39,7 @@ namespace verona::interpreter
   }
 
   VMObject::VMObject(VMObject* region, const VMDescriptor* desc)
-  : Object(desc), parent_(region)
+  : Object(), parent_(region)
   {
     if (descriptor()->field_count > 0)
       fields = std::make_unique<FieldValue[]>(descriptor()->field_count);

--- a/src/interpreter/object.cc
+++ b/src/interpreter/object.cc
@@ -20,7 +20,7 @@ namespace verona::interpreter
     field_count(field_count),
     finaliser_ip(finaliser_ip)
   {
-    rt::Descriptor::size = sizeof(VMObject);
+    rt::Descriptor::size = rt::vsizeof<VMObject>;
     rt::Descriptor::trace = VMObject::trace_fn;
 
     // Try to be on the trivial ring as much as possible. This requires the

--- a/src/rt/cpp/vobject.h
+++ b/src/rt/cpp/vobject.h
@@ -57,12 +57,22 @@ namespace verona::rt
     {
       if constexpr (has_notified<T>::value)
         ((T*)o)->notified(o);
+      else
+      {
+        UNUSED(o);
+      }
     }
 
     static void gc_final(Object* o, Object* region, ObjectStack& sub_regions)
     {
       if constexpr (has_finaliser<T>::value)
         ((T*)o)->finaliser(region, sub_regions);
+      else
+      {
+        UNUSED(o);
+        UNUSED(region);
+        UNUSED(sub_regions);
+      }
     }
 
     static void gc_destructor(Object* o)

--- a/src/rt/cpp/vobject.h
+++ b/src/rt/cpp/vobject.h
@@ -44,9 +44,7 @@ namespace verona::rt
    * Common base class for V and VCown to build descriptors
    * from C++ objects using compile time reflection.
    */
-  template<
-    class T,
-    class Base = Object>
+  template<class T, class Base = Object>
   class VBase : public Base
   {
   private:
@@ -79,16 +77,16 @@ namespace verona::rt
 
     static Descriptor* desc()
     {
-      static Descriptor desc = {
-        vsizeof<T>,
-        gc_trace,
-        has_finaliser<T>::value ? gc_final : nullptr,
-        has_notified<T>::value ? gc_notified : nullptr,
-        has_destructor<T>::value ? gc_destructor : nullptr};
+      static Descriptor desc = {vsizeof<T>,
+                                gc_trace,
+                                has_finaliser<T>::value ? gc_final : nullptr,
+                                has_notified<T>::value ? gc_notified : nullptr,
+                                has_destructor<T>::value ? gc_destructor :
+                                                           nullptr};
 
       return &desc;
     }
-    
+
     void operator delete(void*)
     {
       // Should not be called directly, present to allow calling if the
@@ -129,14 +127,12 @@ namespace verona::rt
     void operator delete[](void* p, size_t sz) = delete;
   };
 
-  /** 
+  /**
    * Converts a C++ class into a Verona Object
    *
    * Will fill the Verona descriptor with relevant fields.
    */
-  template<
-    class T,
-    RegionType region_type = RegionType::Trace>
+  template<class T, RegionType region_type = RegionType::Trace>
   class V : public VBase<T, Object>
   {
     using RegionClass = typename RegionType_to_class<region_type>::T;
@@ -152,7 +148,8 @@ namespace verona::rt
 
     void* operator new(size_t, Alloc* alloc)
     {
-      return RegionClass::template create<vsizeof<T>>(alloc, VBase<T, Object>::desc());
+      return RegionClass::template create<vsizeof<T>>(
+        alloc, VBase<T, Object>::desc());
     }
 
     void* operator new(size_t, Object* region)
@@ -163,11 +160,12 @@ namespace verona::rt
 
     void* operator new(size_t, Alloc* alloc, Object* region)
     {
-      return RegionClass::template alloc<vsizeof<T>>(alloc, region, VBase<T, Object>::desc());
+      return RegionClass::template alloc<vsizeof<T>>(
+        alloc, region, VBase<T, Object>::desc());
     }
   };
 
-  /** 
+  /**
    * Converts a C++ class into a Verona Cown
    *
    * Will fill the Verona descriptor with relevant fields.
@@ -186,7 +184,8 @@ namespace verona::rt
 
     void* operator new(size_t, Alloc* alloc)
     {
-      return Object::register_object(alloc->alloc<vsizeof<T>>(), VBase<T, Cown>::desc());
+      return Object::register_object(
+        alloc->alloc<vsizeof<T>>(), VBase<T, Cown>::desc());
     }
   };
 } // namespace verona::rt

--- a/src/rt/ds/hashmap.h
+++ b/src/rt/ds/hashmap.h
@@ -69,7 +69,7 @@ namespace verona::rt
       if constexpr (is_set)
         return (uintptr_t&)entry;
       else
-        return (uintptr_t&)entry.first;
+        return  (uintptr_t&)std::get<0>(entry);
     }
 
     /**

--- a/src/rt/ds/hashmap.h
+++ b/src/rt/ds/hashmap.h
@@ -69,7 +69,7 @@ namespace verona::rt
       if constexpr (is_set)
         return (uintptr_t&)entry;
       else
-        return  (uintptr_t&)std::get<0>(entry);
+        return (uintptr_t&)std::get<0>(entry);
     }
 
     /**

--- a/src/rt/object/object.h
+++ b/src/rt/object/object.h
@@ -260,8 +260,8 @@ namespace verona::rt
         {
           puts(
             "Internal error! Runtime allocation in progress on this thread.");
-          // This error can occur because a type was allocated by the runtime that 
-          // does not inherit from Object.
+          // This error can occur because a type was allocated by the runtime
+          // that does not inherit from Object.
           abort();
         }
         else

--- a/src/rt/object/object.h
+++ b/src/rt/object/object.h
@@ -150,6 +150,10 @@ namespace verona::rt
     YesTransfer
   };
 
+  /// No fields as part of the C++ representation all meta-data stored before
+  /// object in Verona runtime header. Object should not be allocated directly,
+  /// but instead should be allocated as part of the runtime.
+  /// In systematic testings contains an ID.
   class Object
   {
   public:
@@ -201,19 +205,24 @@ namespace verona::rt
     // ensure that pointers to objects are aligned.
     static constexpr size_t ALIGNMENT = (1 << MIN_ALLOC_BITS);
 
+    /// This class represents the Verona object header.
+    /// It is store directly before a Verona object.
+    struct Header
+    {
+      union
+      {
+        Object* next;
+        std::atomic<size_t> rc;
+        size_t bits;
+      };
+
+      std::atomic<const Descriptor*> descriptor;
+    };
+
   private:
     static constexpr uintptr_t MASK = ALIGNMENT - 1;
     static constexpr uint8_t SHIFT = (uint8_t)bits::next_pow2_bits_const(MASK);
     static constexpr size_t ONE_RC = 1 << SHIFT;
-
-    union
-    {
-      Object* next;
-      std::atomic<size_t> rc;
-      size_t bits;
-    };
-
-    std::atomic<const Descriptor*> descriptor;
 
 #ifdef USE_SYSTEMATIC_TESTING
     // Used to give objects unique identifiers for systematic testing.
@@ -221,15 +230,89 @@ namespace verona::rt
     uintptr_t sys_id;
 #endif
 
+    Header& get_header() const
+    {
+      return *((Header*)real_start());
+    }
+
   public:
+    /// Returns the start of the allocation containing this object
+    /// I.e. the start of the objects verona header.
+    byte* real_start() const
+    {
+      return ((byte*)this) - sizeof(Header);
+    }
+
     Object(const Object&) = delete;
     Object& operator=(const Object&) = delete;
 
-    Object(const Descriptor* desc) : descriptor(desc) {}
+    /// Used to check type has been allocated by the runtime
+    /// Any runtime allocation function sets this, before calling
+    /// the constructor of a class.
+    static void runtime_alloc(bool value)
+    {
+#ifndef NDEBUG
+      thread_local bool previous = false;
+
+      if (previous == value)
+      {
+        if (value)
+        {
+          puts(
+            "Internal error! Runtime allocation in progress on this thread.");
+          // This error can occur because
+          //  * a type was allocated by the runtime that does not inherit from
+          //  Object.
+          //  * ...
+          abort();
+        }
+        else
+        {
+          puts("Internal error! Not part of Verona allocation.");
+          // This error is because produce_alloc was not called prior to
+          // initialising this object.  This is probably due to not being
+          // allocated with the Verona region allocator
+          abort();
+        }
+      }
+
+      previous = value;
+#endif
+    }
+
+    // Should be called by the region allocator prior to initialising an
+    // object as part of the runtime.  This is used to ensure that all
+    // subclasses of rt::Object are actually part of the runtime.
+    static Object* register_object(void* base, const Descriptor* desc)
+    {
+      Object* obj = object_start(base);
+      obj->get_header().descriptor = desc;
+#ifdef USE_SYSTEMATIC_TESTING
+      obj->sys_id = ++id_source;
+#endif
+      runtime_alloc(true);
+      return obj;
+    }
+
+    // Given a pointer to the start of the header return pointer to the
+    // start of the object.
+    static Object* object_start(void* p)
+    {
+      return (Object*)((char*)p + sizeof(Object::Header));
+    }
+
+    Object()
+    {
+      // Confirm this is  runtime alloc, and unset flag
+      runtime_alloc(false);
+      // This should have already been set up.
+      assert(get_descriptor() != nullptr);
+    }
 
     inline const Descriptor* get_descriptor() const
     {
-      return (const Descriptor*)((uintptr_t)descriptor.load() & ~MARK_MASK);
+      return (
+        const Descriptor*)((uintptr_t)get_header().descriptor.load() & ~MARK_MASK);
     }
 
 #ifdef USE_SYSTEMATIC_TESTING
@@ -286,12 +369,13 @@ namespace verona::rt
     {
       assert(debug_is_immutable());
       Object* o = immutable();
-      return o->bits == ((test_rc << SHIFT) | (uint8_t)RegionMD::RC);
+      return o->get_header().bits ==
+        ((test_rc << SHIFT) | (uint8_t)RegionMD::RC);
     }
 
     intptr_t debug_rc()
     {
-      return (intptr_t)bits >> SHIFT;
+      return (intptr_t)get_header().bits >> SHIFT;
     }
 
     Object* debug_immutable_root()
@@ -302,7 +386,7 @@ namespace verona::rt
     Object* debug_next()
     {
       assert(debug_is_iso() || debug_is_mutable());
-      return (Object*)(bits & ~MASK);
+      return (Object*)(get_header().bits & ~MASK);
     }
 
     static bool debug_is_aligned(const void* o)
@@ -330,17 +414,10 @@ namespace verona::rt
     template<typename T>
     friend class Noticeboard;
 
-    inline void set_descriptor(const Descriptor* desc)
-    {
-      descriptor = desc;
-#ifdef USE_SYSTEMATIC_TESTING
-      sys_id = ++id_source;
-#endif
-    }
-
+  private:
     inline RegionMD get_class()
     {
-      return (RegionMD)(bits & MASK);
+      return (RegionMD)(get_header().bits & MASK);
     }
 
     inline size_t size()
@@ -355,18 +432,18 @@ namespace verona::rt
 
     inline void init_iso()
     {
-      bits = (size_t)this | (uint8_t)RegionMD::ISO;
+      get_header().bits = (size_t)this | (uint8_t)RegionMD::ISO;
     }
 
     inline void init_next(Object* o)
     {
-      next = o;
+      get_header().next = o;
     }
 
     inline Object* get_next()
     {
       assert(get_class() == RegionMD::UNMARKED);
-      return next;
+      return get_header().next;
     }
 
     inline Object* get_next_any_mark()
@@ -376,57 +453,57 @@ namespace verona::rt
         (get_class() == RegionMD::UNMARKED) ||
         (get_class() == RegionMD::PENDING) || (get_class() == RegionMD::ISO));
 
-      return (Object*)(bits & ~MASK);
+      return (Object*)(get_header().bits & ~MASK);
     }
 
     inline void set_next(Object* o)
     {
       assert(get_class() == RegionMD::UNMARKED);
-      next = o;
+      get_header().next = o;
     }
 
     inline RegionBase* get_region()
     {
       assert(get_class() == RegionMD::ISO);
-      return (RegionBase*)(bits & ~MASK);
+      return (RegionBase*)(get_header().bits & ~MASK);
     }
 
     inline void set_region(RegionBase* region)
     {
       assert(get_class() == RegionMD::ISO);
-      bits = (size_t)region | (uint8_t)RegionMD::ISO;
+      get_header().bits = (size_t)region | (uint8_t)RegionMD::ISO;
     }
 
     inline Object* get_scc()
     {
       assert(get_class() == RegionMD::SCC_PTR);
-      return (Object*)(bits & ~MASK);
+      return (Object*)(get_header().bits & ~MASK);
     }
 
     inline void set_scc(Object* o)
     {
-      bits = (size_t)o | (uint8_t)RegionMD::SCC_PTR;
+      get_header().bits = (size_t)o | (uint8_t)RegionMD::SCC_PTR;
     }
 
     inline void make_scc()
     {
-      bits = (size_t)RegionMD::RC + ONE_RC;
+      get_header().bits = (size_t)RegionMD::RC + ONE_RC;
     }
 
     inline void make_nonatomic_scc()
     {
-      bits = (size_t)RegionMD::NONATOMIC_RC + ONE_RC;
+      get_header().bits = (size_t)RegionMD::NONATOMIC_RC + ONE_RC;
     }
 
     inline void make_atomic()
     {
       assert(get_class() == RegionMD::NONATOMIC_RC);
-      bits = (bits & ~MASK) | (uint8_t)RegionMD::RC;
+      get_header().bits = (get_header().bits & ~MASK) | (uint8_t)RegionMD::RC;
     }
 
     inline void make_cown()
     {
-      bits = (size_t)RegionMD::COWN + ONE_RC;
+      get_header().bits = (size_t)RegionMD::COWN + ONE_RC;
     }
 
     inline bool is_pending()
@@ -438,7 +515,7 @@ namespace verona::rt
     {
       // If this is balanced it should never get above 64.
       assert(rank < 128);
-      bits = (rank << SHIFT) | (size_t)RegionMD::PENDING;
+      get_header().bits = (rank << SHIFT) | (size_t)RegionMD::PENDING;
     }
 
     inline void set_pending()
@@ -449,7 +526,7 @@ namespace verona::rt
     inline size_t pending_rank()
     {
       assert(is_pending());
-      return bits >> SHIFT;
+      return get_header().bits >> SHIFT;
     }
 
     inline Object* root_and_class(RegionMD& c)
@@ -498,31 +575,31 @@ namespace verona::rt
     inline void mark()
     {
       assert(get_class() == RegionMD::UNMARKED);
-      bits |= (uint8_t)RegionMD::MARKED;
+      get_header().bits |= (uint8_t)RegionMD::MARKED;
     }
 
     inline void unmark()
     {
       assert(get_class() == RegionMD::MARKED);
-      bits &= ~(size_t)RegionMD::MARKED;
+      get_header().bits &= ~(size_t)RegionMD::MARKED;
     }
 
     inline void mark_pending()
     {
       assert(get_class() == RegionMD::UNMARKED);
-      bits |= (uint8_t)RegionMD::PENDING;
+      get_header().bits |= (uint8_t)RegionMD::PENDING;
     }
 
     inline void unmark_pending()
     {
       assert(get_class() == RegionMD::PENDING);
-      bits &= ~(size_t)RegionMD::PENDING;
+      get_header().bits &= ~(size_t)RegionMD::PENDING;
     }
 
   public:
     inline EpochMark get_epoch_mark()
     {
-      return (EpochMark)((uintptr_t)descriptor.load() & MARK_MASK);
+      return (EpochMark)((uintptr_t)get_header().descriptor.load() & MARK_MASK);
     }
 
   private:
@@ -544,7 +621,7 @@ namespace verona::rt
       // We only require relaxed consistency here as we can perfectly see old
       // values as we know that we will only need up-to-date values once we have
       // completed the consensus protocol to enter the sweep phase of the LD.
-      descriptor.store(
+      get_header().descriptor.store(
         (const Descriptor*)((uintptr_t)get_descriptor() | (size_t)e),
         std::memory_order_relaxed);
     }
@@ -566,24 +643,25 @@ namespace verona::rt
     {
       assert(!debug_is_immutable());
 
-      return ((uintptr_t)descriptor.load() & (uintptr_t)1) == (uintptr_t)1;
+      return ((uintptr_t)get_header().descriptor.load() & (uintptr_t)1) ==
+        (uintptr_t)1;
     }
 
     inline void set_has_ext_ref()
     {
       assert(!debug_is_immutable());
-      assert(((uintptr_t)descriptor.load() & MARK_MASK) == 0);
+      assert(((uintptr_t)get_header().descriptor.load() & MARK_MASK) == 0);
 
-      descriptor.store(
-        (const Descriptor*)((uintptr_t)descriptor.load() | (uintptr_t)1),
+      get_header().descriptor.store(
+        (const Descriptor*)((uintptr_t)get_header().descriptor.load() | (uintptr_t)1),
         std::memory_order_relaxed);
     }
 
     inline void clear_has_ext_ref()
     {
       assert(!debug_is_immutable());
-      descriptor.store(
-        (const Descriptor*)((uintptr_t)descriptor.load() & ~(uintptr_t)1),
+      get_header().descriptor.store(
+        (const Descriptor*)((uintptr_t)get_header().descriptor.load() & ~(uintptr_t)1),
         std::memory_order_relaxed);
     }
 
@@ -616,7 +694,7 @@ namespace verona::rt
     inline void incref_nonatomic()
     {
       assert(get_class() == RegionMD::NONATOMIC_RC);
-      bits += ONE_RC;
+      get_header().bits += ONE_RC;
     }
 
     // Returns true if you are incrementing from zero.
@@ -624,7 +702,7 @@ namespace verona::rt
     {
       assert((get_class() == RegionMD::RC) || (get_class() == RegionMD::COWN));
 
-      return rc.fetch_add(ONE_RC) == get_class();
+      return get_header().rc.fetch_add(ONE_RC) == get_class();
     }
 
     inline bool decref()
@@ -636,12 +714,12 @@ namespace verona::rt
 
       size_t done_rc = (size_t)get_class() + ONE_RC;
 
-      size_t approx_rc = bits;
+      size_t approx_rc = get_header().bits;
       assert(approx_rc >= ONE_RC);
 
       if (approx_rc != done_rc)
       {
-        approx_rc = rc.fetch_sub(ONE_RC);
+        approx_rc = get_header().rc.fetch_sub(ONE_RC);
 
         if (approx_rc != done_rc)
           return false;
@@ -672,11 +750,11 @@ namespace verona::rt
       // The top bit of the strong count is set to indicate that the strong
       // count has reached zero, and future weak count increase should fail.
       assert(debug_rc() != 0);
-      assert(rc < FINISHED_RC);
+      assert(get_header().rc < FINISHED_RC);
       assert(get_class() == RegionMD::COWN);
       static constexpr size_t DONE_RC = (size_t)RegionMD::COWN + ONE_RC;
 
-      size_t prev_rc = rc.fetch_sub(ONE_RC);
+      size_t prev_rc = get_header().rc.fetch_sub(ONE_RC);
 
       if (prev_rc != DONE_RC)
         return false;
@@ -684,7 +762,7 @@ namespace verona::rt
       yield();
 
       size_t zero_rc = (size_t)RegionMD::COWN;
-      return rc.compare_exchange_strong(zero_rc, FINISHED_RC);
+      return get_header().rc.compare_exchange_strong(zero_rc, FINISHED_RC);
     }
 
     /**
@@ -694,7 +772,7 @@ namespace verona::rt
     {
       // Check if top bit is set, if not then we have validily created a new
       // strong reference
-      if (rc.fetch_add(ONE_RC) < FINISHED_RC)
+      if (get_header().rc.fetch_add(ONE_RC) < FINISHED_RC)
         return true;
 
       yield();
@@ -702,7 +780,7 @@ namespace verona::rt
       // We failed to create a strong reference reset rc.
       // Note store is fine, as only other operations on this will
       // be failed weak reference promotions.
-      rc.store(FINISHED_RC, std::memory_order_relaxed);
+      get_header().rc.store(FINISHED_RC, std::memory_order_relaxed);
       return false;
     }
 
@@ -736,7 +814,7 @@ namespace verona::rt
     {
       assert(get_class() == RegionMD::COWN);
 
-      return rc.load(std::memory_order_relaxed) == FINISHED_RC;
+      return get_header().rc.load(std::memory_order_relaxed) == FINISHED_RC;
     }
 
   private:
@@ -765,7 +843,7 @@ namespace verona::rt
 
     inline void dealloc(Alloc* alloc)
     {
-      alloc->dealloc(this, size());
+      alloc->dealloc(&this->get_header(), size());
     }
 
   protected:
@@ -788,4 +866,11 @@ namespace verona::rt
       }
     }
   };
+
+  /// Returns the size required for a Verona object to embed the
+  /// C++ object T.
+  template<class T>
+  static constexpr size_t vsizeof = snmalloc::bits::align_up(
+    sizeof(T) + sizeof(Object::Header), Object::ALIGNMENT);
+
 } // namespace verona::rt

--- a/src/rt/object/object.h
+++ b/src/rt/object/object.h
@@ -206,7 +206,7 @@ namespace verona::rt
     static constexpr size_t ALIGNMENT = (1 << MIN_ALLOC_BITS);
 
     /// This class represents the Verona object header.
-    /// It is store directly before a Verona object.
+    /// It is stored directly before a Verona object.
     struct Header
     {
       union
@@ -285,9 +285,6 @@ namespace verona::rt
     {
       Object* obj = object_start(base);
       obj->get_header().descriptor = desc;
-#ifdef USE_SYSTEMATIC_TESTING
-      obj->sys_id = ++id_source;
-#endif
       runtime_alloc(true);
       return obj;
     }
@@ -303,6 +300,11 @@ namespace verona::rt
     {
       // Confirm this is  runtime alloc, and unset flag
       runtime_alloc(false);
+
+#ifdef USE_SYSTEMATIC_TESTING
+      sys_id = ++id_source;
+#endif
+
       // This should have already been set up.
       assert(get_descriptor() != nullptr);
     }

--- a/src/rt/object/object.h
+++ b/src/rt/object/object.h
@@ -260,10 +260,8 @@ namespace verona::rt
         {
           puts(
             "Internal error! Runtime allocation in progress on this thread.");
-          // This error can occur because
-          //  * a type was allocated by the runtime that does not inherit from
-          //  Object.
-          //  * ...
+          // This error can occur because a type was allocated by the runtime that 
+          // does not inherit from Object.
           abort();
         }
         else
@@ -312,7 +310,7 @@ namespace verona::rt
     inline const Descriptor* get_descriptor() const
     {
       return (
-        const Descriptor*)((uintptr_t)get_header().descriptor.load() & ~MARK_MASK);
+        const Descriptor*)((uintptr_t)get_header().descriptor.load(std::memory_order_relaxed) & ~MARK_MASK);
     }
 
 #ifdef USE_SYSTEMATIC_TESTING

--- a/src/rt/object/object.h
+++ b/src/rt/object/object.h
@@ -150,10 +150,10 @@ namespace verona::rt
     YesTransfer
   };
 
-  /// No fields as part of the C++ representation all meta-data stored before
-  /// object in Verona runtime header. Object should not be allocated directly,
+  /// The C++ representation of objects has no fields. All meta-data for the
+  /// object is in the `Header` struct. Object should not be allocated directly,
   /// but instead should be allocated as part of the runtime.
-  /// In systematic testings contains an ID.
+  /// Contains a unique ID in systematic testing.
   class Object
   {
   public:
@@ -246,7 +246,7 @@ namespace verona::rt
     Object(const Object&) = delete;
     Object& operator=(const Object&) = delete;
 
-    /// Used to check type has been allocated by the runtime
+    /// Used to check type has been allocated by the runtime.
     /// Any runtime allocation function sets this, before calling
     /// the constructor of a class.
     static void runtime_alloc(bool value)
@@ -280,9 +280,9 @@ namespace verona::rt
 #endif
     }
 
-    // Should be called by the region allocator prior to initialising an
-    // object as part of the runtime.  This is used to ensure that all
-    // subclasses of rt::Object are actually part of the runtime.
+    /// Should be called by the region allocator prior to initialising an
+    /// object as part of the runtime.  This is used to ensure that all
+    /// subclasses of rt::Object are actually part of the runtime.
     static Object* register_object(void* base, const Descriptor* desc)
     {
       Object* obj = object_start(base);
@@ -294,8 +294,8 @@ namespace verona::rt
       return obj;
     }
 
-    // Given a pointer to the start of the header return pointer to the
-    // start of the object.
+    /// Given a pointer to the start of the header, return a pointer to the
+    /// start of the object.
     static Object* object_start(void* p)
     {
       return (Object*)((char*)p + sizeof(Object::Header));

--- a/src/rt/region/region_arena.h
+++ b/src/rt/region/region_arena.h
@@ -60,11 +60,14 @@ namespace verona::rt
      * Trivial objects (ie. those with no destructor, no finaliser and no iso
      * fields) are allocated from the beginning of the arena, starting at
      * `objects_begin`. `objects_end` points to the first byte after the last
-     * object, i.e. the place where the next object will be allocated.
+     * object, i.e. the place where the next object will be allocated. `objects`
+     * begin points to the start of the allocation, rather then the Object*
+     * that stores the header before it.
      *
      * Non-trivial objects are allocated from the end of the arena.
      * `non_trivial_end` points past the end of the arena and
      * `non_trivial_begin` points to the first non-trivial object.
+     *`non_trivial_begin` points to the start of the header of the first object.
      *
      * Note that certain operations require the bottom `MIN_ALLOC_BITS` to be
      * free, so we need to ensure all objects allocated within an arena are
@@ -176,20 +179,20 @@ namespace verona::rt
         assert(debug_invariant());
         assert(free_space() >= sz);
 
-        Object* o = nullptr;
+        void* p = nullptr;
 
         if (Object::is_trivial(desc))
         {
-          o = (Object*)objects_end;
+          p = objects_end;
           objects_end += sz;
         }
         else
         {
           non_trivial_begin -= sz;
-          o = (Object*)non_trivial_begin;
+          p = non_trivial_begin;
         }
 
-        o->set_descriptor(desc);
+        auto o = Object::register_object(p, desc);
         o->init_next(nullptr);
 
         assert(debug_invariant());
@@ -233,19 +236,18 @@ namespace verona::rt
     Object* last_large;
 
     RegionArena()
-    : RegionBase(desc()),
+    : RegionBase(),
       first_arena(nullptr),
       last_arena(nullptr),
       last_large(nullptr)
     {
-      set_descriptor(desc());
       init_next(this);
     }
 
     static const Descriptor* desc()
     {
       static constexpr Descriptor desc = {
-        sizeof(RegionArena), nullptr, nullptr, nullptr};
+        vsizeof<RegionArena>, nullptr, nullptr, nullptr};
 
       return &desc;
     }
@@ -275,14 +277,14 @@ namespace verona::rt
     template<size_t size = 0>
     static Object* create(Alloc* alloc, const Descriptor* desc)
     {
-      void* p = alloc->alloc<sizeof(RegionArena)>();
+      void* p = Object::register_object(
+        alloc->alloc<vsizeof<RegionArena>>(), RegionArena::desc());
       RegionArena* reg = new (p) RegionArena();
 
       // o might be allocated in the arena or the large object ring.
       Object* o = reg->alloc_internal<size>(alloc, desc);
       assert(Object::debug_is_aligned(o));
 
-      o->set_descriptor(desc);
       o->init_iso();
       o->set_region(reg);
       assert(
@@ -417,16 +419,19 @@ namespace verona::rt
     template<size_t size = 0>
     Object* alloc_internal(Alloc* alloc, const Descriptor* desc)
     {
-      size_t sz = snmalloc::bits::align_up(desc->size, Object::ALIGNMENT);
+      assert((size == 0) || (desc->size == size));
+
+      auto sz = size == 0 ? desc->size : size;
       if (sz > Arena::SIZE)
       {
         // Allocate object.
-        Object* o = nullptr;
+        void* p = nullptr;
         if constexpr (size == 0)
-          o = (Object*)alloc->alloc(desc->size);
+          p = alloc->alloc(desc->size);
         else
-          o = (Object*)alloc->alloc<size>();
-        o->set_descriptor(desc);
+          p = alloc->alloc<size>();
+
+        auto o = Object::register_object(p, desc);
 
         // Add to large object ring
         append(o);
@@ -643,6 +648,8 @@ namespace verona::rt
     private:
       RegionArena* reg;
       Arena* arena;
+      /// ptr points to the object after the header, as this is the pointer
+      /// used most commonly in the runtime.
       Object* ptr;
 
       /**
@@ -653,14 +660,16 @@ namespace verona::rt
       {
         assert(arena->debug_invariant());
         size_t sz = snmalloc::bits::align_up(ptr->size(), Object::ALIGNMENT);
-        std::byte* q = (std::byte*)ptr + sz;
+        // Get actual end of the object, that is,
+        // q points to the start of the header of the next object.
+        std::byte* q = ptr->real_start() + sz;
         if constexpr (type == Trivial)
         {
           assert(q > arena->objects_begin && q <= arena->objects_end);
 
           // We have not yet reached the end, so q is valid.
           if (q != arena->objects_end)
-            return (Object*)q;
+            return Object::object_start(q);
         }
         else if constexpr (type == NonTrivial)
         {
@@ -668,7 +677,7 @@ namespace verona::rt
 
           // We have not yet reached the end, so q is valid.
           if (q != arena->non_trivial_end)
-            return (Object*)q;
+            return Object::object_start(q);
         }
         else if constexpr (type == AllObjects)
         {
@@ -678,14 +687,14 @@ namespace verona::rt
 
           // We have not yet reached either end, so q is valid.
           if (q != arena->objects_end && q != arena->non_trivial_end)
-            return (Object*)q;
+            return Object::object_start(q);
 
           // We reached the end of trivial objects and there are non-trivial
           // objects to iterate over.
           if (
             q == arena->objects_end &&
             arena->non_trivial_begin != arena->non_trivial_end)
-            return (Object*)arena->non_trivial_begin;
+            return Object::object_start(arena->non_trivial_begin);
         }
         return nullptr;
       }
@@ -730,12 +739,14 @@ namespace verona::rt
           if constexpr (type == Trivial || type == AllObjects)
           {
             if (arena->objects_begin != arena->objects_end)
-              return (Object*)arena->objects_begin;
+              // objects_begin points to header of first object.
+              // we return the actually Object*.
+              return Object::object_start(arena->objects_begin);
           }
           if constexpr (type == NonTrivial || type == AllObjects)
           {
             if (arena->non_trivial_begin != arena->non_trivial_end)
-              return (Object*)arena->non_trivial_begin;
+              return Object::object_start(arena->non_trivial_begin);
           }
           // Every arena contains at least one object.
           if constexpr (type == AllObjects)

--- a/src/rt/region/region_arena.h
+++ b/src/rt/region/region_arena.h
@@ -67,7 +67,7 @@ namespace verona::rt
      * Non-trivial objects are allocated from the end of the arena.
      * `non_trivial_end` points past the end of the arena and
      * `non_trivial_begin` points to the first non-trivial object.
-     *`non_trivial_begin` points to the start of the header of the first object.
+     * `non_trivial_begin` points to the start of the header of the first object.
      *
      * Note that certain operations require the bottom `MIN_ALLOC_BITS` to be
      * free, so we need to ensure all objects allocated within an arena are

--- a/src/rt/region/region_arena.h
+++ b/src/rt/region/region_arena.h
@@ -67,7 +67,8 @@ namespace verona::rt
      * Non-trivial objects are allocated from the end of the arena.
      * `non_trivial_end` points past the end of the arena and
      * `non_trivial_begin` points to the first non-trivial object.
-     * `non_trivial_begin` points to the start of the header of the first object.
+     * `non_trivial_begin` points to the start of the header of the first
+     *object.
      *
      * Note that certain operations require the bottom `MIN_ALLOC_BITS` to be
      * free, so we need to ensure all objects allocated within an arena are

--- a/src/rt/region/region_base.h
+++ b/src/rt/region/region_base.h
@@ -21,8 +21,6 @@ namespace verona::rt
 
   enum class RegionType
   {
-    Cown = 0, // only used by vobject for cowns
-
     Trace,
     Arena,
   };

--- a/src/rt/region/region_base.h
+++ b/src/rt/region/region_base.h
@@ -43,7 +43,7 @@ namespace verona::rt
       AllObjects,
     };
 
-    RegionBase(const Descriptor* desc) : Object(desc) {}
+    RegionBase() : Object() {}
 
   private:
     inline void dealloc(Alloc* alloc)

--- a/src/rt/test/systematic.h
+++ b/src/rt/test/systematic.h
@@ -478,8 +478,9 @@ namespace Systematic
 
     // We're ignoring the result of write, as there's not much we can do if it
     // fails. We're about to crash anyway.
-    (void)write(1, str, strlen(str));
-    (void)write(1, "\n", 1);
+    auto s1 = write(1, str, strlen(str));
+    auto s2 = write(1, "\n", 1);
+    UNUSED(s1 + s2);
 
     constexpr size_t max_stack_frames = 64;
     void* frames[max_stack_frames];


### PR DESCRIPTION
GCC was applying dead-store-eliination to the region-meta data
as it was part of Object, and assigned before the C++ constructor.
This changes the representation of Object, to not contain the meta
data, but access the meta-data directly before the Object.

There are some defensive code paths to try to ensure that each Object*
actually has the meta-data before it.