### PR TITLE
Simplify Symbol Table Impl/API

### DIFF
--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -164,10 +164,6 @@ namespace mlir::verona
     /// Get location of an ast node.
     mlir::Location getLocation(const ::ast::WeakAst& ast);
 
-    /// Declares a new variable.
-    void declareVariable(llvm::StringRef name, mlir::Value val);
-    /// Updates an existing variable in the local context.
-    void updateVariable(llvm::StringRef name, mlir::Value val);
     /// Get a (compiler generated) function.
     /// Will declare the prototype if it has not already been defined.
     FuncOp genIntrinsic(

--- a/src/mlir/symbol.h
+++ b/src/mlir/symbol.h
@@ -48,15 +48,35 @@ namespace mlir::verona
     }
 
     /// Insert entry on the last scope only
-    bool insert(llvm::StringRef key, T value)
+    /// Returns the inserted element
+    /// Asserts if element already exist
+    T insert(llvm::StringRef key, T value)
+    {
+      return update(key, value, /* insert= */ true);
+    }
+
+    /// Inserts or update the entry in the last scope
+    /// Returns the inserted/updated element
+    /// If insert=true, asserts if element already exist
+    T update(llvm::StringRef key, T value, bool insert = false)
     {
       auto& frame = stack.back();
       auto res = frame.emplace(key, value);
-      return res.second;
+      if (insert)
+        assert(res.second && "Redeclaration");
+      return std::get<1>(*res.first);
     }
 
-    /// Lookup from the last scope to the first
-    T lookup(llvm::StringRef key)
+    /// Return the entry if it is in the last scope
+    T inScope(llvm::StringRef key)
+    {
+      return lookup(key, /* lastContextOnly= */ true);
+    }
+
+    /// Lookup for the entry on all scopes, from the last to first
+    /// Returns the element or nullptr if none found
+    /// `lastContextOnly=true` only looks up in the local scope
+    T lookup(llvm::StringRef key, bool lastContextOnly = false)
     {
       for (auto it = stack.rbegin(), end = stack.rend(); it != end; it++)
       {
@@ -64,24 +84,10 @@ namespace mlir::verona
         auto val = frame.find(key.str());
         if (val != frame.end())
           return val->second;
+        if (lastContextOnly)
+          return nullptr;
       }
       return nullptr;
-    }
-
-    /// Check that the entry is in the last scope
-    bool inScope(llvm::StringRef key)
-    {
-      auto frame = stack.back();
-      return frame.count(key.str());
-    }
-
-    /// Update the entry in the last scope, or create new
-    bool update(llvm::StringRef key, T value)
-    {
-      auto& frame = stack.back();
-      // FIXME: Check types are compatible
-      frame[key.str()] = value;
-      return true;
     }
 
     /// Creates a new scope


### PR DESCRIPTION
Simplifying the implementation by only having one lookup and one
update/insert method and making "the other" a wrapper with a default
boolean flag.

Also simplifying the API by making all methods return the element if
inserted/updated/found and use that to avoid multiple redundant lookups
throughout the code.

The main difference is the use of `update` when declaring classes, so
that it is clear we can pre-declare them before they're fully defined
(for example, as a type for some earlier class' member).

Before that logic was hidden through a lookup + insert, and now it
simplifies as just an update.

In the end we have a lot less redundant map searches and a simpler code
to follow.