### PR TITLE
SymbolTable: Rename update to getOrAdd

### DIFF
--- a/src/mlir/generator.cc
+++ b/src/mlir/generator.cc
@@ -95,7 +95,7 @@ namespace mlir::verona
     // already, so we use `update` to fetch it.
     auto name = AST::getID(ast);
     auto type = ClassType::get(context, name);
-    typeTable.update(name, type);
+    typeTable.getOrAdd(name, type);
 
     // Nested classes, field names and types, methods, etc.
     llvm::SmallVector<::ast::WeakAst, 4> nodes;
@@ -300,7 +300,7 @@ namespace mlir::verona
       {
         // Class pre-declaration, use `update` it for multiple uses
         // before complete definition (done in `parseClass`).
-        return typeTable.update(name, ClassType::get(context, name));
+        return typeTable.getOrAdd(name, ClassType::get(context, name));
       }
       else
       {

--- a/src/mlir/symbol.h
+++ b/src/mlir/symbol.h
@@ -52,13 +52,13 @@ namespace mlir::verona
     /// Asserts if element already exist
     T insert(llvm::StringRef key, T value)
     {
-      return update(key, value, /* insert= */ true);
+      return getOrAdd(key, value, /* insert= */ true);
     }
 
-    /// Inserts or update the entry in the last scope
-    /// Returns the inserted/updated element
+    /// Fetch or insert the entry in the last scope
+    /// Returns the inserted/fetched element
     /// If insert=true, asserts if element already exist
-    T update(llvm::StringRef key, T value, bool insert = false)
+    T getOrAdd(llvm::StringRef key, T value, bool insert = false)
     {
       auto& frame = stack.back();
       auto res = frame.emplace(key, value);


### PR DESCRIPTION
This is the actual behaviour, so use the right name.