### PR TITLE
Show object ID in systematic logs

### DIFF
--- a/src/interpreter/format.h
+++ b/src/interpreter/format.h
@@ -76,7 +76,7 @@ private:
           return format_object(object, it);
         else
           return fmt::format_to(
-            it, "{}({})", object->descriptor()->name, fmt::ptr(object));
+            it, "{}({})", object->descriptor()->name, object->id<false>());
       }
 
       case Value::COWN:
@@ -84,14 +84,14 @@ private:
           it,
           "{}({})",
           inner.cown->descriptor->name,
-          fmt::ptr(inner.cown->contents));
+          inner.cown->contents->id<false>());
 
       case Value::COWN_UNOWNED:
         return fmt::format_to(
           it,
           "unowned-{}({})",
           inner.cown->descriptor->name,
-          fmt::ptr(inner.cown->contents));
+          inner.cown->contents->id<false>());
 
       case Value::U64:
         return fmt::format_to(it, "{}", inner.u64);

--- a/src/rt/object/object.h
+++ b/src/rt/object/object.h
@@ -193,7 +193,7 @@ namespace verona::rt
 #ifdef USE_SYSTEMATIC_TESTING
     inline friend std::ostream& operator<<(std::ostream& os, const Object* o)
     {
-      return os << o->sys_id;
+      return os << o->id<false>();
     }
 #endif
 
@@ -246,10 +246,14 @@ namespace verona::rt
     }
 #endif
 
+    template<bool scramble = true>
     inline uintptr_t id() const
     {
 #ifdef USE_SYSTEMATIC_TESTING
-      return Systematic::get_scrambler().perm(sys_id);
+      if constexpr (scramble)
+        return Systematic::get_scrambler().perm(sys_id);
+      else
+        return sys_id;
 #else
       return (uintptr_t)this;
 #endif

--- a/src/rt/object/object.h
+++ b/src/rt/object/object.h
@@ -140,7 +140,7 @@ namespace verona::rt
       case EpochMark::SCANNED:
         return os << "SCANNED";
       default:
-        return os;
+        abort();
     }
   }
 
@@ -186,9 +186,16 @@ namespace verona::rt
         case RegionMD::COWN:
           return os << "COWN";
         default:
-          return os;
+          abort();
       }
     }
+
+#ifdef USE_SYSTEMATIC_TESTING
+    inline friend std::ostream& operator<<(std::ostream& os, const Object* o)
+    {
+      return os << o->sys_id;
+    }
+#endif
 
     // Note that while we only need 3 bits, we need to reserve enough bits
     // for the hashmap implementation. A static assert in hashmap.h should

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -356,15 +356,15 @@ namespace verona::rt
             break;
         }
 
-        Systematic::cout() << "Schedule cown: " << cown << " ("
-                           << cown->get_epoch_mark() << ")" << std::endl;
-
         // Administrative work before handling messages.
         if (!prerun(cown))
         {
           cown = nullptr;
           continue;
         }
+
+        Systematic::cout() << "Schedule cown: " << cown << " ("
+                           << cown->get_epoch_mark() << ")" << std::endl;
 
         // This prevents the LD protocol advancing if this cown has not been
         // scanned. This catches various cases where we have stolen, or
@@ -898,8 +898,8 @@ namespace verona::rt
           {
             count++;
             *p = c->next;
-            c->dealloc(alloc);
             Systematic::cout() << "Stub collected: " << c << std::endl;
+            c->dealloc(alloc);
             continue;
           }
           else


### PR DESCRIPTION
All systematic logs would previously show the address of objects, instead of the object identifier generated under systematic testing. This PR adds an overload for the stream operator so that `const Object*` is displayed as the ID under systematic testing.