### PR TITLE
Refactoring how classes are lowered

### DIFF
--- a/src/mlir/ast-utils.h
+++ b/src/mlir/ast-utils.h
@@ -55,6 +55,7 @@ namespace mlir::verona
       None = 0,
       Module = peg::str2tag("module"), // = 73005690
       ClassDef = peg::str2tag("classdef"), // = 983016457
+      Field = peg::str2tag("field"), // = 122469826
       Function = peg::str2tag("function"), // = 89836898
       FuncName = peg::str2tag("funcname"), // = 90200697
       Sig = peg::str2tag("sig"), // = 124317
@@ -196,6 +197,12 @@ namespace mlir::verona
       return isA(ast, NodeKind::TypeOne);
     }
 
+    /// Return true if node is a field
+    static bool isField(::ast::WeakAst ast)
+    {
+      return isA(ast, NodeKind::Field);
+    }
+
     /// Return true if node is a function
     static bool isFunction(::ast::WeakAst ast)
     {
@@ -319,7 +326,7 @@ namespace mlir::verona
 
     // ================================================= Value Helpers
     /// Get the string value of a token
-    static const std::string& getTokenValue(::ast::WeakAst ast)
+    static llvm::StringRef getTokenValue(::ast::WeakAst ast)
     {
       assert(isValue(ast) && "Bad node");
       auto ptr = ast.lock();
@@ -328,7 +335,7 @@ namespace mlir::verona
     }
 
     /// Return true if node is a variable definition
-    static const std::string& getLocalName(::ast::WeakAst ast)
+    static llvm::StringRef getLocalName(::ast::WeakAst ast)
     {
       // Local variables can be new 'local' or existing 'localref'
       if (isLocalRef(ast))
@@ -338,7 +345,7 @@ namespace mlir::verona
     }
 
     /// Return true if node is an ID (func, var, type names)
-    static const std::string& getID(::ast::WeakAst ast)
+    static llvm::StringRef getID(::ast::WeakAst ast)
     {
       // FIXME: Why is the call ID 'function' while all others 'id'?
       if (isA(ast, NodeKind::Call))

--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -165,7 +165,7 @@ namespace mlir::verona
     // MLIR nodes.
 
     /// Get location of an ast node.
-    mlir::Location getLocation(const ::ast::Ast& ast);
+    mlir::Location getLocation(const ::ast::WeakAst& ast);
 
     /// Declares a new variable.
     void declareVariable(llvm::StringRef name, mlir::Value val);
@@ -189,7 +189,8 @@ namespace mlir::verona
     /// Parses a function, from a top-level (module) view.
     llvm::Expected<mlir::FuncOp> parseFunction(const ::ast::Ast& ast);
     /// Parse a class declaration
-    llvm::Expected<mlir::verona::ClassOp> parseClass(const ::ast::Ast& ast);
+    llvm::Error
+    parseClass(const ::ast::Ast& ast, mlir::Type parent = mlir::Type());
 
     /// Recursive type parser, gathers all available information on the type
     /// and sub-types, modifiers, annotations, etc.

--- a/testsuite/mlir/mlir-parse/call/mlir.txt
+++ b/testsuite/mlir/mlir-parse/call/mlir.txt
@@ -1,7 +1,7 @@
 
 
 module {
-  func @foo(%arg0: !verona.imm, %arg1: !verona.meet<U64, imm>) -> !verona.meet<U64, imm> {
+  func @foo(%arg0: !verona.imm, %arg1: !verona.meet<U64, imm>) -> !verona.meet<U64, imm> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !type.alloca
     %1 = "verona.store"(%arg0, %0) : (!verona.imm, !type.alloca) -> !type.unk
     %2 = "verona.alloca"() : () -> !type.alloca
@@ -34,7 +34,7 @@ module {
     %25 = "verona.cast"(%24) : (!type.unk) -> !verona.meet<U64, imm>
     return %25 : !verona.meet<U64, imm>
   }
-  func @apply() {
+  func @apply() attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !type.alloca
     %1 = "verona.constant(10)"() : () -> !type.int
     %2 = "verona.store"(%1, %0) : (!type.int, !type.alloca) -> !type.unk

--- a/testsuite/mlir/mlir-parse/class.verona
+++ b/testsuite/mlir/mlir-parse/class.verona
@@ -1,7 +1,10 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
 
+// Empty class declaration
 class C {  }
+
+// Class with fields only
 class D {
   f: U64 & imm;
   g: C & mut;
@@ -9,25 +12,27 @@ class D {
   i: F64;
   j: bool;
 }
+
+// Class with nested class, some yet-undeclared types
 class E {
   a: D;
   b: E;
+  // Nested class, showing deep recursion
+  class NestE {
+    x: G;
+  }
   c: F;
   d: G;
 }
+
+// Another class using an undeclared type
 class F {
   e: G;
 }
-class G { }
 
-bar(x: U64 & imm, y: U64 & imm) {
-    //let a : C & iso = new C;
-    //let b : C & mut = view a;
-    //let c : D & mut = new D { f: x, g: b } in a;
-    //let d : U64 & imm = c.f;
-    //let e : D & mut = c.g;
-    //let f : U64 & imm = (c.g = y);
-
-    //tidy(a);
-    //drop(a);
+// G is now declared, and has a static method
+class G {
+  static foo(a: U32) : F32 { 3.14; }
 }
+
+bar(c: C, d: D, e: E, ne: NestE, f: F, g: G) { }

--- a/testsuite/mlir/mlir-parse/class/mlir.txt
+++ b/testsuite/mlir/mlir-parse/class/mlir.txt
@@ -1,31 +1,26 @@
 
 
 module {
-  verona.class @C {
-  }
-  verona.class @D {
-    verona.field "f" : !verona.meet<U64, imm>
-    verona.field "g" : !verona.meet<class<"C">, mut>
-    verona.field "h" : !verona.F32
-    verona.field "i" : !verona.F64
-    verona.field "j" : !verona.bool
-  }
-  verona.class @E {
-    verona.field "a" : !verona.class<"D", "j" : meet<U64, imm>, "j" : meet<class<"C">, mut>, "j" : F32, "j" : F64, "j" : bool>
-    verona.field "b" : !verona.class<"E", "d" : class<"D", "j" : meet<U64, imm>, "j" : meet<class<"C">, mut>, "j" : F32, "j" : F64, "j" : bool>, "d" : class<"E">, "d" : class<"F", "e" : class<"G">>, "d" : class<"G">>
-    verona.field "c" : !verona.class<"F", "e" : class<"G">>
-    verona.field "d" : !verona.class<"G">
-  }
-  verona.class @F {
-    verona.field "e" : !verona.class<"G">
-  }
-  verona.class @G {
-  }
-  func @bar(%arg0: !verona.meet<U64, imm>, %arg1: !verona.meet<U64, imm>) {
+  func @foo(%arg0: !verona.U32) -> !verona.F32 attributes {class = !verona.class<"G", "$parent" : class<"$module">>} {
     %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.store"(%arg0, %0) : (!verona.meet<U64, imm>, !type.alloca) -> !type.unk
+    %1 = "verona.store"(%arg0, %0) : (!verona.U32, !type.alloca) -> !type.unk
+    %2 = "verona.constant(3.14)"() : () -> !type.float
+    %3 = "verona.cast"(%2) : (!type.float) -> !verona.F32
+    return %3 : !verona.F32
+  }
+  func @bar(%arg0: !verona.class<"C", "$parent" : class<"$module">>, %arg1: !verona.class<"D", "$parent" : class<"$module">, "f" : meet<U64, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : F32, "i" : F64, "j" : bool>, %arg2: !verona.class<"E", "$parent" : class<"$module">, "a" : class<"D", "$parent" : class<"$module">, "f" : meet<U64, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : F32, "i" : F64, "j" : bool>, "b" : class<"E">, "c" : class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, "d" : class<"G", "$parent" : class<"$module">>>, %arg3: !verona.class<"NestE", "$parent" : class<"E", "$parent" : class<"$module">, "a" : class<"D", "$parent" : class<"$module">, "f" : meet<U64, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : F32, "i" : F64, "j" : bool>, "b" : class<"E">, "c" : class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, "d" : class<"G", "$parent" : class<"$module">>>, "x" : class<"G", "$parent" : class<"$module">>>, %arg4: !verona.class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, %arg5: !verona.class<"G", "$parent" : class<"$module">>) attributes {class = !verona.class<"$module">} {
+    %0 = "verona.alloca"() : () -> !type.alloca
+    %1 = "verona.store"(%arg0, %0) : (!verona.class<"C", "$parent" : class<"$module">>, !type.alloca) -> !type.unk
     %2 = "verona.alloca"() : () -> !type.alloca
-    %3 = "verona.store"(%arg1, %2) : (!verona.meet<U64, imm>, !type.alloca) -> !type.unk
+    %3 = "verona.store"(%arg1, %2) : (!verona.class<"D", "$parent" : class<"$module">, "f" : meet<U64, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : F32, "i" : F64, "j" : bool>, !type.alloca) -> !type.unk
+    %4 = "verona.alloca"() : () -> !type.alloca
+    %5 = "verona.store"(%arg2, %4) : (!verona.class<"E", "$parent" : class<"$module">, "a" : class<"D", "$parent" : class<"$module">, "f" : meet<U64, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : F32, "i" : F64, "j" : bool>, "b" : class<"E">, "c" : class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, "d" : class<"G", "$parent" : class<"$module">>>, !type.alloca) -> !type.unk
+    %6 = "verona.alloca"() : () -> !type.alloca
+    %7 = "verona.store"(%arg3, %6) : (!verona.class<"NestE", "$parent" : class<"E", "$parent" : class<"$module">, "a" : class<"D", "$parent" : class<"$module">, "f" : meet<U64, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : F32, "i" : F64, "j" : bool>, "b" : class<"E">, "c" : class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, "d" : class<"G", "$parent" : class<"$module">>>, "x" : class<"G", "$parent" : class<"$module">>>, !type.alloca) -> !type.unk
+    %8 = "verona.alloca"() : () -> !type.alloca
+    %9 = "verona.store"(%arg4, %8) : (!verona.class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, !type.alloca) -> !type.unk
+    %10 = "verona.alloca"() : () -> !type.alloca
+    %11 = "verona.store"(%arg5, %10) : (!verona.class<"G", "$parent" : class<"$module">>, !type.alloca) -> !type.unk
     return
   }
 }

--- a/testsuite/mlir/mlir-parse/conditional/mlir.txt
+++ b/testsuite/mlir/mlir-parse/conditional/mlir.txt
@@ -1,7 +1,7 @@
 
 
 module {
-  func @f(%arg0: !verona.U16) -> !verona.S16 {
+  func @f(%arg0: !verona.U16) -> !verona.S16 attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !type.alloca
     %1 = "verona.store"(%arg0, %0) : (!verona.U16, !type.alloca) -> !type.unk
     %2 = "verona.load"(%0) : (!type.alloca) -> !type.unk

--- a/testsuite/mlir/mlir-parse/constant/mlir.txt
+++ b/testsuite/mlir/mlir-parse/constant/mlir.txt
@@ -1,7 +1,7 @@
 
 
 module {
-  func @f() {
+  func @f() attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !type.alloca
     %1 = "verona.constant(42)"() : () -> !type.int
     %2 = "verona.store"(%1, %0) : (!type.int, !type.alloca) -> !type.unk

--- a/testsuite/mlir/mlir-parse/for/mlir.txt
+++ b/testsuite/mlir/mlir-parse/for/mlir.txt
@@ -1,11 +1,11 @@
 
 
 module {
-  func @foo(!verona.S32)
+  func @foo(!verona.S32) attributes {class = !verona.class<"$module">}
   func @has_value(!type.unk) -> !type.bool
   func @apply(!type.unk) -> !type.unk
   func @next(!type.unk)
-  func @f(%arg0: !verona.U64) {
+  func @f(%arg0: !verona.U64) attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !type.alloca
     %1 = "verona.store"(%arg0, %0) : (!verona.U64, !type.alloca) -> !type.unk
     %2 = "verona.alloca"() : () -> !type.alloca
@@ -28,7 +28,7 @@ module {
   ^bb4:  // pred: ^bb2
     return
   }
-  func @f2(%arg0: !verona.U64) {
+  func @f2(%arg0: !verona.U64) attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !type.alloca
     %1 = "verona.store"(%arg0, %0) : (!verona.U64, !type.alloca) -> !type.unk
     %2 = "verona.alloca"() : () -> !type.alloca

--- a/testsuite/mlir/mlir-parse/function/mlir.txt
+++ b/testsuite/mlir/mlir-parse/function/mlir.txt
@@ -1,13 +1,13 @@
 
 
 module {
-  func @empty_declaration()
-  func @single_arg(!verona.S16)
-  func @args_and_ret(!verona.U32, !verona.S32) -> !verona.F64
-  func @empty_return() {
+  func @empty_declaration() attributes {class = !verona.class<"$module">}
+  func @single_arg(!verona.S16) attributes {class = !verona.class<"$module">}
+  func @args_and_ret(!verona.U32, !verona.S32) -> !verona.F64 attributes {class = !verona.class<"$module">}
+  func @empty_return() attributes {class = !verona.class<"$module">} {
     return
   }
-  func @foo(%arg0: !verona.imm, %arg1: !verona.meet<U64, imm>) -> !verona.meet<U64, imm> {
+  func @foo(%arg0: !verona.imm, %arg1: !verona.meet<U64, imm>) -> !verona.meet<U64, imm> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !type.alloca
     %1 = "verona.store"(%arg0, %0) : (!verona.imm, !type.alloca) -> !type.unk
     %2 = "verona.alloca"() : () -> !type.alloca
@@ -24,7 +24,7 @@ module {
     %13 = "verona.cast"(%12) : (!type.unk) -> !verona.meet<U64, imm>
     return %13 : !verona.meet<U64, imm>
   }
-  func @apply() {
+  func @apply() attributes {class = !verona.class<"$module">} {
     return
   }
 }

--- a/testsuite/mlir/mlir-parse/nested-conditional/mlir.txt
+++ b/testsuite/mlir/mlir-parse/nested-conditional/mlir.txt
@@ -1,7 +1,7 @@
 
 
 module {
-  func @f(%arg0: !verona.U32) -> !verona.U32 {
+  func @f(%arg0: !verona.U32) -> !verona.U32 attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !type.alloca
     %1 = "verona.store"(%arg0, %0) : (!verona.U32, !type.alloca) -> !type.unk
     %2 = "verona.load"(%0) : (!type.alloca) -> !type.unk

--- a/testsuite/mlir/mlir-parse/nested-while/mlir.txt
+++ b/testsuite/mlir/mlir-parse/nested-while/mlir.txt
@@ -1,7 +1,7 @@
 
 
 module {
-  func @f(%arg0: !verona.S64) -> !verona.S64 {
+  func @f(%arg0: !verona.S64) -> !verona.S64 attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !type.alloca
     %1 = "verona.store"(%arg0, %0) : (!verona.S64, !type.alloca) -> !type.unk
     br ^bb1

--- a/testsuite/mlir/mlir-parse/types/mlir.txt
+++ b/testsuite/mlir/mlir-parse/types/mlir.txt
@@ -1,7 +1,7 @@
 
 
 module {
-  func @foo(%arg0: !verona.meet<S32, iso>, %arg1: !verona.meet<U64, imm>) -> !verona.join<meet<S32, iso>, meet<U64, imm>, meet<U32, mut>> {
+  func @foo(%arg0: !verona.meet<S32, iso>, %arg1: !verona.meet<U64, imm>) -> !verona.join<meet<S32, iso>, meet<U64, imm>, meet<U32, mut>> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !type.alloca
     %1 = "verona.store"(%arg0, %0) : (!verona.meet<S32, iso>, !type.alloca) -> !type.unk
     %2 = "verona.alloca"() : () -> !type.alloca

--- a/testsuite/mlir/mlir-parse/while-cont-brk/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while-cont-brk/mlir.txt
@@ -1,7 +1,7 @@
 
 
 module {
-  func @f(%arg0: !verona.U32, %arg1: !verona.S32) -> !verona.F16 {
+  func @f(%arg0: !verona.U32, %arg1: !verona.S32) -> !verona.F16 attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !type.alloca
     %1 = "verona.store"(%arg0, %0) : (!verona.U32, !type.alloca) -> !type.unk
     %2 = "verona.alloca"() : () -> !type.alloca

--- a/testsuite/mlir/mlir-parse/while-context/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while-context/mlir.txt
@@ -1,7 +1,7 @@
 
 
 module {
-  func @f(%arg0: !verona.F32) -> !verona.F64 {
+  func @f(%arg0: !verona.F32) -> !verona.F64 attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !type.alloca
     %1 = "verona.store"(%arg0, %0) : (!verona.F32, !type.alloca) -> !type.unk
     %2 = "verona.alloca"() : () -> !type.alloca

--- a/testsuite/mlir/mlir-parse/while-if/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while-if/mlir.txt
@@ -1,7 +1,7 @@
 
 
 module {
-  func @f(%arg0: !verona.U32, %arg1: !verona.S32) -> !verona.U32 {
+  func @f(%arg0: !verona.U32, %arg1: !verona.S32) -> !verona.U32 attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !type.alloca
     %1 = "verona.store"(%arg0, %0) : (!verona.U32, !type.alloca) -> !type.unk
     %2 = "verona.alloca"() : () -> !type.alloca

--- a/testsuite/mlir/mlir-parse/while/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while/mlir.txt
@@ -1,7 +1,7 @@
 
 
 module {
-  func @f(%arg0: !verona.U32) -> !verona.U32 {
+  func @f(%arg0: !verona.U32) -> !verona.U32 attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !type.alloca
     %1 = "verona.store"(%arg0, %0) : (!verona.U32, !type.alloca) -> !type.unk
     br ^bb1


### PR DESCRIPTION
Previously, we were treating the module as a special case of class and
lowering a (so far) redundant class representation. This was getting in
the way of simple lowering of methods and nested classes.

This refactory changes how this is done by treating the module as just
another class, and lowering sub-classes, methods and fields in a natural
way. There is no need for a class operation, as the class type is
lowered correctly and is associated with every function via a function
attribute.

Compiler-generated functions (ex. `for` loop's `next`/`has_value`) do
not have a class context. It is debatable if others will need it, and
the intention is to have them declared in Verona code soon enough, in
which case, they will have their classes as an attribute then.

Class types also have gained a "$parent" node, pointing to where they
were declared (either $module or some other class, when nested). This
may turn out to be irrelevant, but it's cheap to add and can help us
when trying to mangle the name of methods correctly.

Only the class test had to be changed, to remove the class operations
and add nested and static method tests. All other tests had their
function declarations changed to account for the new attribute (except
compiler generated functions).

Continues to implement #280.