### PR TITLE
Make `next` call at end of `for` loop

### DIFF
--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -171,8 +171,9 @@ namespace mlir::verona
     void declareVariable(llvm::StringRef name, mlir::Value val);
     /// Updates an existing variable in the local context.
     void updateVariable(llvm::StringRef name, mlir::Value val);
-    /// Declare a (compiler generated) function.
-    void declareFunction(
+    /// Get a (compiler generated) function.
+    /// Will declare the prototype if it has not already been defined.
+    FuncOp getFunction(
       llvm::StringRef name,
       llvm::ArrayRef<llvm::StringRef> types,
       llvm::StringRef retTy);

--- a/testsuite/mlir/mlir-parse/for.verona
+++ b/testsuite/mlir/mlir-parse/for.verona
@@ -10,3 +10,26 @@ f(x : U64)
     foo(a);
   }
 }
+
+f2(x : U64)
+{
+  let a : S32 = 0;
+  for (a in x) {
+    foo(a);
+    if (a > 5)
+    {
+      break
+    }
+    else
+    {
+      if (a < 2)
+      {
+        continue
+      }
+      else
+      {
+        foo(a);
+      }
+    }
+  }
+}

--- a/testsuite/mlir/mlir-parse/for/mlir.txt
+++ b/testsuite/mlir/mlir-parse/for/mlir.txt
@@ -12,18 +12,61 @@ module {
     %3 = "verona.constant(0)"() : () -> !type.int
     %4 = "verona.store"(%3, %2) : (!type.int, !type.alloca) -> !type.unk
     %5 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    br ^bb1
-  ^bb1:  // 2 preds: ^bb0, ^bb2
+    br ^bb2
+  ^bb1:  // pred: ^bb3
+    call @next(%5) : (!type.unk) -> ()
+    br ^bb2
+  ^bb2:  // 2 preds: ^bb0, ^bb1
     %6 = call @has_value(%5) : (!type.unk) -> !type.bool
     %7 = "verona.cast"(%6) : (!type.bool) -> i1
-    cond_br %7, ^bb2, ^bb3
-  ^bb2:  // pred: ^bb1
+    cond_br %7, ^bb3, ^bb4
+  ^bb3:  // pred: ^bb2
     %8 = call @apply(%5) : (!type.unk) -> !type.unk
-    call @next(%5) : (!type.unk) -> ()
     %9 = "verona.cast"(%8) : (!type.unk) -> !verona.S32
     call @foo(%9) : (!verona.S32) -> ()
     br ^bb1
-  ^bb3:  // pred: ^bb1
+  ^bb4:  // pred: ^bb2
     return
+  }
+  func @f2(%arg0: !verona.U64) {
+    %0 = "verona.alloca"() : () -> !type.alloca
+    %1 = "verona.store"(%arg0, %0) : (!verona.U64, !type.alloca) -> !type.unk
+    %2 = "verona.alloca"() : () -> !type.alloca
+    %3 = "verona.constant(0)"() : () -> !type.int
+    %4 = "verona.store"(%3, %2) : (!type.int, !type.alloca) -> !type.unk
+    %5 = "verona.load"(%0) : (!type.alloca) -> !type.unk
+    br ^bb2
+  ^bb1:  // 2 preds: ^bb7, ^bb8
+    call @next(%5) : (!type.unk) -> ()
+    br ^bb2
+  ^bb2:  // 2 preds: ^bb0, ^bb1
+    %6 = call @has_value(%5) : (!type.unk) -> !type.bool
+    %7 = "verona.cast"(%6) : (!type.bool) -> i1
+    cond_br %7, ^bb3, ^bb4
+  ^bb3:  // pred: ^bb2
+    %8 = call @apply(%5) : (!type.unk) -> !type.unk
+    %9 = "verona.cast"(%8) : (!type.unk) -> !verona.S32
+    call @foo(%9) : (!verona.S32) -> ()
+    %10 = "verona.constant(5)"() : () -> !type.int
+    %11 = "verona.gt"(%8, %10) : (!type.unk, !type.int) -> i1
+    cond_br %11, ^bb5, ^bb6
+  ^bb4:  // 2 preds: ^bb2, ^bb5
+    return
+  ^bb5:  // pred: ^bb3
+    br ^bb4
+  ^bb6:  // pred: ^bb3
+    %12 = "verona.constant(2)"() : () -> !type.int
+    %13 = "verona.lt"(%8, %12) : (!type.unk, !type.int) -> i1
+    cond_br %13, ^bb8, ^bb9
+  ^bb7:  // pred: ^bb10
+    br ^bb1
+  ^bb8:  // pred: ^bb6
+    br ^bb1
+  ^bb9:  // pred: ^bb6
+    %14 = "verona.cast"(%8) : (!type.unk) -> !verona.S32
+    call @foo(%14) : (!verona.S32) -> ()
+    br ^bb10
+  ^bb10:  // pred: ^bb9
+    br ^bb7
   }
 }


### PR DESCRIPTION
Changes for loop from
```
   while ($iter.has_value())
     val = $iter.apply()
     $iter.next()
     [body]
```
to
```
   while ($iter.has_value())
     val = $iter.apply()
     [body]
     $iter.next()
```
There is additional complexity to deal with continue, which must call `next`.