### PR TITLE
Lowers classes as ops/types

### DIFF
--- a/src/mlir/ast-utils.h
+++ b/src/mlir/ast-utils.h
@@ -394,19 +394,6 @@ namespace mlir::verona
       }
     }
 
-    /// Get the hierarchy of types from class fields without the field info
-    /// T must be a list<ast> type with push_back.
-    template<class T>
-    static void getClassTypeElements(T& nodes, ::ast::WeakAst ast)
-    {
-      auto body = getClassBody(ast).lock();
-      for (auto field : body->nodes)
-      {
-        auto oftype = findNode(field, NodeKind::OfType);
-        nodes.push_back(oftype);
-      }
-    }
-
     // ================================================= Function Helpers
     /// Get the string name of a function node
     static llvm::StringRef getFunctionName(::ast::WeakAst ast)

--- a/src/mlir/ast-utils.h
+++ b/src/mlir/ast-utils.h
@@ -392,6 +392,18 @@ namespace mlir::verona
       }
     }
 
+    /// Get the hierarchy of types from class fields without the field info
+    template<class T>
+    static void getClassTypeElements(::ast::WeakAst ast, T& nodes)
+    {
+      auto body = getClassBody(ast).lock();
+      for (auto field : body->nodes)
+      {
+        auto oftype = findNode(field, NodeKind::OfType);
+        nodes.push_back(oftype);
+      }
+    }
+
     // ================================================= Function Helpers
     /// Get the string name of a function node
     static llvm::StringRef getFunctionName(::ast::WeakAst ast)

--- a/src/mlir/ast-utils.h
+++ b/src/mlir/ast-utils.h
@@ -303,7 +303,8 @@ namespace mlir::verona
       return ptr->nodes[0];
     }
 
-    /// Return a list of sub-nodes
+    /// Get a list of sub-nodes.
+    /// T must be a list<ast> type with push_back.
     template<class T>
     static void getSubNodes(T& nodes, ::ast::WeakAst ast)
     {
@@ -361,7 +362,8 @@ namespace mlir::verona
     }
 
     /// Get the list of types grouped by the same operator (| or &) or
-    /// a single type, if no grouping. T must be a list type with push_back.
+    /// a single type, if no grouping.
+    /// T must be a list<ast> type with push_back.
     template<class T>
     static void getTypeElements(::ast::WeakAst ast, char& sep, T& nodes)
     {
@@ -393,8 +395,9 @@ namespace mlir::verona
     }
 
     /// Get the hierarchy of types from class fields without the field info
+    /// T must be a list<ast> type with push_back.
     template<class T>
-    static void getClassTypeElements(::ast::WeakAst ast, T& nodes)
+    static void getClassTypeElements(T& nodes, ::ast::WeakAst ast)
     {
       auto body = getClassBody(ast).lock();
       for (auto field : body->nodes)
@@ -425,7 +428,8 @@ namespace mlir::verona
       return getType(sig);
     }
 
-    /// Get the ast nodes for the function arguments
+    /// Get the ast nodes for the function arguments.
+    /// T must be a list<ast> type with push_back.
     template<class T>
     static void getFunctionArgs(T& args, ::ast::WeakAst ast)
     {
@@ -439,6 +443,7 @@ namespace mlir::verona
     }
 
     /// Get the ast nodes for the function constraints
+    /// T must be a list<ast> type with push_back.
     template<class T>
     static void getFunctionConstraints(T& constraints, ::ast::WeakAst ast)
     {
@@ -551,7 +556,8 @@ namespace mlir::verona
       return args.lock()->nodes[n - 1];
     }
 
-    /// Return all operands of the operation
+    /// Get all operands of the operation.
+    /// T must be a list<ast> type with push_back.
     template<class T>
     static void getAllOperands(T& ops, ::ast::WeakAst ast)
     {

--- a/src/mlir/ast-utils.h
+++ b/src/mlir/ast-utils.h
@@ -479,6 +479,24 @@ namespace mlir::verona
       return findNode(ast, NodeKind::TypeBody);
     }
 
+    /// Get the body of a class/module declaration
+    static bool isClassType(::ast::WeakAst ast)
+    {
+      if (!isTypeHolder(ast))
+        return false;
+
+      auto typeID = findNode(
+        findNode(
+          findNode(findNode(ast, NodeKind::Type), NodeKind::TypeOne),
+          NodeKind::TypeRef),
+        NodeKind::ID);
+      auto ptr = typeID.lock();
+      auto def = ast::get_def(ptr, ptr->token);
+      if (!def)
+        return false;
+      return isClass(def);
+    }
+
     // ================================================= Operation Helpers
     /// Return the number of operands in an operation
     static size_t numOperands(::ast::WeakAst ast)

--- a/src/mlir/generator.cc
+++ b/src/mlir/generator.cc
@@ -131,15 +131,13 @@ namespace mlir::verona
     typeTable.insert(name, type);
 
     // Field names and types
-    llvm::SmallVector<::ast::WeakAst, 1> names;
-    AST::getSubNodes(names, AST::getClassBody(ast));
-    llvm::SmallVector<::ast::WeakAst, 1> types;
-    AST::getClassTypeElements(types, ast);
+    llvm::SmallVector<::ast::WeakAst, 1> nodes;
+    AST::getSubNodes(nodes, AST::getClassBody(ast));
     llvm::SmallVector<std::pair<StringRef, mlir::Type>, 4> fields;
-    for (auto name_type : llvm::zip(names, types))
+    for (auto node : nodes)
     {
-      auto fieldName = AST::getID(std::get<0>(name_type));
-      auto fieldType = parseType(std::get<1>(name_type).lock());
+      auto fieldName = AST::getID(node);
+      auto fieldType = parseType(AST::getType(node).lock());
       fields.push_back({fieldName, fieldType});
     }
     type.setFields(fields);

--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -193,9 +193,6 @@ namespace mlir::verona
     /// Recursive type parser, gathers all available information on the type
     /// and sub-types, modifiers, annotations, etc.
     mlir::Type parseType(const ::ast::Ast& ast);
-    /// Parses a class type, using parseType to find the field types. Can only
-    /// find other class types that have been defined, including itself.
-    mlir::Type parseClassType(const ::ast::Ast& ast);
 
     /// Generic node parser, calls other parse functions to handle each
     /// individual type.

--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -193,6 +193,9 @@ namespace mlir::verona
     /// Recursive type parser, gathers all available information on the type
     /// and sub-types, modifiers, annotations, etc.
     mlir::Type parseType(const ::ast::Ast& ast);
+    /// Parses a class type, using parseType to find the field types. Can only
+    /// find other class types that have been defined, including itself.
+    mlir::Type parseClassType(const ::ast::Ast& ast);
 
     /// Generic node parser, calls other parse functions to handle each
     /// individual type.

--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "ast/ast.h"
+#include "dialect/VeronaOps.h"
 #include "error.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Function.h"
@@ -186,6 +187,8 @@ namespace mlir::verona
 
     /// Parses a function, from a top-level (module) view.
     llvm::Expected<mlir::FuncOp> parseFunction(const ::ast::Ast& ast);
+    /// Parse a class declaration
+    llvm::Expected<mlir::verona::ClassOp> parseClass(const ::ast::Ast& ast);
 
     /// Recursive type parser, gathers all available information on the type
     /// and sub-types, modifiers, annotations, etc.

--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -223,7 +223,7 @@ namespace mlir::verona
     // These methods build complex MLIR constructs from parameters either
     // acquired from the AST or built by the compiler as to mimic the AST.
 
-    /// Generate a Verona type from parsing its name.
+    /// Generate a Verona type from parsing its name, caching in the typeTable.
     mlir::Type generateType(llvm::StringRef name);
     /// Generate a prototype, populating the symbol table
     llvm::Expected<mlir::FuncOp> generateProto(

--- a/testsuite/mlir/mlir-parse/class.verona
+++ b/testsuite/mlir/mlir-parse/class.verona
@@ -12,6 +12,10 @@ class D {
 class E {
   a: D;
   b: E;
+  c: F;
+}
+class F {
+  d: F32;
 }
 
 bar(x: U64 & imm, y: U64 & imm) {

--- a/testsuite/mlir/mlir-parse/class.verona
+++ b/testsuite/mlir/mlir-parse/class.verona
@@ -4,10 +4,14 @@
 class C {  }
 class D {
   f: U64 & imm;
-  g: S32 & mut;
+  g: C & mut;
   h: F32;
   i: F64;
   j: bool;
+}
+class E {
+  a: D;
+  b: E;
 }
 
 bar(x: U64 & imm, y: U64 & imm) {

--- a/testsuite/mlir/mlir-parse/class.verona
+++ b/testsuite/mlir/mlir-parse/class.verona
@@ -1,0 +1,23 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+class C {  }
+class D {
+  f: U64 & imm;
+  g: S32 & mut;
+  h: F32;
+  i: F64;
+  j: bool;
+}
+
+bar(x: U64 & imm, y: U64 & imm) {
+    //let a : C & iso = new C;
+    //let b : C & mut = view a;
+    //let c : D & mut = new D { f: x, g: b } in a;
+    //let d : U64 & imm = c.f;
+    //let e : D & mut = c.g;
+    //let f : U64 & imm = (c.g = y);
+
+    //tidy(a);
+    //drop(a);
+}

--- a/testsuite/mlir/mlir-parse/class.verona
+++ b/testsuite/mlir/mlir-parse/class.verona
@@ -13,10 +13,12 @@ class E {
   a: D;
   b: E;
   c: F;
+  d: G;
 }
 class F {
-  d: F32;
+  e: G;
 }
+class G { }
 
 bar(x: U64 & imm, y: U64 & imm) {
     //let a : C & iso = new C;

--- a/testsuite/mlir/mlir-parse/class/mlir.txt
+++ b/testsuite/mlir/mlir-parse/class/mlir.txt
@@ -1,0 +1,20 @@
+
+
+module {
+  verona.class @C {
+  }
+  verona.class @D {
+    verona.field "f" : !verona.meet<U64, imm>
+    verona.field "g" : !verona.meet<S32, mut>
+    verona.field "h" : !verona.F32
+    verona.field "i" : !verona.F64
+    verona.field "j" : !verona.bool
+  }
+  func @bar(%arg0: !verona.meet<U64, imm>, %arg1: !verona.meet<U64, imm>) {
+    %0 = "verona.alloca"() : () -> !type.alloca
+    %1 = "verona.store"(%arg0, %0) : (!verona.meet<U64, imm>, !type.alloca) -> !type.unk
+    %2 = "verona.alloca"() : () -> !type.alloca
+    %3 = "verona.store"(%arg1, %2) : (!verona.meet<U64, imm>, !type.alloca) -> !type.unk
+    return
+  }
+}

--- a/testsuite/mlir/mlir-parse/class/mlir.txt
+++ b/testsuite/mlir/mlir-parse/class/mlir.txt
@@ -12,11 +12,14 @@ module {
   }
   verona.class @E {
     verona.field "a" : !verona.class<"D", "j" : meet<U64, imm>, "j" : meet<class<"C">, mut>, "j" : F32, "j" : F64, "j" : bool>
-    verona.field "b" : !verona.class<"E", "c" : class<"D", "j" : meet<U64, imm>, "j" : meet<class<"C">, mut>, "j" : F32, "j" : F64, "j" : bool>, "c" : class<"E">, "c" : class<"F", "d" : F32>>
-    verona.field "c" : !verona.class<"F", "d" : F32>
+    verona.field "b" : !verona.class<"E", "d" : class<"D", "j" : meet<U64, imm>, "j" : meet<class<"C">, mut>, "j" : F32, "j" : F64, "j" : bool>, "d" : class<"E">, "d" : class<"F", "e" : class<"G">>, "d" : class<"G">>
+    verona.field "c" : !verona.class<"F", "e" : class<"G">>
+    verona.field "d" : !verona.class<"G">
   }
   verona.class @F {
-    verona.field "d" : !verona.F32
+    verona.field "e" : !verona.class<"G">
+  }
+  verona.class @G {
   }
   func @bar(%arg0: !verona.meet<U64, imm>, %arg1: !verona.meet<U64, imm>) {
     %0 = "verona.alloca"() : () -> !type.alloca

--- a/testsuite/mlir/mlir-parse/class/mlir.txt
+++ b/testsuite/mlir/mlir-parse/class/mlir.txt
@@ -12,7 +12,11 @@ module {
   }
   verona.class @E {
     verona.field "a" : !verona.class<"D", "j" : meet<U64, imm>, "j" : meet<class<"C">, mut>, "j" : F32, "j" : F64, "j" : bool>
-    verona.field "b" : !verona.class<"E", "b" : class<"D", "j" : meet<U64, imm>, "j" : meet<class<"C">, mut>, "j" : F32, "j" : F64, "j" : bool>, "b" : class<"E">>
+    verona.field "b" : !verona.class<"E", "c" : class<"D", "j" : meet<U64, imm>, "j" : meet<class<"C">, mut>, "j" : F32, "j" : F64, "j" : bool>, "c" : class<"E">, "c" : class<"F", "d" : F32>>
+    verona.field "c" : !verona.class<"F", "d" : F32>
+  }
+  verona.class @F {
+    verona.field "d" : !verona.F32
   }
   func @bar(%arg0: !verona.meet<U64, imm>, %arg1: !verona.meet<U64, imm>) {
     %0 = "verona.alloca"() : () -> !type.alloca

--- a/testsuite/mlir/mlir-parse/class/mlir.txt
+++ b/testsuite/mlir/mlir-parse/class/mlir.txt
@@ -5,10 +5,14 @@ module {
   }
   verona.class @D {
     verona.field "f" : !verona.meet<U64, imm>
-    verona.field "g" : !verona.meet<S32, mut>
+    verona.field "g" : !verona.meet<class<"C">, mut>
     verona.field "h" : !verona.F32
     verona.field "i" : !verona.F64
     verona.field "j" : !verona.bool
+  }
+  verona.class @E {
+    verona.field "a" : !verona.class<"D", "j" : meet<U64, imm>, "j" : meet<class<"C">, mut>, "j" : F32, "j" : F64, "j" : bool>
+    verona.field "b" : !verona.class<"E", "b" : class<"D", "j" : meet<U64, imm>, "j" : meet<class<"C">, mut>, "j" : F32, "j" : F64, "j" : bool>, "b" : class<"E">>
   }
   func @bar(%arg0: !verona.meet<U64, imm>, %arg1: !verona.meet<U64, imm>) {
     %0 = "verona.alloca"() : () -> !type.alloca


### PR DESCRIPTION
This lowers classes as the existing dialect operator and type. I'm following the existing `dialect.mlir` file for syntax and I can make it agree on the class definition.

Part of this work was also lowering `new`, `view` and fields access, but that may need changes to the dialect representation, so I'll leave it for the next PR, after we have discussed it properly.

Working towards #280 