### PR TITLE
Fix log message for rescheduled cown

### DIFF
--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -421,6 +421,13 @@ namespace verona::rt
                   cown = stolen;
                 }
               }
+
+              if (!has_thread_bit(cown))
+              {
+                Systematic::cout()
+                  << "Reschedule cown: " << cown << " ("
+                  << cown->get_epoch_mark() << ")" << std::endl;
+              }
             }
           }
         }

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -421,9 +421,6 @@ namespace verona::rt
                   cown = stolen;
                 }
               }
-
-              Systematic::cout() << "Reschedule cown: " << cown << " ("
-                                 << cown->get_epoch_mark() << ")" << std::endl;
             }
           }
         }


### PR DESCRIPTION
This PR removes prevents a log message in the scheduler from attempting to show an invalid epoch mark in the case that the cown popped from the scheduler queue is the token.