### PR TITLE
Adding field_read / field_write

### DIFF
--- a/src/mlir/dialect/Typechecker.cc
+++ b/src/mlir/dialect/Typechecker.cc
@@ -117,7 +117,10 @@ namespace mlir::verona
   /// `RULES` is a callable object, which takes two Type values and returns a
   /// boolean.
   static constexpr auto RULES = detail::combineRules(
-    [](Type left, Type right) { return left == right; },
+    [](Type left, Type right) {
+      return left == right || left.isa<UnknownType>() ||
+        right.isa<UnknownType>();
+    },
     [](JoinType left, Type right) {
       return llvm::all_of(left.getElements(), [&](Type element) {
         return isSubtype(element, right);

--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -221,6 +221,11 @@ namespace mlir::verona
     llvm::Expected<ReturnValue> parseReturn(const ::ast::Ast& ast);
     /// Parses a 'new' statement.
     llvm::Expected<ReturnValue> parseNew(const ::ast::Ast& ast);
+    /// Parses a '.' statement for reading.
+    llvm::Expected<ReturnValue> parseFieldRead(const ::ast::Ast& ast);
+    /// Parses a '.' statement for writing.
+    llvm::Expected<ReturnValue>
+    parseFieldWrite(const ::ast::Ast& ast, mlir::Value value);
 
     // ============================================================== Generators
     // These methods build complex MLIR constructs from parameters either

--- a/testsuite/mlir/mlir-parse/call/mlir.txt
+++ b/testsuite/mlir/mlir-parse/call/mlir.txt
@@ -32,14 +32,12 @@ module {
   }
   func @apply() attributes {class = !verona.class<"$module">} {
     %0 = "verona.constant(10)"() : () -> !verona.S64
-    %1 = "verona.alloca"() : () -> !verona.S64
-    %2 = "verona.store"(%0, %1) : (!verona.S64, !verona.S64) -> !verona.unknown
+    %1 = "verona.alloca"() : () -> !verona.imm
+    %2 = "verona.store"(%0, %1) : (!verona.S64, !verona.imm) -> !verona.unknown
     %3 = "verona.constant(20)"() : () -> !verona.S64
-    %4 = "verona.alloca"() : () -> !verona.S64
-    %5 = "verona.store"(%3, %4) : (!verona.S64, !verona.S64) -> !verona.unknown
-    %6 = "verona.cast"(%1) : (!verona.S64) -> !verona.imm
-    %7 = "verona.cast"(%4) : (!verona.S64) -> !verona.meet<U64, imm>
-    %8 = call @foo(%6, %7) : (!verona.imm, !verona.meet<U64, imm>) -> !verona.meet<U64, imm>
+    %4 = "verona.alloca"() : () -> !verona.meet<U64, imm>
+    %5 = "verona.store"(%3, %4) : (!verona.S64, !verona.meet<U64, imm>) -> !verona.unknown
+    %6 = call @foo(%1, %4) : (!verona.imm, !verona.meet<U64, imm>) -> !verona.meet<U64, imm>
     return
   }
 }

--- a/testsuite/mlir/mlir-parse/class.verona
+++ b/testsuite/mlir/mlir-parse/class.verona
@@ -50,6 +50,14 @@ bar(c: C, d: D, e: E, ne: NestE, f: F, g: G) {
   let p : POD & iso = new POD { a = 42; b = 3.14; };
   // Allocate a POD class, in region
   let q : POD & iso = new POD { a = 21; b = 2.72; } in p;
+
+  // Field read / write
+  let var1: U32 & mut = p.a;
+  let var2: U32 & mut = q.a;
+  q.a = var1 + var2;
+  p.a = q.a;
+  q.a = (p.a = 1337);
+
   // Garbage collect
   tidy(c);
   // Drop value

--- a/testsuite/mlir/mlir-parse/class/mlir.txt
+++ b/testsuite/mlir/mlir-parse/class/mlir.txt
@@ -22,21 +22,35 @@ module {
     %10 = "verona.alloca"() : () -> !verona.class<"G", "$parent" : class<"$module">>
     %11 = "verona.store"(%arg5, %10) : (!verona.class<"G", "$parent" : class<"$module">>, !verona.class<"G", "$parent" : class<"$module">>) -> !verona.unknown
     %12 = verona.new_region @C [] : !verona.class<"C", "$parent" : class<"$module">>
-    %13 = "verona.alloca"() : () -> !verona.class<"C", "$parent" : class<"$module">>
-    %14 = "verona.store"(%12, %13) : (!verona.class<"C", "$parent" : class<"$module">>, !verona.class<"C", "$parent" : class<"$module">>) -> !verona.unknown
-    %15 = verona.new_object @C [] in(%13 : !verona.class<"C", "$parent" : class<"$module">>) : !verona.class<"C", "$parent" : class<"$module">>
-    %16 = "verona.alloca"() : () -> !verona.class<"C", "$parent" : class<"$module">>
-    %17 = "verona.store"(%15, %16) : (!verona.class<"C", "$parent" : class<"$module">>, !verona.class<"C", "$parent" : class<"$module">>) -> !verona.unknown
+    %13 = "verona.alloca"() : () -> !verona.meet<class<"C", "$parent" : class<"$module">>, iso>
+    %14 = "verona.store"(%12, %13) : (!verona.class<"C", "$parent" : class<"$module">>, !verona.meet<class<"C", "$parent" : class<"$module">>, iso>) -> !verona.unknown
+    %15 = verona.new_object @C [] in(%13 : !verona.meet<class<"C", "$parent" : class<"$module">>, iso>) : !verona.class<"C", "$parent" : class<"$module">>
+    %16 = "verona.alloca"() : () -> !verona.meet<class<"C", "$parent" : class<"$module">>, iso>
+    %17 = "verona.store"(%15, %16) : (!verona.class<"C", "$parent" : class<"$module">>, !verona.meet<class<"C", "$parent" : class<"$module">>, iso>) -> !verona.unknown
     %18 = "verona.constant(42)"() : () -> !verona.S64
     %19 = "verona.constant(3.14)"() : () -> !verona.F64
     %20 = verona.new_region @POD ["a", "b"](%18, %19 : !verona.S64, !verona.F64) : !verona.class<"POD", "$parent" : class<"$module">, "a" : U32, "b" : F64>
-    %21 = "verona.alloca"() : () -> !verona.class<"POD", "$parent" : class<"$module">, "a" : U32, "b" : F64>
-    %22 = "verona.store"(%20, %21) : (!verona.class<"POD", "$parent" : class<"$module">, "a" : U32, "b" : F64>, !verona.class<"POD", "$parent" : class<"$module">, "a" : U32, "b" : F64>) -> !verona.unknown
+    %21 = "verona.alloca"() : () -> !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : U32, "b" : F64>, iso>
+    %22 = "verona.store"(%20, %21) : (!verona.class<"POD", "$parent" : class<"$module">, "a" : U32, "b" : F64>, !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : U32, "b" : F64>, iso>) -> !verona.unknown
     %23 = "verona.constant(21)"() : () -> !verona.S64
     %24 = "verona.constant(2.72)"() : () -> !verona.F64
-    %25 = verona.new_object @POD ["a", "b"](%23, %24 : !verona.S64, !verona.F64) in(%21 : !verona.class<"POD", "$parent" : class<"$module">, "a" : U32, "b" : F64>) : !verona.class<"POD", "$parent" : class<"$module">, "a" : U32, "b" : F64>
-    %26 = "verona.alloca"() : () -> !verona.class<"POD", "$parent" : class<"$module">, "a" : U32, "b" : F64>
-    %27 = "verona.store"(%25, %26) : (!verona.class<"POD", "$parent" : class<"$module">, "a" : U32, "b" : F64>, !verona.class<"POD", "$parent" : class<"$module">, "a" : U32, "b" : F64>) -> !verona.unknown
+    %25 = verona.new_object @POD ["a", "b"](%23, %24 : !verona.S64, !verona.F64) in(%21 : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : U32, "b" : F64>, iso>) : !verona.class<"POD", "$parent" : class<"$module">, "a" : U32, "b" : F64>
+    %26 = "verona.alloca"() : () -> !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : U32, "b" : F64>, iso>
+    %27 = "verona.store"(%25, %26) : (!verona.class<"POD", "$parent" : class<"$module">, "a" : U32, "b" : F64>, !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : U32, "b" : F64>, iso>) -> !verona.unknown
+    %28 = verona.field_read %21["a"] : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : U32, "b" : F64>, iso> -> !verona.unknown
+    %29 = "verona.alloca"() : () -> !verona.meet<U32, mut>
+    %30 = "verona.store"(%28, %29) : (!verona.unknown, !verona.meet<U32, mut>) -> !verona.unknown
+    %31 = verona.field_read %26["a"] : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : U32, "b" : F64>, iso> -> !verona.unknown
+    %32 = "verona.alloca"() : () -> !verona.meet<U32, mut>
+    %33 = "verona.store"(%31, %32) : (!verona.unknown, !verona.meet<U32, mut>) -> !verona.unknown
+    %34 = "verona.add"(%29, %32) : (!verona.meet<U32, mut>, !verona.meet<U32, mut>) -> !verona.unknown
+    %35 = verona.field_write %26["a"], %34 : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : U32, "b" : F64>, iso> -> !verona.unknown -> !verona.unknown
+    %36 = verona.field_read %26["a"] : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : U32, "b" : F64>, iso> -> !verona.unknown
+    %37 = verona.field_write %21["a"], %36 : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : U32, "b" : F64>, iso> -> !verona.unknown -> !verona.unknown
+    %38 = "verona.constant(1337)"() : () -> !verona.S64
+    %39 = "verona.cast"(%38) : (!verona.S64) -> !verona.unknown
+    %40 = verona.field_write %21["a"], %39 : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : U32, "b" : F64>, iso> -> !verona.unknown -> !verona.unknown
+    %41 = verona.field_write %26["a"], %40 : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : U32, "b" : F64>, iso> -> !verona.unknown -> !verona.unknown
     verona.tidy %0 : !verona.class<"C", "$parent" : class<"$module">>
     verona.drop %2 : !verona.class<"D", "$parent" : class<"$module">, "f" : meet<U64, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : F32, "i" : F64, "j" : bool>
     return

--- a/testsuite/mlir/mlir-parse/constant/mlir.txt
+++ b/testsuite/mlir/mlir-parse/constant/mlir.txt
@@ -3,35 +3,35 @@
 module {
   func @f() attributes {class = !verona.class<"$module">} {
     %0 = "verona.constant(42)"() : () -> !verona.S64
-    %1 = "verona.alloca"() : () -> !verona.S64
-    %2 = "verona.store"(%0, %1) : (!verona.S64, !verona.S64) -> !verona.unknown
+    %1 = "verona.alloca"() : () -> !verona.unknown
+    %2 = "verona.store"(%0, %1) : (!verona.S64, !verona.unknown) -> !verona.unknown
     %3 = "verona.constant(3.1415)"() : () -> !verona.F64
-    %4 = "verona.alloca"() : () -> !verona.F64
-    %5 = "verona.store"(%3, %4) : (!verona.F64, !verona.F64) -> !verona.unknown
+    %4 = "verona.alloca"() : () -> !verona.unknown
+    %5 = "verona.store"(%3, %4) : (!verona.F64, !verona.unknown) -> !verona.unknown
     %6 = "verona.constant(true)"() : () -> !verona.bool
-    %7 = "verona.alloca"() : () -> !verona.bool
-    %8 = "verona.store"(%6, %7) : (!verona.bool, !verona.bool) -> !verona.unknown
+    %7 = "verona.alloca"() : () -> !verona.unknown
+    %8 = "verona.store"(%6, %7) : (!verona.bool, !verona.unknown) -> !verona.unknown
     %9 = "verona.constant(0xAE)"() : () -> !verona.U64
-    %10 = "verona.alloca"() : () -> !verona.U64
-    %11 = "verona.store"(%9, %10) : (!verona.U64, !verona.U64) -> !verona.unknown
+    %10 = "verona.alloca"() : () -> !verona.unknown
+    %11 = "verona.store"(%9, %10) : (!verona.U64, !verona.unknown) -> !verona.unknown
     %12 = "verona.constant(0b11011)"() : () -> !verona.U64
-    %13 = "verona.alloca"() : () -> !verona.U64
-    %14 = "verona.store"(%12, %13) : (!verona.U64, !verona.U64) -> !verona.unknown
+    %13 = "verona.alloca"() : () -> !verona.unknown
+    %14 = "verona.store"(%12, %13) : (!verona.U64, !verona.unknown) -> !verona.unknown
     %15 = "verona.constant(42)"() : () -> !verona.S64
-    %16 = "verona.alloca"() : () -> !verona.S64
-    %17 = "verona.store"(%15, %16) : (!verona.S64, !verona.S64) -> !verona.unknown
+    %16 = "verona.alloca"() : () -> !verona.S32
+    %17 = "verona.store"(%15, %16) : (!verona.S64, !verona.S32) -> !verona.unknown
     %18 = "verona.constant(3.1415)"() : () -> !verona.F64
-    %19 = "verona.alloca"() : () -> !verona.F64
-    %20 = "verona.store"(%18, %19) : (!verona.F64, !verona.F64) -> !verona.unknown
+    %19 = "verona.alloca"() : () -> !verona.F32
+    %20 = "verona.store"(%18, %19) : (!verona.F64, !verona.F32) -> !verona.unknown
     %21 = "verona.constant(false)"() : () -> !verona.bool
     %22 = "verona.alloca"() : () -> !verona.bool
     %23 = "verona.store"(%21, %22) : (!verona.bool, !verona.bool) -> !verona.unknown
     %24 = "verona.constant(0xDEADBEEF)"() : () -> !verona.U64
-    %25 = "verona.alloca"() : () -> !verona.U64
-    %26 = "verona.store"(%24, %25) : (!verona.U64, !verona.U64) -> !verona.unknown
+    %25 = "verona.alloca"() : () -> !verona.U32
+    %26 = "verona.store"(%24, %25) : (!verona.U64, !verona.U32) -> !verona.unknown
     %27 = "verona.constant(0b1)"() : () -> !verona.U64
-    %28 = "verona.alloca"() : () -> !verona.U64
-    %29 = "verona.store"(%27, %28) : (!verona.U64, !verona.U64) -> !verona.unknown
+    %28 = "verona.alloca"() : () -> !verona.bool
+    %29 = "verona.store"(%27, %28) : (!verona.U64, !verona.bool) -> !verona.unknown
     return
   }
 }

--- a/testsuite/mlir/mlir-parse/for/mlir.txt
+++ b/testsuite/mlir/mlir-parse/for/mlir.txt
@@ -9,8 +9,8 @@ module {
     %0 = "verona.alloca"() : () -> !verona.U64
     %1 = "verona.store"(%arg0, %0) : (!verona.U64, !verona.U64) -> !verona.unknown
     %2 = "verona.constant(0)"() : () -> !verona.S64
-    %3 = "verona.alloca"() : () -> !verona.S64
-    %4 = "verona.store"(%2, %3) : (!verona.S64, !verona.S64) -> !verona.unknown
+    %3 = "verona.alloca"() : () -> !verona.S32
+    %4 = "verona.store"(%2, %3) : (!verona.S64, !verona.S32) -> !verona.unknown
     br ^bb2
   ^bb1:  // pred: ^bb3
     call @next(%0) : (!verona.U64) -> ()
@@ -31,8 +31,8 @@ module {
     %0 = "verona.alloca"() : () -> !verona.U64
     %1 = "verona.store"(%arg0, %0) : (!verona.U64, !verona.U64) -> !verona.unknown
     %2 = "verona.constant(0)"() : () -> !verona.S64
-    %3 = "verona.alloca"() : () -> !verona.S64
-    %4 = "verona.store"(%2, %3) : (!verona.S64, !verona.S64) -> !verona.unknown
+    %3 = "verona.alloca"() : () -> !verona.S32
+    %4 = "verona.store"(%2, %3) : (!verona.S64, !verona.S32) -> !verona.unknown
     br ^bb2
   ^bb1:  // 2 preds: ^bb7, ^bb8
     call @next(%0) : (!verona.U64) -> ()

--- a/testsuite/mlir/mlir-parse/function/mlir.txt
+++ b/testsuite/mlir/mlir-parse/function/mlir.txt
@@ -16,8 +16,8 @@ module {
     %5 = "verona.alloca"() : () -> !verona.unknown
     %6 = "verona.store"(%4, %5) : (!verona.unknown, !verona.unknown) -> !verona.unknown
     %7 = "verona.load"(%5) : (!verona.unknown) -> !verona.unknown
-    %8 = "verona.alloca"() : () -> !verona.unknown
-    %9 = "verona.store"(%7, %8) : (!verona.unknown, !verona.unknown) -> !verona.unknown
+    %8 = "verona.alloca"() : () -> !verona.meet<U64, imm>
+    %9 = "verona.store"(%7, %8) : (!verona.unknown, !verona.meet<U64, imm>) -> !verona.unknown
     %10 = "verona.load"(%5) : (!verona.unknown) -> !verona.unknown
     %11 = "verona.cast"(%10) : (!verona.unknown) -> !verona.meet<U64, imm>
     return %11 : !verona.meet<U64, imm>

--- a/testsuite/mlir/mlir-parse/nested-while/mlir.txt
+++ b/testsuite/mlir/mlir-parse/nested-while/mlir.txt
@@ -11,21 +11,24 @@ module {
     cond_br %3, ^bb2, ^bb3
   ^bb2:  // pred: ^bb1
     %4 = "verona.constant(1)"() : () -> !verona.S64
-    %5 = "verona.alloca"() : () -> !verona.S64
-    %6 = "verona.store"(%4, %5) : (!verona.S64, !verona.S64) -> !verona.unknown
+    %5 = "verona.alloca"() : () -> !verona.unknown
+    %6 = "verona.store"(%4, %5) : (!verona.S64, !verona.unknown) -> !verona.unknown
     br ^bb4
   ^bb3:  // pred: ^bb1
     return %0 : !verona.S64
   ^bb4:  // 2 preds: ^bb2, ^bb5
-    %7 = "verona.constant(10)"() : () -> !verona.S64
-    %8 = "verona.lt"(%5, %7) : (!verona.S64, !verona.S64) -> i1
-    cond_br %8, ^bb5, ^bb6
+    %7 = "verona.load"(%5) : (!verona.unknown) -> !verona.unknown
+    %8 = "verona.constant(10)"() : () -> !verona.S64
+    %9 = "verona.lt"(%7, %8) : (!verona.unknown, !verona.S64) -> i1
+    cond_br %9, ^bb5, ^bb6
   ^bb5:  // pred: ^bb4
-    %9 = "verona.add"(%5, %0) : (!verona.S64, !verona.S64) -> !verona.unknown
-    %10 = "verona.store"(%9, %5) : (!verona.unknown, !verona.S64) -> !verona.unknown
+    %10 = "verona.load"(%5) : (!verona.unknown) -> !verona.unknown
+    %11 = "verona.add"(%10, %0) : (!verona.unknown, !verona.S64) -> !verona.unknown
+    %12 = "verona.store"(%11, %5) : (!verona.unknown, !verona.unknown) -> !verona.unknown
     br ^bb4
   ^bb6:  // pred: ^bb4
-    %11 = "verona.store"(%5, %0) : (!verona.S64, !verona.S64) -> !verona.unknown
+    %13 = "verona.load"(%5) : (!verona.unknown) -> !verona.unknown
+    %14 = "verona.store"(%13, %0) : (!verona.unknown, !verona.S64) -> !verona.unknown
     br ^bb1
   }
 }

--- a/testsuite/mlir/mlir-parse/while-context/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while-context/mlir.txt
@@ -5,8 +5,8 @@ module {
     %0 = "verona.alloca"() : () -> !verona.F32
     %1 = "verona.store"(%arg0, %0) : (!verona.F32, !verona.F32) -> !verona.unknown
     %2 = "verona.constant(1)"() : () -> !verona.S64
-    %3 = "verona.alloca"() : () -> !verona.S64
-    %4 = "verona.store"(%2, %3) : (!verona.S64, !verona.S64) -> !verona.unknown
+    %3 = "verona.alloca"() : () -> !verona.unknown
+    %4 = "verona.store"(%2, %3) : (!verona.S64, !verona.unknown) -> !verona.unknown
     br ^bb1
   ^bb1:  // 2 preds: ^bb0, ^bb2
     %5 = "verona.constant(5)"() : () -> !verona.S64
@@ -14,18 +14,19 @@ module {
     cond_br %6, ^bb2, ^bb3
   ^bb2:  // pred: ^bb1
     %7 = "verona.constant(2)"() : () -> !verona.S64
-    %8 = "verona.alloca"() : () -> !verona.S64
-    %9 = "verona.store"(%7, %8) : (!verona.S64, !verona.S64) -> !verona.unknown
-    %10 = "verona.constant(3)"() : () -> !verona.S64
-    %11 = "verona.add"(%8, %10) : (!verona.S64, !verona.S64) -> !verona.unknown
-    %12 = "verona.alloca"() : () -> !verona.unknown
-    %13 = "verona.store"(%11, %12) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    %14 = "verona.load"(%12) : (!verona.unknown) -> !verona.unknown
-    %15 = "verona.add"(%0, %14) : (!verona.F32, !verona.unknown) -> !verona.unknown
-    %16 = "verona.store"(%15, %0) : (!verona.unknown, !verona.F32) -> !verona.unknown
+    %8 = "verona.alloca"() : () -> !verona.unknown
+    %9 = "verona.store"(%7, %8) : (!verona.S64, !verona.unknown) -> !verona.unknown
+    %10 = "verona.load"(%8) : (!verona.unknown) -> !verona.unknown
+    %11 = "verona.constant(3)"() : () -> !verona.S64
+    %12 = "verona.add"(%10, %11) : (!verona.unknown, !verona.S64) -> !verona.unknown
+    %13 = "verona.alloca"() : () -> !verona.unknown
+    %14 = "verona.store"(%12, %13) : (!verona.unknown, !verona.unknown) -> !verona.unknown
+    %15 = "verona.load"(%13) : (!verona.unknown) -> !verona.unknown
+    %16 = "verona.add"(%0, %15) : (!verona.F32, !verona.unknown) -> !verona.unknown
+    %17 = "verona.store"(%16, %0) : (!verona.unknown, !verona.F32) -> !verona.unknown
     br ^bb1
   ^bb3:  // pred: ^bb1
-    %17 = "verona.cast"(%0) : (!verona.F32) -> !verona.F64
-    return %17 : !verona.F64
+    %18 = "verona.cast"(%0) : (!verona.F32) -> !verona.F64
+    return %18 : !verona.F64
   }
 }


### PR DESCRIPTION
Implementing field read/write for some simple cases. Not all options covered
yet. We have a few examples that show the mechanism working, but there
are a few cases that are not covered. The main impediment right now is
the viewpoint validation that fails to check some cases.

Before we enbark on a full check of the actual pass, we need to make
sure the types we're generating early (including unknown) will ever be
seen by these passes or the type inference (not implemented yet) will have
cleaned enough of them.

Additional work:
 * Adding assignment type from let's declaration, when available by
   processing the RHS first and only updating the type if the
   declaration has one.
 * Created a class-type extraction utility to field_read from lets so we
   can find the class extraction point even from complex type structure
   (meets of joint, joins of meets, etc)
 * Propagate types through opaque operations (see below).

Propagate types through opaque operations

This propagates types through most operations to avoid the type check
from failing at unknown types. Perhaps we should change the unknown type
to pass any initial type check, perhaps we won't evern get to a type
check with unknowns, but right now, we do and it breaks.

So, to avoid having to handle (and decide) it in this commit, here's
what I'm doing:
 * Arithmetic return value is a join<lhs, rhs>.
 * Load/store returns the type of the pointer

Since we don't have a pointer/reference type yet, and it's not clear
what new region/object operators will do regarding allocation, I'm
leaving the "alloca" nodes as the same type as their objects (no ptr).

This is clearly wrong, but will have to do until we define what's the
actual behaviour. This series is only about implementing the code for
accessing fields and their "addresses".