### PR TITLE
Add unknown type to dialect, implement `tidy` and `drop`.

### DIFF
--- a/src/mlir/dialect/TypeSyntax.cc
+++ b/src/mlir/dialect/TypeSyntax.cc
@@ -63,6 +63,7 @@ namespace mlir::verona::detail
         })
         .Case<FloatType>([&](FloatType type) { os << "F" << type.getWidth(); })
         .Case<BoolType>([&](BoolType type) { os << "bool"; })
+        .Case<UnknownType>([&](UnknownType type) { os << "unk"; })
         .Case<MeetType>([&](MeetType type) {
           if (type.getElements().empty())
           {
@@ -288,6 +289,8 @@ namespace mlir::verona::detail
         return CapabilityType::get(context, Capability::Immutable);
       else if (keyword == "bool")
         return BoolType::get(context);
+      else if (keyword == "unk")
+        return UnknownType::get(context);
       else if (keyword.startswith("U") || keyword.startswith("S"))
         return parseIntegerType(keyword);
       else if (keyword.startswith("F"))

--- a/src/mlir/dialect/VeronaDialect.cc
+++ b/src/mlir/dialect/VeronaDialect.cc
@@ -29,6 +29,7 @@ void VeronaDialect::initialize()
     ClassType,
     FloatType,
     BoolType,
+    UnknownType,
     ViewpointType>();
 
   allowUnknownOperations();

--- a/src/mlir/dialect/VeronaTypes.cc
+++ b/src/mlir/dialect/VeronaTypes.cc
@@ -274,6 +274,11 @@ namespace mlir::verona
     return ::mlir::detail::TypeUniquer::get<BoolType>(ctx);
   }
 
+  UnknownType UnknownType::get(MLIRContext* ctx)
+  {
+    return ::mlir::detail::TypeUniquer::get<UnknownType>(ctx);
+  }
+
   CapabilityType CapabilityType::get(MLIRContext* ctx, Capability cap)
   {
     return Base::get(ctx, cap);
@@ -350,6 +355,7 @@ namespace mlir::verona
       ClassType,
       FloatType,
       BoolType,
+      UnknownType,
       ViewpointType>();
   }
 

--- a/src/mlir/dialect/VeronaTypes.h
+++ b/src/mlir/dialect/VeronaTypes.h
@@ -92,6 +92,13 @@ namespace mlir::verona
     static BoolType get(MLIRContext* context);
   };
 
+  struct UnknownType : public Type::TypeBase<UnknownType, Type, TypeStorage>
+  {
+    using Base::Base;
+
+    static UnknownType get(MLIRContext* context);
+  };
+
   enum class Capability
   {
     Isolated,

--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -205,6 +205,10 @@ namespace mlir::verona
     llvm::Expected<ReturnValue> parseAssign(const ::ast::Ast& ast);
     /// Parses function calls and native operations.
     llvm::Expected<ReturnValue> parseCall(const ::ast::Ast& ast);
+    /// Parses function calls and native operations.
+    llvm::Expected<ReturnValue> parseUnop(const ::ast::Ast& ast);
+    /// Parses function calls and native operations.
+    llvm::Expected<ReturnValue> parseBinop(const ::ast::Ast& ast);
     /// Parses an if/else block.
     llvm::Expected<ReturnValue> parseCondition(const ::ast::Ast& ast);
     /// Parses a 'while' loop block.

--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -5,6 +5,7 @@
 
 #include "ast/ast.h"
 #include "dialect/VeronaOps.h"
+#include "dialect/VeronaTypes.h"
 #include "error.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Function.h"
@@ -123,10 +124,8 @@ namespace mlir::verona
     Generator(MLIRContext* context)
     : context(context), builder(context), unkLoc(builder.getUnknownLoc())
     {
-      // Initialise known opaque types, for comparison.
-      // TODO: Use Verona dialect types directly and isA<>.
-      allocaTy = genOpaqueType("alloca");
-      unkTy = genOpaqueType("unk");
+      // Initialise boolean / unknown types for convenience coding
+      unkTy = generateType("unk");
       boolTy = builder.getI1Type();
     }
 
@@ -153,8 +152,6 @@ namespace mlir::verona
     /// Nested reference for head/exit blocks in loops.
     BasicBlockTableT loopTable;
 
-    /// Alloca types, before we start using Verona types with known sizes.
-    mlir::Type allocaTy;
     /// Unknown types, will be defined during type inference.
     mlir::Type unkTy;
     /// MLIR boolean type (int1).
@@ -282,8 +279,5 @@ namespace mlir::verona
       llvm::StringRef name,
       llvm::ArrayRef<mlir::Value> ops,
       mlir::Type retTy);
-
-    /// Wrappers for opaque types before we use actual Verona dialect.
-    mlir::OpaqueType genOpaqueType(llvm::StringRef name);
   };
 }

--- a/testsuite/mlir/mlir-parse/call/mlir.txt
+++ b/testsuite/mlir/mlir-parse/call/mlir.txt
@@ -2,49 +2,49 @@
 
 module {
   func @foo(%arg0: !verona.imm, %arg1: !verona.meet<U64, imm>) -> !verona.meet<U64, imm> attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.store"(%arg0, %0) : (!verona.imm, !type.alloca) -> !type.unk
-    %2 = "verona.alloca"() : () -> !type.alloca
-    %3 = "verona.store"(%arg1, %2) : (!verona.meet<U64, imm>, !type.alloca) -> !type.unk
-    %4 = "verona.alloca"() : () -> !type.alloca
-    %5 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %6 = "verona.load"(%2) : (!type.alloca) -> !type.unk
-    %7 = "verona.add"(%5, %6) : (!type.unk, !type.unk) -> !type.unk
-    %8 = "verona.store"(%7, %4) : (!type.unk, !type.alloca) -> !type.unk
-    %9 = "verona.alloca"() : () -> !type.alloca
-    %10 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %11 = "verona.load"(%2) : (!type.alloca) -> !type.unk
-    %12 = "verona.sub"(%10, %11) : (!type.unk, !type.unk) -> !type.unk
-    %13 = "verona.store"(%12, %9) : (!type.unk, !type.alloca) -> !type.unk
-    %14 = "verona.load"(%4) : (!type.alloca) -> !type.unk
-    %15 = "verona.constant(100)"() : () -> !type.int
-    %16 = "verona.lt"(%14, %15) : (!type.unk, !type.int) -> i1
+    %0 = "verona.alloca"() : () -> !verona.unk
+    %1 = "verona.store"(%arg0, %0) : (!verona.imm, !verona.unk) -> !verona.unk
+    %2 = "verona.alloca"() : () -> !verona.unk
+    %3 = "verona.store"(%arg1, %2) : (!verona.meet<U64, imm>, !verona.unk) -> !verona.unk
+    %4 = "verona.alloca"() : () -> !verona.unk
+    %5 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %6 = "verona.load"(%2) : (!verona.unk) -> !verona.unk
+    %7 = "verona.add"(%5, %6) : (!verona.unk, !verona.unk) -> !verona.unk
+    %8 = "verona.store"(%7, %4) : (!verona.unk, !verona.unk) -> !verona.unk
+    %9 = "verona.alloca"() : () -> !verona.unk
+    %10 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %11 = "verona.load"(%2) : (!verona.unk) -> !verona.unk
+    %12 = "verona.sub"(%10, %11) : (!verona.unk, !verona.unk) -> !verona.unk
+    %13 = "verona.store"(%12, %9) : (!verona.unk, !verona.unk) -> !verona.unk
+    %14 = "verona.load"(%4) : (!verona.unk) -> !verona.unk
+    %15 = "verona.constant(100)"() : () -> !verona.S64
+    %16 = "verona.lt"(%14, %15) : (!verona.unk, !verona.S64) -> i1
     cond_br %16, ^bb1, ^bb2
   ^bb1:  // pred: ^bb0
-    %17 = "verona.load"(%4) : (!type.alloca) -> !type.unk
-    %18 = "verona.cast"(%17) : (!type.unk) -> !verona.imm
-    %19 = "verona.load"(%9) : (!type.alloca) -> !type.unk
-    %20 = "verona.cast"(%19) : (!type.unk) -> !verona.meet<U64, imm>
+    %17 = "verona.load"(%4) : (!verona.unk) -> !verona.unk
+    %18 = "verona.cast"(%17) : (!verona.unk) -> !verona.imm
+    %19 = "verona.load"(%9) : (!verona.unk) -> !verona.unk
+    %20 = "verona.cast"(%19) : (!verona.unk) -> !verona.meet<U64, imm>
     %21 = call @foo(%18, %20) : (!verona.imm, !verona.meet<U64, imm>) -> !verona.meet<U64, imm>
     return %21 : !verona.meet<U64, imm>
   ^bb2:  // pred: ^bb0
-    %22 = "verona.load"(%4) : (!type.alloca) -> !type.unk
-    %23 = "verona.load"(%9) : (!type.alloca) -> !type.unk
-    %24 = "verona.add"(%22, %23) : (!type.unk, !type.unk) -> !type.unk
-    %25 = "verona.cast"(%24) : (!type.unk) -> !verona.meet<U64, imm>
+    %22 = "verona.load"(%4) : (!verona.unk) -> !verona.unk
+    %23 = "verona.load"(%9) : (!verona.unk) -> !verona.unk
+    %24 = "verona.add"(%22, %23) : (!verona.unk, !verona.unk) -> !verona.unk
+    %25 = "verona.cast"(%24) : (!verona.unk) -> !verona.meet<U64, imm>
     return %25 : !verona.meet<U64, imm>
   }
   func @apply() attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.constant(10)"() : () -> !type.int
-    %2 = "verona.store"(%1, %0) : (!type.int, !type.alloca) -> !type.unk
-    %3 = "verona.alloca"() : () -> !type.alloca
-    %4 = "verona.constant(20)"() : () -> !type.int
-    %5 = "verona.store"(%4, %3) : (!type.int, !type.alloca) -> !type.unk
-    %6 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %7 = "verona.cast"(%6) : (!type.unk) -> !verona.imm
-    %8 = "verona.load"(%3) : (!type.alloca) -> !type.unk
-    %9 = "verona.cast"(%8) : (!type.unk) -> !verona.meet<U64, imm>
+    %0 = "verona.alloca"() : () -> !verona.unk
+    %1 = "verona.constant(10)"() : () -> !verona.S64
+    %2 = "verona.store"(%1, %0) : (!verona.S64, !verona.unk) -> !verona.unk
+    %3 = "verona.alloca"() : () -> !verona.unk
+    %4 = "verona.constant(20)"() : () -> !verona.S64
+    %5 = "verona.store"(%4, %3) : (!verona.S64, !verona.unk) -> !verona.unk
+    %6 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %7 = "verona.cast"(%6) : (!verona.unk) -> !verona.imm
+    %8 = "verona.load"(%3) : (!verona.unk) -> !verona.unk
+    %9 = "verona.cast"(%8) : (!verona.unk) -> !verona.meet<U64, imm>
     %10 = call @foo(%7, %9) : (!verona.imm, !verona.meet<U64, imm>) -> !verona.meet<U64, imm>
     return
   }

--- a/testsuite/mlir/mlir-parse/class.verona
+++ b/testsuite/mlir/mlir-parse/class.verona
@@ -35,4 +35,9 @@ class G {
   static foo(a: U32) : F32 { 3.14; }
 }
 
-bar(c: C, d: D, e: E, ne: NestE, f: F, g: G) { }
+bar(c: C, d: D, e: E, ne: NestE, f: F, g: G) {
+  // Garbage collect
+  tidy(c);
+  // Drop value
+  drop(d);
+}

--- a/testsuite/mlir/mlir-parse/class/mlir.txt
+++ b/testsuite/mlir/mlir-parse/class/mlir.txt
@@ -21,6 +21,10 @@ module {
     %9 = "verona.store"(%arg4, %8) : (!verona.class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, !verona.unk) -> !verona.unk
     %10 = "verona.alloca"() : () -> !verona.unk
     %11 = "verona.store"(%arg5, %10) : (!verona.class<"G", "$parent" : class<"$module">>, !verona.unk) -> !verona.unk
+    %12 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    verona.tidy %12 : !verona.unk
+    %13 = "verona.load"(%2) : (!verona.unk) -> !verona.unk
+    verona.drop %13 : !verona.unk
     return
   }
 }

--- a/testsuite/mlir/mlir-parse/class/mlir.txt
+++ b/testsuite/mlir/mlir-parse/class/mlir.txt
@@ -2,25 +2,25 @@
 
 module {
   func @foo(%arg0: !verona.U32) -> !verona.F32 attributes {class = !verona.class<"G", "$parent" : class<"$module">>} {
-    %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.store"(%arg0, %0) : (!verona.U32, !type.alloca) -> !type.unk
-    %2 = "verona.constant(3.14)"() : () -> !type.float
-    %3 = "verona.cast"(%2) : (!type.float) -> !verona.F32
+    %0 = "verona.alloca"() : () -> !verona.unk
+    %1 = "verona.store"(%arg0, %0) : (!verona.U32, !verona.unk) -> !verona.unk
+    %2 = "verona.constant(3.14)"() : () -> !verona.F64
+    %3 = "verona.cast"(%2) : (!verona.F64) -> !verona.F32
     return %3 : !verona.F32
   }
   func @bar(%arg0: !verona.class<"C", "$parent" : class<"$module">>, %arg1: !verona.class<"D", "$parent" : class<"$module">, "f" : meet<U64, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : F32, "i" : F64, "j" : bool>, %arg2: !verona.class<"E", "$parent" : class<"$module">, "a" : class<"D", "$parent" : class<"$module">, "f" : meet<U64, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : F32, "i" : F64, "j" : bool>, "b" : class<"E">, "c" : class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, "d" : class<"G", "$parent" : class<"$module">>>, %arg3: !verona.class<"NestE", "$parent" : class<"E", "$parent" : class<"$module">, "a" : class<"D", "$parent" : class<"$module">, "f" : meet<U64, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : F32, "i" : F64, "j" : bool>, "b" : class<"E">, "c" : class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, "d" : class<"G", "$parent" : class<"$module">>>, "x" : class<"G", "$parent" : class<"$module">>>, %arg4: !verona.class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, %arg5: !verona.class<"G", "$parent" : class<"$module">>) attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.store"(%arg0, %0) : (!verona.class<"C", "$parent" : class<"$module">>, !type.alloca) -> !type.unk
-    %2 = "verona.alloca"() : () -> !type.alloca
-    %3 = "verona.store"(%arg1, %2) : (!verona.class<"D", "$parent" : class<"$module">, "f" : meet<U64, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : F32, "i" : F64, "j" : bool>, !type.alloca) -> !type.unk
-    %4 = "verona.alloca"() : () -> !type.alloca
-    %5 = "verona.store"(%arg2, %4) : (!verona.class<"E", "$parent" : class<"$module">, "a" : class<"D", "$parent" : class<"$module">, "f" : meet<U64, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : F32, "i" : F64, "j" : bool>, "b" : class<"E">, "c" : class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, "d" : class<"G", "$parent" : class<"$module">>>, !type.alloca) -> !type.unk
-    %6 = "verona.alloca"() : () -> !type.alloca
-    %7 = "verona.store"(%arg3, %6) : (!verona.class<"NestE", "$parent" : class<"E", "$parent" : class<"$module">, "a" : class<"D", "$parent" : class<"$module">, "f" : meet<U64, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : F32, "i" : F64, "j" : bool>, "b" : class<"E">, "c" : class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, "d" : class<"G", "$parent" : class<"$module">>>, "x" : class<"G", "$parent" : class<"$module">>>, !type.alloca) -> !type.unk
-    %8 = "verona.alloca"() : () -> !type.alloca
-    %9 = "verona.store"(%arg4, %8) : (!verona.class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, !type.alloca) -> !type.unk
-    %10 = "verona.alloca"() : () -> !type.alloca
-    %11 = "verona.store"(%arg5, %10) : (!verona.class<"G", "$parent" : class<"$module">>, !type.alloca) -> !type.unk
+    %0 = "verona.alloca"() : () -> !verona.unk
+    %1 = "verona.store"(%arg0, %0) : (!verona.class<"C", "$parent" : class<"$module">>, !verona.unk) -> !verona.unk
+    %2 = "verona.alloca"() : () -> !verona.unk
+    %3 = "verona.store"(%arg1, %2) : (!verona.class<"D", "$parent" : class<"$module">, "f" : meet<U64, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : F32, "i" : F64, "j" : bool>, !verona.unk) -> !verona.unk
+    %4 = "verona.alloca"() : () -> !verona.unk
+    %5 = "verona.store"(%arg2, %4) : (!verona.class<"E", "$parent" : class<"$module">, "a" : class<"D", "$parent" : class<"$module">, "f" : meet<U64, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : F32, "i" : F64, "j" : bool>, "b" : class<"E">, "c" : class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, "d" : class<"G", "$parent" : class<"$module">>>, !verona.unk) -> !verona.unk
+    %6 = "verona.alloca"() : () -> !verona.unk
+    %7 = "verona.store"(%arg3, %6) : (!verona.class<"NestE", "$parent" : class<"E", "$parent" : class<"$module">, "a" : class<"D", "$parent" : class<"$module">, "f" : meet<U64, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : F32, "i" : F64, "j" : bool>, "b" : class<"E">, "c" : class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, "d" : class<"G", "$parent" : class<"$module">>>, "x" : class<"G", "$parent" : class<"$module">>>, !verona.unk) -> !verona.unk
+    %8 = "verona.alloca"() : () -> !verona.unk
+    %9 = "verona.store"(%arg4, %8) : (!verona.class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, !verona.unk) -> !verona.unk
+    %10 = "verona.alloca"() : () -> !verona.unk
+    %11 = "verona.store"(%arg5, %10) : (!verona.class<"G", "$parent" : class<"$module">>, !verona.unk) -> !verona.unk
     return
   }
 }

--- a/testsuite/mlir/mlir-parse/conditional/mlir.txt
+++ b/testsuite/mlir/mlir-parse/conditional/mlir.txt
@@ -2,35 +2,35 @@
 
 module {
   func @f(%arg0: !verona.U16) -> !verona.S16 attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.store"(%arg0, %0) : (!verona.U16, !type.alloca) -> !type.unk
-    %2 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %3 = "verona.constant(2)"() : () -> !type.int
-    %4 = "verona.lt"(%2, %3) : (!type.unk, !type.int) -> i1
+    %0 = "verona.alloca"() : () -> !verona.unk
+    %1 = "verona.store"(%arg0, %0) : (!verona.U16, !verona.unk) -> !verona.unk
+    %2 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %3 = "verona.constant(2)"() : () -> !verona.S64
+    %4 = "verona.lt"(%2, %3) : (!verona.unk, !verona.S64) -> i1
     cond_br %4, ^bb1, ^bb2
   ^bb1:  // pred: ^bb0
-    %5 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %6 = "verona.constant(1)"() : () -> !type.int
-    %7 = "verona.add"(%5, %6) : (!type.unk, !type.int) -> !type.unk
-    %8 = "verona.store"(%7, %0) : (!type.unk, !type.alloca) -> !type.unk
+    %5 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %6 = "verona.constant(1)"() : () -> !verona.S64
+    %7 = "verona.add"(%5, %6) : (!verona.unk, !verona.S64) -> !verona.unk
+    %8 = "verona.store"(%7, %0) : (!verona.unk, !verona.unk) -> !verona.unk
     br ^bb3
   ^bb2:  // pred: ^bb0
-    %9 = "verona.constant(true)"() : () -> !type.bool
-    %10 = "verona.cast"(%9) : (!type.bool) -> i1
+    %9 = "verona.constant(true)"() : () -> !verona.bool
+    %10 = "verona.cast"(%9) : (!verona.bool) -> i1
     cond_br %10, ^bb4, ^bb5
   ^bb3:  // 2 preds: ^bb1, ^bb6
-    %11 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %12 = "verona.cast"(%11) : (!type.unk) -> !verona.S16
+    %11 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %12 = "verona.cast"(%11) : (!verona.unk) -> !verona.S16
     return %12 : !verona.S16
   ^bb4:  // pred: ^bb2
-    %13 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %14 = "verona.constant(1)"() : () -> !type.int
-    %15 = "verona.sub"(%13, %14) : (!type.unk, !type.int) -> !type.unk
-    %16 = "verona.store"(%15, %0) : (!type.unk, !type.alloca) -> !type.unk
+    %13 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %14 = "verona.constant(1)"() : () -> !verona.S64
+    %15 = "verona.sub"(%13, %14) : (!verona.unk, !verona.S64) -> !verona.unk
+    %16 = "verona.store"(%15, %0) : (!verona.unk, !verona.unk) -> !verona.unk
     br ^bb6
   ^bb5:  // pred: ^bb2
-    %17 = "verona.constant(0)"() : () -> !type.int
-    %18 = "verona.store"(%17, %0) : (!type.int, !type.alloca) -> !type.unk
+    %17 = "verona.constant(0)"() : () -> !verona.S64
+    %18 = "verona.store"(%17, %0) : (!verona.S64, !verona.unk) -> !verona.unk
     br ^bb6
   ^bb6:  // 2 preds: ^bb4, ^bb5
     br ^bb3

--- a/testsuite/mlir/mlir-parse/constant/mlir.txt
+++ b/testsuite/mlir/mlir-parse/constant/mlir.txt
@@ -2,36 +2,36 @@
 
 module {
   func @f() attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.constant(42)"() : () -> !type.int
-    %2 = "verona.store"(%1, %0) : (!type.int, !type.alloca) -> !type.unk
-    %3 = "verona.alloca"() : () -> !type.alloca
-    %4 = "verona.constant(3.1415)"() : () -> !type.float
-    %5 = "verona.store"(%4, %3) : (!type.float, !type.alloca) -> !type.unk
-    %6 = "verona.alloca"() : () -> !type.alloca
-    %7 = "verona.constant(true)"() : () -> !type.bool
-    %8 = "verona.store"(%7, %6) : (!type.bool, !type.alloca) -> !type.unk
-    %9 = "verona.alloca"() : () -> !type.alloca
-    %10 = "verona.constant(0xAE)"() : () -> !type.hex
-    %11 = "verona.store"(%10, %9) : (!type.hex, !type.alloca) -> !type.unk
-    %12 = "verona.alloca"() : () -> !type.alloca
-    %13 = "verona.constant(0b11011)"() : () -> !type.binary
-    %14 = "verona.store"(%13, %12) : (!type.binary, !type.alloca) -> !type.unk
-    %15 = "verona.alloca"() : () -> !type.alloca
-    %16 = "verona.constant(42)"() : () -> !type.int
-    %17 = "verona.store"(%16, %15) : (!type.int, !type.alloca) -> !type.unk
-    %18 = "verona.alloca"() : () -> !type.alloca
-    %19 = "verona.constant(3.1415)"() : () -> !type.float
-    %20 = "verona.store"(%19, %18) : (!type.float, !type.alloca) -> !type.unk
-    %21 = "verona.alloca"() : () -> !type.alloca
-    %22 = "verona.constant(false)"() : () -> !type.bool
-    %23 = "verona.store"(%22, %21) : (!type.bool, !type.alloca) -> !type.unk
-    %24 = "verona.alloca"() : () -> !type.alloca
-    %25 = "verona.constant(0xDEADBEEF)"() : () -> !type.hex
-    %26 = "verona.store"(%25, %24) : (!type.hex, !type.alloca) -> !type.unk
-    %27 = "verona.alloca"() : () -> !type.alloca
-    %28 = "verona.constant(0b1)"() : () -> !type.binary
-    %29 = "verona.store"(%28, %27) : (!type.binary, !type.alloca) -> !type.unk
+    %0 = "verona.alloca"() : () -> !verona.unk
+    %1 = "verona.constant(42)"() : () -> !verona.S64
+    %2 = "verona.store"(%1, %0) : (!verona.S64, !verona.unk) -> !verona.unk
+    %3 = "verona.alloca"() : () -> !verona.unk
+    %4 = "verona.constant(3.1415)"() : () -> !verona.F64
+    %5 = "verona.store"(%4, %3) : (!verona.F64, !verona.unk) -> !verona.unk
+    %6 = "verona.alloca"() : () -> !verona.unk
+    %7 = "verona.constant(true)"() : () -> !verona.bool
+    %8 = "verona.store"(%7, %6) : (!verona.bool, !verona.unk) -> !verona.unk
+    %9 = "verona.alloca"() : () -> !verona.unk
+    %10 = "verona.constant(0xAE)"() : () -> !verona.U64
+    %11 = "verona.store"(%10, %9) : (!verona.U64, !verona.unk) -> !verona.unk
+    %12 = "verona.alloca"() : () -> !verona.unk
+    %13 = "verona.constant(0b11011)"() : () -> !verona.U64
+    %14 = "verona.store"(%13, %12) : (!verona.U64, !verona.unk) -> !verona.unk
+    %15 = "verona.alloca"() : () -> !verona.unk
+    %16 = "verona.constant(42)"() : () -> !verona.S64
+    %17 = "verona.store"(%16, %15) : (!verona.S64, !verona.unk) -> !verona.unk
+    %18 = "verona.alloca"() : () -> !verona.unk
+    %19 = "verona.constant(3.1415)"() : () -> !verona.F64
+    %20 = "verona.store"(%19, %18) : (!verona.F64, !verona.unk) -> !verona.unk
+    %21 = "verona.alloca"() : () -> !verona.unk
+    %22 = "verona.constant(false)"() : () -> !verona.bool
+    %23 = "verona.store"(%22, %21) : (!verona.bool, !verona.unk) -> !verona.unk
+    %24 = "verona.alloca"() : () -> !verona.unk
+    %25 = "verona.constant(0xDEADBEEF)"() : () -> !verona.U64
+    %26 = "verona.store"(%25, %24) : (!verona.U64, !verona.unk) -> !verona.unk
+    %27 = "verona.alloca"() : () -> !verona.unk
+    %28 = "verona.constant(0b1)"() : () -> !verona.U64
+    %29 = "verona.store"(%28, %27) : (!verona.U64, !verona.unk) -> !verona.unk
     return
   }
 }

--- a/testsuite/mlir/mlir-parse/for/mlir.txt
+++ b/testsuite/mlir/mlir-parse/for/mlir.txt
@@ -2,69 +2,74 @@
 
 module {
   func @foo(!verona.S32) attributes {class = !verona.class<"$module">}
-  func @has_value(!type.unk) -> !type.bool
-  func @apply(!type.unk) -> !type.unk
-  func @next(!type.unk)
+  func @has_value(!verona.unk) -> !verona.bool
+  func @apply(!verona.unk) -> !verona.unk
+  func @next(!verona.unk)
   func @f(%arg0: !verona.U64) attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.store"(%arg0, %0) : (!verona.U64, !type.alloca) -> !type.unk
-    %2 = "verona.alloca"() : () -> !type.alloca
-    %3 = "verona.constant(0)"() : () -> !type.int
-    %4 = "verona.store"(%3, %2) : (!type.int, !type.alloca) -> !type.unk
-    %5 = "verona.load"(%0) : (!type.alloca) -> !type.unk
+    %0 = "verona.alloca"() : () -> !verona.unk
+    %1 = "verona.store"(%arg0, %0) : (!verona.U64, !verona.unk) -> !verona.unk
+    %2 = "verona.alloca"() : () -> !verona.unk
+    %3 = "verona.constant(0)"() : () -> !verona.S64
+    %4 = "verona.store"(%3, %2) : (!verona.S64, !verona.unk) -> !verona.unk
+    %5 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
     br ^bb2
   ^bb1:  // pred: ^bb3
-    call @next(%5) : (!type.unk) -> ()
+    call @next(%5) : (!verona.unk) -> ()
     br ^bb2
   ^bb2:  // 2 preds: ^bb0, ^bb1
-    %6 = call @has_value(%5) : (!type.unk) -> !type.bool
-    %7 = "verona.cast"(%6) : (!type.bool) -> i1
+    %6 = call @has_value(%5) : (!verona.unk) -> !verona.bool
+    %7 = "verona.cast"(%6) : (!verona.bool) -> i1
     cond_br %7, ^bb3, ^bb4
   ^bb3:  // pred: ^bb2
-    %8 = call @apply(%5) : (!type.unk) -> !type.unk
-    %9 = "verona.cast"(%8) : (!type.unk) -> !verona.S32
-    call @foo(%9) : (!verona.S32) -> ()
+    %8 = call @apply(%5) : (!verona.unk) -> !verona.unk
+    %9 = "verona.load"(%8) : (!verona.unk) -> !verona.unk
+    %10 = "verona.cast"(%9) : (!verona.unk) -> !verona.S32
+    call @foo(%10) : (!verona.S32) -> ()
     br ^bb1
   ^bb4:  // pred: ^bb2
     return
   }
   func @f2(%arg0: !verona.U64) attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.store"(%arg0, %0) : (!verona.U64, !type.alloca) -> !type.unk
-    %2 = "verona.alloca"() : () -> !type.alloca
-    %3 = "verona.constant(0)"() : () -> !type.int
-    %4 = "verona.store"(%3, %2) : (!type.int, !type.alloca) -> !type.unk
-    %5 = "verona.load"(%0) : (!type.alloca) -> !type.unk
+    %0 = "verona.alloca"() : () -> !verona.unk
+    %1 = "verona.store"(%arg0, %0) : (!verona.U64, !verona.unk) -> !verona.unk
+    %2 = "verona.alloca"() : () -> !verona.unk
+    %3 = "verona.constant(0)"() : () -> !verona.S64
+    %4 = "verona.store"(%3, %2) : (!verona.S64, !verona.unk) -> !verona.unk
+    %5 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
     br ^bb2
   ^bb1:  // 2 preds: ^bb7, ^bb8
-    call @next(%5) : (!type.unk) -> ()
+    call @next(%5) : (!verona.unk) -> ()
     br ^bb2
   ^bb2:  // 2 preds: ^bb0, ^bb1
-    %6 = call @has_value(%5) : (!type.unk) -> !type.bool
-    %7 = "verona.cast"(%6) : (!type.bool) -> i1
+    %6 = call @has_value(%5) : (!verona.unk) -> !verona.bool
+    %7 = "verona.cast"(%6) : (!verona.bool) -> i1
     cond_br %7, ^bb3, ^bb4
   ^bb3:  // pred: ^bb2
-    %8 = call @apply(%5) : (!type.unk) -> !type.unk
-    %9 = "verona.cast"(%8) : (!type.unk) -> !verona.S32
-    call @foo(%9) : (!verona.S32) -> ()
-    %10 = "verona.constant(5)"() : () -> !type.int
-    %11 = "verona.gt"(%8, %10) : (!type.unk, !type.int) -> i1
-    cond_br %11, ^bb5, ^bb6
+    %8 = call @apply(%5) : (!verona.unk) -> !verona.unk
+    %9 = "verona.load"(%8) : (!verona.unk) -> !verona.unk
+    %10 = "verona.cast"(%9) : (!verona.unk) -> !verona.S32
+    call @foo(%10) : (!verona.S32) -> ()
+    %11 = "verona.load"(%8) : (!verona.unk) -> !verona.unk
+    %12 = "verona.constant(5)"() : () -> !verona.S64
+    %13 = "verona.gt"(%11, %12) : (!verona.unk, !verona.S64) -> i1
+    cond_br %13, ^bb5, ^bb6
   ^bb4:  // 2 preds: ^bb2, ^bb5
     return
   ^bb5:  // pred: ^bb3
     br ^bb4
   ^bb6:  // pred: ^bb3
-    %12 = "verona.constant(2)"() : () -> !type.int
-    %13 = "verona.lt"(%8, %12) : (!type.unk, !type.int) -> i1
-    cond_br %13, ^bb8, ^bb9
+    %14 = "verona.load"(%8) : (!verona.unk) -> !verona.unk
+    %15 = "verona.constant(2)"() : () -> !verona.S64
+    %16 = "verona.lt"(%14, %15) : (!verona.unk, !verona.S64) -> i1
+    cond_br %16, ^bb8, ^bb9
   ^bb7:  // pred: ^bb10
     br ^bb1
   ^bb8:  // pred: ^bb6
     br ^bb1
   ^bb9:  // pred: ^bb6
-    %14 = "verona.cast"(%8) : (!type.unk) -> !verona.S32
-    call @foo(%14) : (!verona.S32) -> ()
+    %17 = "verona.load"(%8) : (!verona.unk) -> !verona.unk
+    %18 = "verona.cast"(%17) : (!verona.unk) -> !verona.S32
+    call @foo(%18) : (!verona.S32) -> ()
     br ^bb10
   ^bb10:  // pred: ^bb9
     br ^bb7

--- a/testsuite/mlir/mlir-parse/function/mlir.txt
+++ b/testsuite/mlir/mlir-parse/function/mlir.txt
@@ -8,20 +8,20 @@ module {
     return
   }
   func @foo(%arg0: !verona.imm, %arg1: !verona.meet<U64, imm>) -> !verona.meet<U64, imm> attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.store"(%arg0, %0) : (!verona.imm, !type.alloca) -> !type.unk
-    %2 = "verona.alloca"() : () -> !type.alloca
-    %3 = "verona.store"(%arg1, %2) : (!verona.meet<U64, imm>, !type.alloca) -> !type.unk
-    %4 = "verona.alloca"() : () -> !type.alloca
-    %5 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %6 = "verona.load"(%2) : (!type.alloca) -> !type.unk
-    %7 = "verona.add"(%5, %6) : (!type.unk, !type.unk) -> !type.unk
-    %8 = "verona.store"(%7, %4) : (!type.unk, !type.alloca) -> !type.unk
-    %9 = "verona.alloca"() : () -> !type.alloca
-    %10 = "verona.load"(%4) : (!type.alloca) -> !type.unk
-    %11 = "verona.store"(%10, %9) : (!type.unk, !type.alloca) -> !type.unk
-    %12 = "verona.load"(%4) : (!type.alloca) -> !type.unk
-    %13 = "verona.cast"(%12) : (!type.unk) -> !verona.meet<U64, imm>
+    %0 = "verona.alloca"() : () -> !verona.unk
+    %1 = "verona.store"(%arg0, %0) : (!verona.imm, !verona.unk) -> !verona.unk
+    %2 = "verona.alloca"() : () -> !verona.unk
+    %3 = "verona.store"(%arg1, %2) : (!verona.meet<U64, imm>, !verona.unk) -> !verona.unk
+    %4 = "verona.alloca"() : () -> !verona.unk
+    %5 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %6 = "verona.load"(%2) : (!verona.unk) -> !verona.unk
+    %7 = "verona.add"(%5, %6) : (!verona.unk, !verona.unk) -> !verona.unk
+    %8 = "verona.store"(%7, %4) : (!verona.unk, !verona.unk) -> !verona.unk
+    %9 = "verona.alloca"() : () -> !verona.unk
+    %10 = "verona.load"(%4) : (!verona.unk) -> !verona.unk
+    %11 = "verona.store"(%10, %9) : (!verona.unk, !verona.unk) -> !verona.unk
+    %12 = "verona.load"(%4) : (!verona.unk) -> !verona.unk
+    %13 = "verona.cast"(%12) : (!verona.unk) -> !verona.meet<U64, imm>
     return %13 : !verona.meet<U64, imm>
   }
   func @apply() attributes {class = !verona.class<"$module">} {

--- a/testsuite/mlir/mlir-parse/nested-conditional/mlir.txt
+++ b/testsuite/mlir/mlir-parse/nested-conditional/mlir.txt
@@ -2,84 +2,84 @@
 
 module {
   func @f(%arg0: !verona.U32) -> !verona.U32 attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.store"(%arg0, %0) : (!verona.U32, !type.alloca) -> !type.unk
-    %2 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %3 = "verona.constant(2)"() : () -> !type.int
-    %4 = "verona.lt"(%2, %3) : (!type.unk, !type.int) -> i1
+    %0 = "verona.alloca"() : () -> !verona.unk
+    %1 = "verona.store"(%arg0, %0) : (!verona.U32, !verona.unk) -> !verona.unk
+    %2 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %3 = "verona.constant(2)"() : () -> !verona.S64
+    %4 = "verona.lt"(%2, %3) : (!verona.unk, !verona.S64) -> i1
     cond_br %4, ^bb1, ^bb2
   ^bb1:  // pred: ^bb0
-    %5 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %6 = "verona.constant(1)"() : () -> !type.int
-    %7 = "verona.add"(%5, %6) : (!type.unk, !type.int) -> !type.unk
-    %8 = "verona.store"(%7, %0) : (!type.unk, !type.alloca) -> !type.unk
+    %5 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %6 = "verona.constant(1)"() : () -> !verona.S64
+    %7 = "verona.add"(%5, %6) : (!verona.unk, !verona.S64) -> !verona.unk
+    %8 = "verona.store"(%7, %0) : (!verona.unk, !verona.unk) -> !verona.unk
     br ^bb3
   ^bb2:  // pred: ^bb0
-    %9 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %10 = "verona.constant(100)"() : () -> !type.int
-    %11 = "verona.gt"(%9, %10) : (!type.unk, !type.int) -> i1
+    %9 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %10 = "verona.constant(100)"() : () -> !verona.S64
+    %11 = "verona.gt"(%9, %10) : (!verona.unk, !verona.S64) -> i1
     cond_br %11, ^bb4, ^bb5
   ^bb3:  // 2 preds: ^bb1, ^bb6
-    %12 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %13 = "verona.cast"(%12) : (!type.unk) -> !verona.U32
+    %12 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %13 = "verona.cast"(%12) : (!verona.unk) -> !verona.U32
     return %13 : !verona.U32
   ^bb4:  // pred: ^bb2
-    %14 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %15 = "verona.constant(1)"() : () -> !type.int
-    %16 = "verona.sub"(%14, %15) : (!type.unk, !type.int) -> !type.unk
-    %17 = "verona.store"(%16, %0) : (!type.unk, !type.alloca) -> !type.unk
+    %14 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %15 = "verona.constant(1)"() : () -> !verona.S64
+    %16 = "verona.sub"(%14, %15) : (!verona.unk, !verona.S64) -> !verona.unk
+    %17 = "verona.store"(%16, %0) : (!verona.unk, !verona.unk) -> !verona.unk
     br ^bb6
   ^bb5:  // pred: ^bb2
-    %18 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %19 = "verona.constant(20)"() : () -> !type.int
-    %20 = "verona.le"(%18, %19) : (!type.unk, !type.int) -> i1
+    %18 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %19 = "verona.constant(20)"() : () -> !verona.S64
+    %20 = "verona.le"(%18, %19) : (!verona.unk, !verona.S64) -> i1
     cond_br %20, ^bb7, ^bb8
   ^bb6:  // 2 preds: ^bb4, ^bb9
     br ^bb3
   ^bb7:  // pred: ^bb5
-    %21 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %22 = "verona.constant(2)"() : () -> !type.int
-    %23 = "verona.mul"(%21, %22) : (!type.unk, !type.int) -> !type.unk
-    %24 = "verona.store"(%23, %0) : (!type.unk, !type.alloca) -> !type.unk
+    %21 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %22 = "verona.constant(2)"() : () -> !verona.S64
+    %23 = "verona.mul"(%21, %22) : (!verona.unk, !verona.S64) -> !verona.unk
+    %24 = "verona.store"(%23, %0) : (!verona.unk, !verona.unk) -> !verona.unk
     br ^bb9
   ^bb8:  // pred: ^bb5
-    %25 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %26 = "verona.constant(50)"() : () -> !type.int
-    %27 = "verona.ge"(%25, %26) : (!type.unk, !type.int) -> i1
+    %25 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %26 = "verona.constant(50)"() : () -> !verona.S64
+    %27 = "verona.ge"(%25, %26) : (!verona.unk, !verona.S64) -> i1
     cond_br %27, ^bb10, ^bb11
   ^bb9:  // 2 preds: ^bb7, ^bb12
     br ^bb6
   ^bb10:  // pred: ^bb8
-    %28 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %29 = "verona.constant(10)"() : () -> !type.int
-    %30 = "verona.div"(%28, %29) : (!type.unk, !type.int) -> !type.unk
-    %31 = "verona.store"(%30, %0) : (!type.unk, !type.alloca) -> !type.unk
+    %28 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %29 = "verona.constant(10)"() : () -> !verona.S64
+    %30 = "verona.div"(%28, %29) : (!verona.unk, !verona.S64) -> !verona.unk
+    %31 = "verona.store"(%30, %0) : (!verona.unk, !verona.unk) -> !verona.unk
     br ^bb12
   ^bb11:  // pred: ^bb8
-    %32 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %33 = "verona.constant(10)"() : () -> !type.int
-    %34 = "verona.eq"(%32, %33) : (!type.unk, !type.int) -> i1
+    %32 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %33 = "verona.constant(10)"() : () -> !verona.S64
+    %34 = "verona.eq"(%32, %33) : (!verona.unk, !verona.S64) -> i1
     cond_br %34, ^bb13, ^bb14
   ^bb12:  // 2 preds: ^bb10, ^bb15
     br ^bb9
   ^bb13:  // pred: ^bb11
-    %35 = "verona.constant(10)"() : () -> !type.int
-    %36 = "verona.store"(%35, %0) : (!type.int, !type.alloca) -> !type.unk
+    %35 = "verona.constant(10)"() : () -> !verona.S64
+    %36 = "verona.store"(%35, %0) : (!verona.S64, !verona.unk) -> !verona.unk
     br ^bb15
   ^bb14:  // pred: ^bb11
-    %37 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %38 = "verona.constant(20)"() : () -> !type.int
-    %39 = "verona.ne"(%37, %38) : (!type.unk, !type.int) -> i1
+    %37 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %38 = "verona.constant(20)"() : () -> !verona.S64
+    %39 = "verona.ne"(%37, %38) : (!verona.unk, !verona.S64) -> i1
     cond_br %39, ^bb16, ^bb17
   ^bb15:  // 2 preds: ^bb13, ^bb18
     br ^bb12
   ^bb16:  // pred: ^bb14
-    %40 = "verona.constant(42)"() : () -> !type.int
-    %41 = "verona.store"(%40, %0) : (!type.int, !type.alloca) -> !type.unk
+    %40 = "verona.constant(42)"() : () -> !verona.S64
+    %41 = "verona.store"(%40, %0) : (!verona.S64, !verona.unk) -> !verona.unk
     br ^bb18
   ^bb17:  // pred: ^bb14
-    %42 = "verona.constant(0)"() : () -> !type.int
-    %43 = "verona.store"(%42, %0) : (!type.int, !type.alloca) -> !type.unk
+    %42 = "verona.constant(0)"() : () -> !verona.S64
+    %43 = "verona.store"(%42, %0) : (!verona.S64, !verona.unk) -> !verona.unk
     br ^bb18
   ^bb18:  // 2 preds: ^bb16, ^bb17
     br ^bb15

--- a/testsuite/mlir/mlir-parse/nested-while/mlir.txt
+++ b/testsuite/mlir/mlir-parse/nested-while/mlir.txt
@@ -2,37 +2,37 @@
 
 module {
   func @f(%arg0: !verona.S64) -> !verona.S64 attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.store"(%arg0, %0) : (!verona.S64, !type.alloca) -> !type.unk
+    %0 = "verona.alloca"() : () -> !verona.unk
+    %1 = "verona.store"(%arg0, %0) : (!verona.S64, !verona.unk) -> !verona.unk
     br ^bb1
   ^bb1:  // 2 preds: ^bb0, ^bb6
-    %2 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %3 = "verona.constant(50)"() : () -> !type.int
-    %4 = "verona.lt"(%2, %3) : (!type.unk, !type.int) -> i1
+    %2 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %3 = "verona.constant(50)"() : () -> !verona.S64
+    %4 = "verona.lt"(%2, %3) : (!verona.unk, !verona.S64) -> i1
     cond_br %4, ^bb2, ^bb3
   ^bb2:  // pred: ^bb1
-    %5 = "verona.alloca"() : () -> !type.alloca
-    %6 = "verona.constant(1)"() : () -> !type.int
-    %7 = "verona.store"(%6, %5) : (!type.int, !type.alloca) -> !type.unk
+    %5 = "verona.alloca"() : () -> !verona.unk
+    %6 = "verona.constant(1)"() : () -> !verona.S64
+    %7 = "verona.store"(%6, %5) : (!verona.S64, !verona.unk) -> !verona.unk
     br ^bb4
   ^bb3:  // pred: ^bb1
-    %8 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %9 = "verona.cast"(%8) : (!type.unk) -> !verona.S64
+    %8 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %9 = "verona.cast"(%8) : (!verona.unk) -> !verona.S64
     return %9 : !verona.S64
   ^bb4:  // 2 preds: ^bb2, ^bb5
-    %10 = "verona.load"(%5) : (!type.alloca) -> !type.unk
-    %11 = "verona.constant(10)"() : () -> !type.int
-    %12 = "verona.lt"(%10, %11) : (!type.unk, !type.int) -> i1
+    %10 = "verona.load"(%5) : (!verona.unk) -> !verona.unk
+    %11 = "verona.constant(10)"() : () -> !verona.S64
+    %12 = "verona.lt"(%10, %11) : (!verona.unk, !verona.S64) -> i1
     cond_br %12, ^bb5, ^bb6
   ^bb5:  // pred: ^bb4
-    %13 = "verona.load"(%5) : (!type.alloca) -> !type.unk
-    %14 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %15 = "verona.add"(%13, %14) : (!type.unk, !type.unk) -> !type.unk
-    %16 = "verona.store"(%15, %5) : (!type.unk, !type.alloca) -> !type.unk
+    %13 = "verona.load"(%5) : (!verona.unk) -> !verona.unk
+    %14 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %15 = "verona.add"(%13, %14) : (!verona.unk, !verona.unk) -> !verona.unk
+    %16 = "verona.store"(%15, %5) : (!verona.unk, !verona.unk) -> !verona.unk
     br ^bb4
   ^bb6:  // pred: ^bb4
-    %17 = "verona.load"(%5) : (!type.alloca) -> !type.unk
-    %18 = "verona.store"(%17, %0) : (!type.unk, !type.alloca) -> !type.unk
+    %17 = "verona.load"(%5) : (!verona.unk) -> !verona.unk
+    %18 = "verona.store"(%17, %0) : (!verona.unk, !verona.unk) -> !verona.unk
     br ^bb1
   }
 }

--- a/testsuite/mlir/mlir-parse/types/mlir.txt
+++ b/testsuite/mlir/mlir-parse/types/mlir.txt
@@ -2,14 +2,14 @@
 
 module {
   func @foo(%arg0: !verona.meet<S32, iso>, %arg1: !verona.meet<U64, imm>) -> !verona.join<meet<S32, iso>, meet<U64, imm>, meet<U32, mut>> attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.store"(%arg0, %0) : (!verona.meet<S32, iso>, !type.alloca) -> !type.unk
-    %2 = "verona.alloca"() : () -> !type.alloca
-    %3 = "verona.store"(%arg1, %2) : (!verona.meet<U64, imm>, !type.alloca) -> !type.unk
-    %4 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %5 = "verona.load"(%2) : (!type.alloca) -> !type.unk
-    %6 = "verona.add"(%4, %5) : (!type.unk, !type.unk) -> !type.unk
-    %7 = "verona.cast"(%6) : (!type.unk) -> !verona.join<meet<S32, iso>, meet<U64, imm>, meet<U32, mut>>
+    %0 = "verona.alloca"() : () -> !verona.unk
+    %1 = "verona.store"(%arg0, %0) : (!verona.meet<S32, iso>, !verona.unk) -> !verona.unk
+    %2 = "verona.alloca"() : () -> !verona.unk
+    %3 = "verona.store"(%arg1, %2) : (!verona.meet<U64, imm>, !verona.unk) -> !verona.unk
+    %4 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %5 = "verona.load"(%2) : (!verona.unk) -> !verona.unk
+    %6 = "verona.add"(%4, %5) : (!verona.unk, !verona.unk) -> !verona.unk
+    %7 = "verona.cast"(%6) : (!verona.unk) -> !verona.join<meet<S32, iso>, meet<U64, imm>, meet<U32, mut>>
     return %7 : !verona.join<meet<S32, iso>, meet<U64, imm>, meet<U32, mut>>
   }
 }

--- a/testsuite/mlir/mlir-parse/while-cont-brk/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while-cont-brk/mlir.txt
@@ -2,35 +2,35 @@
 
 module {
   func @f(%arg0: !verona.U32, %arg1: !verona.S32) -> !verona.F16 attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.store"(%arg0, %0) : (!verona.U32, !type.alloca) -> !type.unk
-    %2 = "verona.alloca"() : () -> !type.alloca
-    %3 = "verona.store"(%arg1, %2) : (!verona.S32, !type.alloca) -> !type.unk
+    %0 = "verona.alloca"() : () -> !verona.unk
+    %1 = "verona.store"(%arg0, %0) : (!verona.U32, !verona.unk) -> !verona.unk
+    %2 = "verona.alloca"() : () -> !verona.unk
+    %3 = "verona.store"(%arg1, %2) : (!verona.S32, !verona.unk) -> !verona.unk
     br ^bb1
   ^bb1:  // 3 preds: ^bb0, ^bb4, ^bb7
-    %4 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %5 = "verona.constant(5)"() : () -> !type.int
-    %6 = "verona.lt"(%4, %5) : (!type.unk, !type.int) -> i1
+    %4 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %5 = "verona.constant(5)"() : () -> !verona.S64
+    %6 = "verona.lt"(%4, %5) : (!verona.unk, !verona.S64) -> i1
     cond_br %6, ^bb2, ^bb3
   ^bb2:  // pred: ^bb1
-    %7 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %8 = "verona.constant(1)"() : () -> !type.int
-    %9 = "verona.add"(%7, %8) : (!type.unk, !type.int) -> !type.unk
-    %10 = "verona.store"(%9, %0) : (!type.unk, !type.alloca) -> !type.unk
-    %11 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %12 = "verona.load"(%2) : (!type.alloca) -> !type.unk
-    %13 = "verona.lt"(%11, %12) : (!type.unk, !type.unk) -> i1
+    %7 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %8 = "verona.constant(1)"() : () -> !verona.S64
+    %9 = "verona.add"(%7, %8) : (!verona.unk, !verona.S64) -> !verona.unk
+    %10 = "verona.store"(%9, %0) : (!verona.unk, !verona.unk) -> !verona.unk
+    %11 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %12 = "verona.load"(%2) : (!verona.unk) -> !verona.unk
+    %13 = "verona.lt"(%11, %12) : (!verona.unk, !verona.unk) -> i1
     cond_br %13, ^bb4, ^bb5
   ^bb3:  // 2 preds: ^bb1, ^bb6
-    %14 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %15 = "verona.cast"(%14) : (!type.unk) -> !verona.F16
+    %14 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %15 = "verona.cast"(%14) : (!verona.unk) -> !verona.F16
     return %15 : !verona.F16
   ^bb4:  // pred: ^bb2
     br ^bb1
   ^bb5:  // pred: ^bb2
-    %16 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %17 = "verona.load"(%2) : (!type.alloca) -> !type.unk
-    %18 = "verona.gt"(%16, %17) : (!type.unk, !type.unk) -> i1
+    %16 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %17 = "verona.load"(%2) : (!verona.unk) -> !verona.unk
+    %18 = "verona.gt"(%16, %17) : (!verona.unk, !verona.unk) -> i1
     cond_br %18, ^bb6, ^bb7
   ^bb6:  // pred: ^bb5
     br ^bb3

--- a/testsuite/mlir/mlir-parse/while-context/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while-context/mlir.txt
@@ -2,34 +2,34 @@
 
 module {
   func @f(%arg0: !verona.F32) -> !verona.F64 attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.store"(%arg0, %0) : (!verona.F32, !type.alloca) -> !type.unk
-    %2 = "verona.alloca"() : () -> !type.alloca
-    %3 = "verona.constant(1)"() : () -> !type.int
-    %4 = "verona.store"(%3, %2) : (!type.int, !type.alloca) -> !type.unk
+    %0 = "verona.alloca"() : () -> !verona.unk
+    %1 = "verona.store"(%arg0, %0) : (!verona.F32, !verona.unk) -> !verona.unk
+    %2 = "verona.alloca"() : () -> !verona.unk
+    %3 = "verona.constant(1)"() : () -> !verona.S64
+    %4 = "verona.store"(%3, %2) : (!verona.S64, !verona.unk) -> !verona.unk
     br ^bb1
   ^bb1:  // 2 preds: ^bb0, ^bb2
-    %5 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %6 = "verona.constant(5)"() : () -> !type.int
-    %7 = "verona.lt"(%5, %6) : (!type.unk, !type.int) -> i1
+    %5 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %6 = "verona.constant(5)"() : () -> !verona.S64
+    %7 = "verona.lt"(%5, %6) : (!verona.unk, !verona.S64) -> i1
     cond_br %7, ^bb2, ^bb3
   ^bb2:  // pred: ^bb1
-    %8 = "verona.alloca"() : () -> !type.alloca
-    %9 = "verona.constant(2)"() : () -> !type.int
-    %10 = "verona.store"(%9, %8) : (!type.int, !type.alloca) -> !type.unk
-    %11 = "verona.alloca"() : () -> !type.alloca
-    %12 = "verona.load"(%8) : (!type.alloca) -> !type.unk
-    %13 = "verona.constant(3)"() : () -> !type.int
-    %14 = "verona.add"(%12, %13) : (!type.unk, !type.int) -> !type.unk
-    %15 = "verona.store"(%14, %11) : (!type.unk, !type.alloca) -> !type.unk
-    %16 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %17 = "verona.load"(%11) : (!type.alloca) -> !type.unk
-    %18 = "verona.add"(%16, %17) : (!type.unk, !type.unk) -> !type.unk
-    %19 = "verona.store"(%18, %0) : (!type.unk, !type.alloca) -> !type.unk
+    %8 = "verona.alloca"() : () -> !verona.unk
+    %9 = "verona.constant(2)"() : () -> !verona.S64
+    %10 = "verona.store"(%9, %8) : (!verona.S64, !verona.unk) -> !verona.unk
+    %11 = "verona.alloca"() : () -> !verona.unk
+    %12 = "verona.load"(%8) : (!verona.unk) -> !verona.unk
+    %13 = "verona.constant(3)"() : () -> !verona.S64
+    %14 = "verona.add"(%12, %13) : (!verona.unk, !verona.S64) -> !verona.unk
+    %15 = "verona.store"(%14, %11) : (!verona.unk, !verona.unk) -> !verona.unk
+    %16 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %17 = "verona.load"(%11) : (!verona.unk) -> !verona.unk
+    %18 = "verona.add"(%16, %17) : (!verona.unk, !verona.unk) -> !verona.unk
+    %19 = "verona.store"(%18, %0) : (!verona.unk, !verona.unk) -> !verona.unk
     br ^bb1
   ^bb3:  // pred: ^bb1
-    %20 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %21 = "verona.cast"(%20) : (!type.unk) -> !verona.F64
+    %20 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %21 = "verona.cast"(%20) : (!verona.unk) -> !verona.F64
     return %21 : !verona.F64
   }
 }

--- a/testsuite/mlir/mlir-parse/while-if/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while-if/mlir.txt
@@ -2,30 +2,30 @@
 
 module {
   func @f(%arg0: !verona.U32, %arg1: !verona.S32) -> !verona.U32 attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.store"(%arg0, %0) : (!verona.U32, !type.alloca) -> !type.unk
-    %2 = "verona.alloca"() : () -> !type.alloca
-    %3 = "verona.store"(%arg1, %2) : (!verona.S32, !type.alloca) -> !type.unk
+    %0 = "verona.alloca"() : () -> !verona.unk
+    %1 = "verona.store"(%arg0, %0) : (!verona.U32, !verona.unk) -> !verona.unk
+    %2 = "verona.alloca"() : () -> !verona.unk
+    %3 = "verona.store"(%arg1, %2) : (!verona.S32, !verona.unk) -> !verona.unk
     br ^bb1
   ^bb1:  // 2 preds: ^bb0, ^bb5
-    %4 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %5 = "verona.constant(5)"() : () -> !type.int
-    %6 = "verona.lt"(%4, %5) : (!type.unk, !type.int) -> i1
+    %4 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %5 = "verona.constant(5)"() : () -> !verona.S64
+    %6 = "verona.lt"(%4, %5) : (!verona.unk, !verona.S64) -> i1
     cond_br %6, ^bb2, ^bb3
   ^bb2:  // pred: ^bb1
-    %7 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %8 = "verona.load"(%2) : (!type.alloca) -> !type.unk
-    %9 = "verona.ne"(%7, %8) : (!type.unk, !type.unk) -> i1
+    %7 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %8 = "verona.load"(%2) : (!verona.unk) -> !verona.unk
+    %9 = "verona.ne"(%7, %8) : (!verona.unk, !verona.unk) -> i1
     cond_br %9, ^bb4, ^bb5
   ^bb3:  // pred: ^bb1
-    %10 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %11 = "verona.cast"(%10) : (!type.unk) -> !verona.U32
+    %10 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %11 = "verona.cast"(%10) : (!verona.unk) -> !verona.U32
     return %11 : !verona.U32
   ^bb4:  // pred: ^bb2
-    %12 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %13 = "verona.constant(1)"() : () -> !type.int
-    %14 = "verona.add"(%12, %13) : (!type.unk, !type.int) -> !type.unk
-    %15 = "verona.store"(%14, %0) : (!type.unk, !type.alloca) -> !type.unk
+    %12 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %13 = "verona.constant(1)"() : () -> !verona.S64
+    %14 = "verona.add"(%12, %13) : (!verona.unk, !verona.S64) -> !verona.unk
+    %15 = "verona.store"(%14, %0) : (!verona.unk, !verona.unk) -> !verona.unk
     br ^bb5
   ^bb5:  // 2 preds: ^bb2, ^bb4
     br ^bb1

--- a/testsuite/mlir/mlir-parse/while/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while/mlir.txt
@@ -2,35 +2,35 @@
 
 module {
   func @f(%arg0: !verona.U32) -> !verona.U32 attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !type.alloca
-    %1 = "verona.store"(%arg0, %0) : (!verona.U32, !type.alloca) -> !type.unk
+    %0 = "verona.alloca"() : () -> !verona.unk
+    %1 = "verona.store"(%arg0, %0) : (!verona.U32, !verona.unk) -> !verona.unk
     br ^bb1
   ^bb1:  // 2 preds: ^bb0, ^bb2
-    %2 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %3 = "verona.constant(5)"() : () -> !type.int
-    %4 = "verona.lt"(%2, %3) : (!type.unk, !type.int) -> i1
+    %2 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %3 = "verona.constant(5)"() : () -> !verona.S64
+    %4 = "verona.lt"(%2, %3) : (!verona.unk, !verona.S64) -> i1
     cond_br %4, ^bb2, ^bb3
   ^bb2:  // pred: ^bb1
-    %5 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %6 = "verona.constant(1)"() : () -> !type.int
-    %7 = "verona.add"(%5, %6) : (!type.unk, !type.int) -> !type.unk
-    %8 = "verona.store"(%7, %0) : (!type.unk, !type.alloca) -> !type.unk
+    %5 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %6 = "verona.constant(1)"() : () -> !verona.S64
+    %7 = "verona.add"(%5, %6) : (!verona.unk, !verona.S64) -> !verona.unk
+    %8 = "verona.store"(%7, %0) : (!verona.unk, !verona.unk) -> !verona.unk
     br ^bb1
   ^bb3:  // pred: ^bb1
     br ^bb4
   ^bb4:  // 2 preds: ^bb3, ^bb5
-    %9 = "verona.constant(false)"() : () -> !type.bool
-    %10 = "verona.cast"(%9) : (!type.bool) -> i1
+    %9 = "verona.constant(false)"() : () -> !verona.bool
+    %10 = "verona.cast"(%9) : (!verona.bool) -> i1
     cond_br %10, ^bb5, ^bb6
   ^bb5:  // pred: ^bb4
-    %11 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %12 = "verona.constant(1)"() : () -> !type.int
-    %13 = "verona.sub"(%11, %12) : (!type.unk, !type.int) -> !type.unk
-    %14 = "verona.store"(%13, %0) : (!type.unk, !type.alloca) -> !type.unk
+    %11 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %12 = "verona.constant(1)"() : () -> !verona.S64
+    %13 = "verona.sub"(%11, %12) : (!verona.unk, !verona.S64) -> !verona.unk
+    %14 = "verona.store"(%13, %0) : (!verona.unk, !verona.unk) -> !verona.unk
     br ^bb4
   ^bb6:  // pred: ^bb4
-    %15 = "verona.load"(%0) : (!type.alloca) -> !type.unk
-    %16 = "verona.cast"(%15) : (!type.unk) -> !verona.U32
+    %15 = "verona.load"(%0) : (!verona.unk) -> !verona.unk
+    %16 = "verona.cast"(%15) : (!verona.unk) -> !verona.U32
     return %16 : !verona.U32
   }
 }


### PR DESCRIPTION
Adding the unknown type to the Verona dialect to allow use in dialect operations. The opaque types could only really work with opaque "operations" and as we phase them out, we'll need a proper unknown type to run type inference over.

All opaque types removed, including literals and compile generate functions.

This refactoring was necessary to add support for new dialect constructs: `tidy` and `drop`. Given they're special dialect operations and not function calls, we need to special treat them early on.

Continues implementing #280.