### PR TITLE
Add coin to overload cowns in systematic testing

### DIFF
--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -955,6 +955,14 @@ namespace verona::rt
       }
       stat.inc_load();
       stat.set_has_token(true);
+#ifdef USE_SYSTEMATIC_TESTING
+      if (Systematic::coin(5) && !stat.overloaded())
+      {
+        stat.overload();
+        assert(stat.overloaded());
+        Systematic::cout() << "Cown " << this << " overloaded" << std::endl;
+      }
+#endif
       status.store(stat, std::memory_order_release);
 
       return false;

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -251,7 +251,7 @@ namespace verona::rt
 
           continue;
         }
-        Systematic::cout() << "Cown " << this << ": backpressure state " << bp
+        Systematic::cout() << "Cown " << cown << ": backpressure state " << bp
                            << " -> Muted" << std::endl;
         assert(!(bp & BackpressureState::IsUnmutable));
       }

--- a/src/rt/sched/status.h
+++ b/src/rt/sched/status.h
@@ -114,6 +114,15 @@ namespace verona::rt
       _current_load = 0;
     }
 
+    /// Artificially overload a cown.
+    /// TODO: In the future, this will require a bit to remain overloaded after
+    /// the load drops.
+    inline void overload()
+    {
+      _load_hist = (uint16_t)-1;
+      _current_load = (uint8_t)-1;
+    }
+
     /// Indicates if the token message is in a cown's queue. If zero, a
     /// new token message should be added if the cown runs another message.
     inline bool has_token()


### PR DESCRIPTION
This PR adds a coin flip to artificially overload a running cown before each behaviour step.