### PR TITLE
Add additional roots to traced region

### DIFF
--- a/src/rt/ds/stack.h
+++ b/src/rt/ds/stack.h
@@ -146,10 +146,9 @@ namespace verona::rt
     }
 
     /// For all elements of the stack
-    template<void apply(T* t)>
-    void forall()
+    void forall(snmalloc::function_ref<void(T*)> apply)
     {
-      T* curr = index;
+      T** curr = index;
 
       while (curr != null_index)
       {
@@ -157,7 +156,7 @@ namespace verona::rt
         {
           apply(*curr);
           curr--;
-        } while (is_empty(curr));
+        } while (!is_empty(curr));
 
         curr = get_block(curr)->prev;
       }
@@ -294,10 +293,10 @@ namespace verona::rt
     }
 
     /// Apply function to every element of the stack.
-    template<void apply(T* t)>
-    void forall()
+    ALWAYSINLINE
+    void forall(snmalloc::function_ref<void(T*)> apply)
     {
-      stack.template forall<apply>();
+      stack.template forall(apply);
     }
 
     ~Stack()

--- a/src/rt/region/region_trace.h
+++ b/src/rt/region/region_trace.h
@@ -287,8 +287,8 @@ namespace verona::rt
       reg->additional_entry_points.push(o, alloc);
     }
 
-    /// Remove root to the stack.
-    /// Must be called in reservse order with respect to push_additional_root.
+    /// Remove root from the stack.
+    /// Must be called in reverse order with respect to push_additional_root.
     static void pop_additional_root(Object* root, Object* o, Alloc* alloc)
     {
       RegionTrace* reg = get(root);

--- a/src/rt/test/func/cowngc1/cowngc1.cc
+++ b/src/rt/test/func/cowngc1/cowngc1.cc
@@ -201,8 +201,8 @@ struct RCown : public VCown<RCown>
       Cown::release(alloc, r2->f1->cown);
 
       // Want to make sure one of the objects is RC and the other is SCC_PTR.
-      assert(imm1->debug_is_rc() || imm2->debug_is_rc());
-      assert(imm1->debug_is_rc() != imm2->debug_is_rc());
+      check(imm1->debug_is_rc() || imm2->debug_is_rc());
+      check(imm1->debug_is_rc() != imm2->debug_is_rc());
     }
 
     // Release our (RCown's) refcount on the shared_child.
@@ -236,7 +236,7 @@ struct RCown : public VCown<RCown>
     if (imm2 != nullptr)
       fields.push(imm2);
 
-    assert(next != nullptr);
+    check(next != nullptr);
     fields.push(next);
   }
 };

--- a/src/rt/test/func/cowngc4/cowngc4.cc
+++ b/src/rt/test/func/cowngc4/cowngc4.cc
@@ -227,9 +227,9 @@ struct RCown : public VCown<RCown<region_type>>
       Cown::release(alloc, r2->f1->cown);
 
       // Want to make sure one of the objects is RC and the other is SCC_PTR.
-      assert(
+      check(
         reg_with_imm->imm1->debug_is_rc() || reg_with_imm->imm2->debug_is_rc());
-      assert(
+      check(
         reg_with_imm->imm1->debug_is_rc() != reg_with_imm->imm2->debug_is_rc());
     }
 
@@ -255,7 +255,7 @@ struct RCown : public VCown<RCown<region_type>>
     if (reg_with_imm != nullptr)
       fields.push(reg_with_imm);
 
-    assert(next != nullptr);
+    check(next != nullptr);
     fields.push(next);
   }
 };

--- a/src/rt/test/func/diningphilosophers/diningphil.cc
+++ b/src/rt/test/func/diningphilosophers/diningphil.cc
@@ -13,7 +13,7 @@ struct Fork : public VCown<Fork>
 
   ~Fork()
   {
-    assert(uses_expected == uses);
+    check(uses_expected == uses);
   }
 };
 

--- a/src/rt/test/func/ext_ref/ext_ref_basic.h
+++ b/src/rt/test/func/ext_ref/ext_ref_basic.h
@@ -1,5 +1,6 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
+#include <test/harness.h>
 #include <verona.h>
 
 using namespace snmalloc;
@@ -46,9 +47,9 @@ namespace ext_ref_basic
 
     void trace(ObjectStack& st) const
     {
-      assert(ext_node);
+      check(ext_node);
       st.push(ext_node);
-      assert(ext_node_alias);
+      check(ext_node_alias);
       st.push(ext_node_alias);
     }
   };
@@ -104,7 +105,7 @@ namespace ext_ref_basic
 
     void trace(ObjectStack& st) const
     {
-      assert(list);
+      check(list);
       st.push(list);
     }
   };
@@ -125,7 +126,7 @@ namespace ext_ref_basic
       auto alloc = ThreadAlloc::get();
 
       auto list = a->list;
-      assert(ext_node->is_in(Region::get(g_list)));
+      check(ext_node->is_in(Region::get(g_list)));
       auto node = get();
 
       node->prev->next = node->next;
@@ -134,7 +135,7 @@ namespace ext_ref_basic
       node->element = nullptr;
       RegionTrace::gc(alloc, list);
 
-      assert(!ext_node->is_in(Region::get(g_list)));
+      check(!ext_node->is_in(Region::get(g_list)));
       Immutable::release(alloc, ext_node);
     }
 
@@ -184,8 +185,8 @@ namespace ext_ref_basic
     auto r = new (alloc) R<region_type>;
     auto region = Region::get(r);
     auto ext_ref = ExternalRef::create(region, r);
-    assert(ext_ref->is_in(region));
-    assert(ext_ref->get() == r);
+    check(ext_ref->is_in(region));
+    check(ext_ref->get() == r);
 
     Immutable::release(alloc, ext_ref);
     Region::release(alloc, r);

--- a/src/rt/test/func/ext_ref/ext_ref_merge.h
+++ b/src/rt/test/func/ext_ref/ext_ref_merge.h
@@ -1,5 +1,6 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
+#include <test/harness.h>
 #include <verona.h>
 
 using namespace snmalloc;
@@ -41,7 +42,7 @@ namespace ext_ref_merge
 
     r1->f1->f1 = r2;
 
-    assert(!r2->debug_is_iso());
+    check(!r2->debug_is_iso());
 
     Immutable::release(alloc, wref1);
     Immutable::release(alloc, wref2);

--- a/src/rt/test/func/ext_ref_freeze/ext_ref_freeze.cc
+++ b/src/rt/test/func/ext_ref_freeze/ext_ref_freeze.cc
@@ -1,6 +1,6 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
-#include <test/opt.h>
+#include <test/harness.h>
 #include <verona.h>
 
 using namespace snmalloc;

--- a/src/rt/test/func/memory/memory.cc
+++ b/src/rt/test/func/memory/memory.cc
@@ -60,6 +60,15 @@ int main(int argc, char** argv)
 #  endif
 #endif
 
+#ifdef CI_BUILD
+  auto log = true;
+#else
+  auto log = opt.has("--log-all");
+#endif
+
+  if (log)
+    Systematic::enable_logging();
+
   memory_alloc::run_test();
   memory_iterator::run_test();
   memory_swap_root::run_test();

--- a/src/rt/test/func/memory/memory.h
+++ b/src/rt/test/func/memory/memory.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include <test/harness.h>
 #include <verona.h>
 
 using namespace snmalloc;

--- a/src/rt/test/func/memory/memory_alloc.h
+++ b/src/rt/test/func/memory/memory_alloc.h
@@ -20,7 +20,7 @@ namespace memory_alloc
     First* a = alloc_region<First, Rest...>(alloc);
     Region::release(alloc, a);
     snmalloc::current_alloc_pool()->debug_check_empty();
-    assert(live_count == 0);
+    check(live_count == 0);
   }
 
   /**
@@ -76,7 +76,7 @@ namespace memory_alloc
       using S5 = C2<48, region_type>;
       using S6 = C2<52, region_type>;
       using S7 = C2<56, region_type>;
-      assert(
+      check(
         sizeof(S1) % Object::ALIGNMENT != 0 ||
         sizeof(S2) % Object::ALIGNMENT != 0 ||
         sizeof(S3) % Object::ALIGNMENT != 0 ||

--- a/src/rt/test/func/memory/memory_gc.h
+++ b/src/rt/test/func/memory/memory_gc.h
@@ -475,14 +475,29 @@ namespace memory_gc
     // Allocate some reachable objects.
     auto* o1 = new (alloc, o) C;
     Systematic::cout() << " other" << o1 << std::endl;
+    auto* s1 = new (alloc, o) C;
+    Systematic::cout() << " sub" << s1 << std::endl;
+    o1->f1 = s1;
     auto* o2 = new (alloc, o) C;
     Systematic::cout() << " other" << o2 << std::endl;
+    auto* s2 = new (alloc, o) C;
+    Systematic::cout() << " sub" << s2 << std::endl;
+    o2->f1 = s2;
     auto* o3 = new (alloc, o) C;
     Systematic::cout() << " other" << o3 << std::endl;
+    auto* s3 = new (alloc, o) C;
+    Systematic::cout() << " sub" << s2 << std::endl;
+    o3->f1 = s3;
     auto* o4 = new (alloc, o) C;
     Systematic::cout() << " other" << o4 << std::endl;
+    auto* s4 = new (alloc, o) C;
+    Systematic::cout() << " sub" << s4 << std::endl;
+    o4->f1 = s4;
     auto* o5 = new (alloc, o) C;
     Systematic::cout() << " other" << o5 << std::endl;
+    auto* s5 = new (alloc, o) C;
+    Systematic::cout() << " sub" << s5 << std::endl;
+    o5->f1 = s5;
 
     RegionTrace::push_additional_root(o, o1, alloc);
     RegionTrace::push_additional_root(o, o2, alloc);
@@ -490,17 +505,17 @@ namespace memory_gc
     RegionTrace::push_additional_root(o, o4, alloc);
     RegionTrace::push_additional_root(o, o5, alloc);
 
-    check(Region::debug_size(o) == 6);
+    check(Region::debug_size(o) == 11);
     RegionTrace::gc(alloc, o);
     Systematic::cout() << Region::debug_size(o) << std::endl;
-    check(Region::debug_size(o) == 6);
+    check(Region::debug_size(o) == 11);
 
     RegionTrace::pop_additional_root(o, o5, alloc);
     RegionTrace::pop_additional_root(o, o4, alloc);
 
     // Run another GC.
     RegionTrace::gc(alloc, o);
-    check(Region::debug_size(o) == 4);
+    check(Region::debug_size(o) == 7);
 
     RegionTrace::pop_additional_root(o, o3, alloc);
     RegionTrace::pop_additional_root(o, o2, alloc);

--- a/src/rt/test/func/memory/memory_gc.h
+++ b/src/rt/test/func/memory/memory_gc.h
@@ -23,9 +23,9 @@ namespace memory_gc
   void alloc_garbage_helper(Alloc* alloc, Object* o)
   {
     alloc_in_region<T...>(alloc, o);
-    assert(Region::debug_size(o) == 1 + sizeof...(T)); // o + T...
+    check(Region::debug_size(o) == 1 + sizeof...(T)); // o + T...
     RegionTrace::gc(alloc, o);
-    assert(Region::debug_size(o) == 1); // only o is left
+    check(Region::debug_size(o) == 1); // only o is left
   }
 
   /**
@@ -76,25 +76,25 @@ namespace memory_gc
       o2->f2 = o4;
       o4->f2 = o7;
 
-      assert(Region::debug_size(o) == 8);
+      check(Region::debug_size(o) == 8);
       RegionTrace::gc(alloc, o);
-      assert(Region::debug_size(o) == 8); // nothing collected
+      check(Region::debug_size(o) == 8); // nothing collected
 
       // Break a link but re-add it.
       o1->f1 = nullptr;
       o1->f2 = o2;
       RegionTrace::gc(alloc, o);
-      assert(Region::debug_size(o) == 8); // nothing collected
+      check(Region::debug_size(o) == 8); // nothing collected
 
       // Now actually break a link.
       o5->f1 = nullptr;
       RegionTrace::gc(alloc, o);
-      assert(Region::debug_size(o) == 3);
+      check(Region::debug_size(o) == 3);
 
       // Now break the first link.
       o->f1 = nullptr;
       RegionTrace::gc(alloc, o);
-      assert(Region::debug_size(o) == 1); // only o is left
+      check(Region::debug_size(o) == 1); // only o is left
 
       Region::release(alloc, o);
       snmalloc::current_alloc_pool()->debug_check_empty();
@@ -143,9 +143,9 @@ namespace memory_gc
       o10->f1 = o15;
 
       // Now run a GC.
-      assert(Region::debug_size(o) == 16);
+      check(Region::debug_size(o) == 16);
       RegionTrace::gc(alloc, o);
-      assert(Region::debug_size(o) == 6);
+      check(Region::debug_size(o) == 6);
 
       Region::release(alloc, o);
       snmalloc::current_alloc_pool()->debug_check_empty();
@@ -185,9 +185,9 @@ namespace memory_gc
       o12->f1 = o13;
 
       // Now run a GC.
-      assert(Region::debug_size(o) == 14);
+      check(Region::debug_size(o) == 14);
       RegionTrace::gc(alloc, o);
-      assert(Region::debug_size(o) == 11);
+      check(Region::debug_size(o) == 11);
 
       Region::release(alloc, o);
       snmalloc::current_alloc_pool()->debug_check_empty();
@@ -228,9 +228,9 @@ namespace memory_gc
       o12->c1 = o14;
 
       // Now run a GC.
-      assert(Region::debug_size(o) == 17);
+      check(Region::debug_size(o) == 17);
       RegionTrace::gc(alloc, o);
-      assert(Region::debug_size(o) == 7);
+      check(Region::debug_size(o) == 7);
 
       Region::release(alloc, o);
       snmalloc::current_alloc_pool()->debug_check_empty();
@@ -255,9 +255,9 @@ namespace memory_gc
     // Check that it's valid.
     auto rr = scc->debug_immutable_root();
     UNUSED(rr);
-    assert(rr->debug_test_rc(1));
-    assert(scc->f1->debug_immutable_root() == rr);
-    assert(scc->f1->debug_test_rc(1));
+    check(rr->debug_test_rc(1));
+    check(scc->f1->debug_immutable_root() == rr);
+    check(scc->f1->debug_test_rc(1));
 
     // Now create a region that has pointers to the frozen SCC.
     C* r = new (alloc) C;
@@ -265,14 +265,14 @@ namespace memory_gc
     r->f1 = scc;
     r->f2 = scc->f1;
 
-    assert(Region::debug_size(r) == 2);
-    assert(scc->debug_test_rc(1));
+    check(Region::debug_size(r) == 2);
+    check(scc->debug_test_rc(1));
     RegionTrace::gc(alloc, r);
-    assert(Region::debug_size(r) == 1);
-    assert(scc->debug_test_rc(2)); // gc discovered reference to scc
+    check(Region::debug_size(r) == 1);
+    check(scc->debug_test_rc(2)); // gc discovered reference to scc
 
     Immutable::release(alloc, scc);
-    assert(scc->debug_test_rc(1));
+    check(scc->debug_test_rc(1));
     Region::release(alloc, r);
     snmalloc::current_alloc_pool()->debug_check_empty();
   }
@@ -308,9 +308,9 @@ namespace memory_gc
     o4->f2 = o2;
 
     // Now run a GC.
-    assert(Region::debug_size(o) == 6);
+    check(Region::debug_size(o) == 6);
     RegionTrace::gc(alloc, o);
-    assert(Region::debug_size(o) == 6);
+    check(Region::debug_size(o) == 6);
 
     // Allocate some garbage cycles.
 
@@ -347,9 +347,9 @@ namespace memory_gc
     o16->f1 = o14;
 
     // Now run a GC.
-    assert(Region::debug_size(o) == 17);
+    check(Region::debug_size(o) == 17);
     RegionTrace::gc(alloc, o);
-    assert(Region::debug_size(o) == 6);
+    check(Region::debug_size(o) == 6);
 
     Region::release(alloc, o);
     snmalloc::current_alloc_pool()->debug_check_empty();
@@ -368,7 +368,7 @@ namespace memory_gc
     r1->c2 = new (alloc, r1) Cx;
     r1->c1->f1 = new (alloc, r1) Fx;
     alloc_in_region<Cx, Cx, Fx, Fx>(alloc, r1); // unreachable
-    assert(Region::debug_size(r1) == 8);
+    check(Region::debug_size(r1) == 8);
 
     // Create another region.
     auto* r2 = new (alloc) Fx;
@@ -376,7 +376,7 @@ namespace memory_gc
     r2->f2 = new (alloc, r2) Fx;
     r2->f1->c1 = new (alloc, r2) Cx;
     alloc_in_region<Fx, Fx, Cx, Cx>(alloc, r2); // unreachable
-    assert(Region::debug_size(r2) == 8);
+    check(Region::debug_size(r2) == 8);
 
     // Link the two regions together. Make both reachable from the other.
     r1->f1 = r2;
@@ -384,23 +384,23 @@ namespace memory_gc
 
     // Now merge them.
     RegionTrace::merge(alloc, r1, r2);
-    assert(!r2->debug_is_iso());
+    check(!r2->debug_is_iso());
 
     // Run a GC.
-    assert(Region::debug_size(r1) == 16);
+    check(Region::debug_size(r1) == 16);
     RegionTrace::gc(alloc, r1);
-    assert(Region::debug_size(r1) == 8);
+    check(Region::debug_size(r1) == 8);
 
     // Alloc a few things, swap root, then alloc some more.
     alloc_in_region<Fx, Cx, Fx>(alloc, r1);
     RegionTrace::swap_root(r1, r2);
-    assert(!r1->debug_is_iso() && r2->debug_is_iso());
+    check(!r1->debug_is_iso() && r2->debug_is_iso());
     alloc_in_region<Cx, Cx, Fx>(alloc, r2);
 
     // Run another GC.
-    assert(Region::debug_size(r2) == 14);
+    check(Region::debug_size(r2) == 14);
     RegionTrace::gc(alloc, r2);
-    assert(Region::debug_size(r2) == 8);
+    check(Region::debug_size(r2) == 8);
 
     Region::release(alloc, r2);
     snmalloc::current_alloc_pool()->debug_check_empty();
@@ -426,17 +426,17 @@ namespace memory_gc
     alloc_in_region<Cx, Fx, Cx, Fx>(alloc, o); // unreachable
 
     // Run a GC.
-    assert(Region::debug_size(o) == 13);
+    check(Region::debug_size(o) == 13);
     RegionTrace::gc(alloc, o);
-    assert(Region::debug_size(o) == 9);
+    check(Region::debug_size(o) == 9);
 
     // Swap root, but this creates garbage.
     RegionTrace::swap_root(o, nroot);
-    assert(!o->debug_is_iso() && nroot->debug_is_iso());
+    check(!o->debug_is_iso() && nroot->debug_is_iso());
 
     // Run another GC.
     RegionTrace::gc(alloc, nroot);
-    assert(Region::debug_size(nroot) == 4);
+    check(Region::debug_size(nroot) == 4);
 
     // Create another region.
     o = new (alloc) Cx;
@@ -444,21 +444,21 @@ namespace memory_gc
     o->f1->c1 = new (alloc, o) Cx;
     auto* nnroot = new (alloc, o) Cx;
     o->f1->c2 = nnroot;
-    assert(Region::debug_size(o) == 4);
+    check(Region::debug_size(o) == 4);
 
     // Merge the regions.
     RegionTrace::merge(alloc, nroot, o);
     nroot->c2 = o;
-    assert(Region::debug_size(nroot) == 8);
+    check(Region::debug_size(nroot) == 8);
 
     // Swap root again.
     RegionTrace::swap_root(nroot, nnroot);
-    assert(!nroot->debug_is_iso() && nnroot->debug_is_iso());
+    check(!nroot->debug_is_iso() && nnroot->debug_is_iso());
 
     // Run another GC.
-    assert(Region::debug_size(nnroot) == 8);
+    check(Region::debug_size(nnroot) == 8);
     RegionTrace::gc(alloc, nnroot);
-    assert(Region::debug_size(nnroot) == 1);
+    check(Region::debug_size(nnroot) == 1);
 
     Region::release(alloc, nnroot);
     snmalloc::current_alloc_pool()->debug_check_empty();
@@ -490,25 +490,25 @@ namespace memory_gc
     RegionTrace::push_additional_root(o, o4, alloc);
     RegionTrace::push_additional_root(o, o5, alloc);
 
-    assert(Region::debug_size(o) == 6);
+    check(Region::debug_size(o) == 6);
     RegionTrace::gc(alloc, o);
     Systematic::cout() << Region::debug_size(o) << std::endl;
-    assert(Region::debug_size(o) == 6);
+    check(Region::debug_size(o) == 6);
 
     RegionTrace::pop_additional_root(o, o5, alloc);
     RegionTrace::pop_additional_root(o, o4, alloc);
 
     // Run another GC.
     RegionTrace::gc(alloc, o);
-    assert(Region::debug_size(o) == 4);
- 
+    check(Region::debug_size(o) == 4);
+
     RegionTrace::pop_additional_root(o, o3, alloc);
     RegionTrace::pop_additional_root(o, o2, alloc);
     RegionTrace::pop_additional_root(o, o1, alloc);
 
     // Run another GC.
     RegionTrace::gc(alloc, o);
-    assert(Region::debug_size(o) == 1);
+    check(Region::debug_size(o) == 1);
     Region::release(alloc, o);
     snmalloc::current_alloc_pool()->debug_check_empty();
   }

--- a/src/rt/test/func/memory/memory_iterator.h
+++ b/src/rt/test/func/memory/memory_iterator.h
@@ -52,21 +52,21 @@ namespace memory_iterator
       for (auto p : *reg)
       {
         UNUSED(p);
-        assert(p == o);
+        check(p == o);
       }
 
       for (auto n_it = reg->template begin<RegionBase::Trivial>();
            n_it != reg->template end<RegionBase::Trivial>();
            ++n_it)
       {
-        assert(0); // unreachable
+        check(0); // unreachable
       }
 
       for (auto f_it = reg->template begin<RegionBase::NonTrivial>();
            f_it != reg->template end<RegionBase::NonTrivial>();
            ++f_it)
       {
-        assert(*f_it == o);
+        check(*f_it == o);
       }
 
       Region::release(ThreadAlloc::get(), o);
@@ -80,21 +80,21 @@ namespace memory_iterator
       for (auto p : *reg)
       {
         UNUSED(p);
-        assert(p == o);
+        check(p == o);
       }
 
       for (auto n_it = reg->template begin<RegionBase::Trivial>();
            n_it != reg->template end<RegionBase::Trivial>();
            ++n_it)
       {
-        assert(*n_it == o);
+        check(*n_it == o);
       }
 
       for (auto f_it = reg->template begin<RegionBase::NonTrivial>();
            f_it != reg->template end<RegionBase::NonTrivial>();
            ++f_it)
       {
-        assert(0); // unreachable
+        check(0); // unreachable
       }
 
       Region::release(ThreadAlloc::get(), o);
@@ -168,49 +168,49 @@ namespace memory_iterator
       s4.insert(of);
 
       // Sanity check.
-      assert(s1.size() == s2.size() + s3.size());
+      check(s1.size() == s2.size() + s3.size());
 
       // Now check that we iterated over everything.
       for (auto p : *reg)
       {
-        assert(s1.count(p));
+        check(s1.count(p));
         s1.erase(p);
       }
-      assert(s1.empty());
+      check(s1.empty());
 
       for (auto n_it = reg->template begin<RegionBase::Trivial>();
            n_it != reg->template end<RegionBase::Trivial>();
            ++n_it)
       {
-        assert(s2.count(*n_it));
+        check(s2.count(*n_it));
         s2.erase(*n_it);
       }
-      assert(s2.empty());
+      check(s2.empty());
 
       for (auto f_it = reg->template begin<RegionBase::NonTrivial>();
            f_it != reg->template end<RegionBase::NonTrivial>();
            ++f_it)
       {
-        assert(s3.count(*f_it));
+        check(s3.count(*f_it));
         s3.erase(*f_it);
       }
-      assert(s3.empty());
+      check(s3.empty());
 
       // Run a GC.
-      assert(Region::debug_size(r) == 9);
+      check(Region::debug_size(r) == 9);
       RegionTrace::gc(alloc, r);
-      assert(Region::debug_size(r) == 5);
+      check(Region::debug_size(r) == 5);
 
       // Check that we didn't collect anything we shouldn't have.
       for (auto p : *reg)
       {
         UNUSED(p);
-        assert(!s4.count(p));
+        check(!s4.count(p));
       }
 
       Region::release(alloc, r);
       snmalloc::current_alloc_pool()->debug_check_empty();
-      assert(live_count == 0);
+      check(live_count == 0);
     }
     else if constexpr (region_type == RegionType::Arena)
     {
@@ -248,37 +248,37 @@ namespace memory_iterator
       test_iterator_insert<LF, LF, LC, LC>(alloc, o, s1, s2, s3);
 
       // Sanity check.
-      assert(s1.size() == s2.size() + s3.size());
+      check(s1.size() == s2.size() + s3.size());
 
       // Now check that we iterated over everything.
       for (auto p : *reg)
       {
-        assert(s1.count(p));
+        check(s1.count(p));
         s1.erase(p);
       }
-      assert(s1.empty());
+      check(s1.empty());
 
       for (auto n_it = reg->template begin<RegionBase::Trivial>();
            n_it != reg->template end<RegionBase::Trivial>();
            ++n_it)
       {
-        assert(s2.count(*n_it));
+        check(s2.count(*n_it));
         s2.erase(*n_it);
       }
-      assert(s2.empty());
+      check(s2.empty());
 
       for (auto f_it = reg->template begin<RegionBase::NonTrivial>();
            f_it != reg->template end<RegionBase::NonTrivial>();
            ++f_it)
       {
-        assert(s3.count(*f_it));
+        check(s3.count(*f_it));
         s3.erase(*f_it);
       }
-      assert(s3.empty());
+      check(s3.empty());
 
       Region::release(alloc, o);
       snmalloc::current_alloc_pool()->debug_check_empty();
-      assert(live_count == 0);
+      check(live_count == 0);
     }
   }
 

--- a/src/rt/test/func/memory/memory_merge.h
+++ b/src/rt/test/func/memory/memory_merge.h
@@ -17,7 +17,7 @@ namespace memory_merge
     using RegionClass = typename RegionType_to_class<region_type>::T;
 
     RegionClass::merge(alloc, r1, r2);
-    assert(!r2->debug_is_iso());
+    check(!r2->debug_is_iso());
 
     // Allocate a few more things to ensure our pointers are correct.
     new (alloc, r1) LargeC2<region_type>;
@@ -26,7 +26,7 @@ namespace memory_merge
 
     Region::release(alloc, r1);
     snmalloc::current_alloc_pool()->debug_check_empty();
-    assert(live_count == 0);
+    check(live_count == 0);
   }
 
   /**
@@ -57,7 +57,7 @@ namespace memory_merge
       new (alloc, r2) LC;
 
       RegionClass::merge(alloc, r1, r2);
-      assert(r1->debug_is_iso() && !r2->debug_is_iso());
+      check(r1->debug_is_iso() && !r2->debug_is_iso());
 
       alloc_in_region<F, F, LC, XC>(alloc, r1);
 
@@ -66,13 +66,13 @@ namespace memory_merge
       RegionClass::swap_root(o1, r2);
       alloc_in_region<LC, F>(alloc, r2);
       RegionClass::swap_root(r2, o2);
-      assert(o2->debug_is_iso());
+      check(o2->debug_is_iso());
 
       alloc_in_region<F, LC>(alloc, o2);
 
       Region::release(alloc, o2);
       snmalloc::current_alloc_pool()->debug_check_empty();
-      assert(live_count == 0);
+      check(live_count == 0);
     }
 
     if constexpr (region_type == RegionType::Trace)

--- a/src/rt/test/func/memory/memory_subregion.h
+++ b/src/rt/test/func/memory/memory_subregion.h
@@ -53,7 +53,7 @@ namespace memory_subregion
 
     Region::release(alloc, r);
     snmalloc::current_alloc_pool()->debug_check_empty();
-    assert(live_count == 0);
+    check(live_count == 0);
   }
 
   /**
@@ -101,7 +101,7 @@ namespace memory_subregion
 
     Region::release(alloc, r);
     snmalloc::current_alloc_pool()->debug_check_empty();
-    assert(live_count == 0);
+    check(live_count == 0);
   }
 
   /**
@@ -144,20 +144,20 @@ namespace memory_subregion
     r2->f1 = r3;
 
     // Count items in each subregion.
-    assert(Region::debug_size(r) == 6);
-    assert(Region::debug_size(r1) == 4);
-    assert(Region::debug_size(r2) == 6);
-    assert(Region::debug_size(r3) == 3);
+    check(Region::debug_size(r) == 6);
+    check(Region::debug_size(r1) == 4);
+    check(Region::debug_size(r2) == 6);
+    check(Region::debug_size(r3) == 3);
 
     // GC r3, then r, but not r1.
     RegionTrace::gc(alloc, r3);
     RegionTrace::gc(alloc, r);
 
     // Check the sizes again.
-    assert(Region::debug_size(r) == 3);
-    assert(Region::debug_size(r1) == 4);
-    assert(Region::debug_size(r2) == 6);
-    assert(Region::debug_size(r3) == 1);
+    check(Region::debug_size(r) == 3);
+    check(Region::debug_size(r1) == 4);
+    check(Region::debug_size(r2) == 6);
+    check(Region::debug_size(r3) == 1);
 
     Region::release(alloc, r);
     snmalloc::current_alloc_pool()->debug_check_empty();
@@ -193,9 +193,9 @@ namespace memory_subregion
       if constexpr (region_type == RegionType::Trace)
       {
         // After the swap, we have some unreachable objects.
-        assert(Region::debug_size(nroot) == 3);
+        check(Region::debug_size(nroot) == 3);
         RegionTrace::gc(alloc, nroot);
-        assert(Region::debug_size(nroot) == 1);
+        check(Region::debug_size(nroot) == 1);
       }
 
       Region::release(alloc, nroot);
@@ -222,9 +222,9 @@ namespace memory_subregion
       if constexpr (region_type == RegionType::Trace)
       {
         // After the swap, we have some unreachable objects.
-        assert(Region::debug_size(nroot) == 3);
+        check(Region::debug_size(nroot) == 3);
         RegionTrace::gc(alloc, nroot);
-        assert(Region::debug_size(nroot) == 1);
+        check(Region::debug_size(nroot) == 1);
       }
 
       Region::release(alloc, nroot);
@@ -254,9 +254,9 @@ namespace memory_subregion
       if constexpr (region_type == RegionType::Trace)
       {
         // After the swap, we have some unreachable objects.
-        assert(Region::debug_size(nroot) == 3);
+        check(Region::debug_size(nroot) == 3);
         RegionTrace::gc(alloc, nroot);
-        assert(Region::debug_size(nroot) == 1);
+        check(Region::debug_size(nroot) == 1);
       }
 
       Region::release(alloc, r);
@@ -299,9 +299,9 @@ namespace memory_subregion
     // Run GC.
     if constexpr (region_type == RegionType::Trace)
     {
-      assert(Region::debug_size(r1) == 14);
+      check(Region::debug_size(r1) == 14);
       RegionTrace::gc(alloc, r1);
-      assert(Region::debug_size(r1) == 8);
+      check(Region::debug_size(r1) == 8);
     }
 
     // Let's break a link to create some more garbage, then run GC again.
@@ -309,7 +309,7 @@ namespace memory_subregion
     if constexpr (region_type == RegionType::Trace)
     {
       RegionTrace::gc(alloc, r1);
-      assert(Region::debug_size(r1) == 5);
+      check(Region::debug_size(r1) == 5);
     }
 
     Region::release(alloc, r1);

--- a/src/rt/test/func/memory/memory_swap_root.h
+++ b/src/rt/test/func/memory/memory_swap_root.h
@@ -20,7 +20,7 @@ namespace memory_swap_root
     UNUSED(reg);
 
     RegionClass::swap_root(oroot, nroot);
-    assert(
+    check(
       !oroot->debug_is_iso() && nroot->debug_is_iso() &&
       reg == Region::get(nroot));
 
@@ -31,7 +31,7 @@ namespace memory_swap_root
 
     Region::release(alloc, nroot);
     snmalloc::current_alloc_pool()->debug_check_empty();
-    assert(live_count == 0);
+    check(live_count == 0);
   }
 
   /**
@@ -62,20 +62,20 @@ namespace memory_swap_root
 
       RegionClass::swap_root(oroot1, nroot1);
       RegionClass::swap_root(oroot2, nroot2);
-      assert(!oroot1->debug_is_iso() && nroot1->debug_is_iso());
-      assert(!oroot2->debug_is_iso() && nroot2->debug_is_iso());
+      check(!oroot1->debug_is_iso() && nroot1->debug_is_iso());
+      check(!oroot2->debug_is_iso() && nroot2->debug_is_iso());
 
       alloc_in_region<F, F, XC>(alloc, nroot1);
       alloc_in_region<C, C>(alloc, nroot2);
 
       RegionClass::merge(alloc, nroot1, nroot2);
-      assert(nroot1->debug_is_iso() && !nroot2->debug_is_iso());
+      check(nroot1->debug_is_iso() && !nroot2->debug_is_iso());
 
       alloc_in_region<XC, XC, C>(alloc, nroot1);
 
       Region::release(alloc, nroot1);
       snmalloc::current_alloc_pool()->debug_check_empty();
-      assert(live_count == 0);
+      check(live_count == 0);
     }
 
     if constexpr (region_type == RegionType::Trace)

--- a/src/rt/test/func/noticeboard/noticeboard_basic.h
+++ b/src/rt/test/func/noticeboard/noticeboard_basic.h
@@ -88,7 +88,7 @@ namespace noticeboard_basic
       {
         fields.push(alive);
       }
-      assert(db);
+      check(db);
       fields.push(db);
     }
   };
@@ -160,7 +160,7 @@ namespace noticeboard_basic
           }
           else
           {
-            assert(o->alive);
+            check(o->alive);
             Cown::acquire(o->alive);
             peeker->alive = o->alive;
             peeker->state = WAITFORCOLLECTION;
@@ -195,7 +195,7 @@ namespace noticeboard_basic
           return;
         }
       }
-      assert(false);
+      check(false);
     }
   };
 

--- a/src/rt/test/func/noticeboard/noticeboard_primitive_weak.h
+++ b/src/rt/test/func/noticeboard/noticeboard_primitive_weak.h
@@ -62,7 +62,7 @@ namespace noticeboard_primitive_weak
 
       // expected assertion failure; write to x_1 was picked up before x_0
       // if (x_1 == 2) {
-      //   assert(x_0 == 1);
+      //   check(x_0 == 1);
       // }
 
       UNUSED(x_0);

--- a/src/rt/test/func/noticeboard/noticeboard_weak.h
+++ b/src/rt/test/func/noticeboard/noticeboard_weak.h
@@ -78,7 +78,7 @@ namespace noticeboard_weak
 
       // expected assertion failure; write to c_1 was picked up before c_0
       // if (c_1->x == 2) {
-      //   assert(c_0->x == 1);
+      //   check(c_0->x == 1);
       // }
 
       // out of scope

--- a/src/rt/test/func/notify/notify.cc
+++ b/src/rt/test/func/notify/notify.cc
@@ -14,7 +14,7 @@ int main(int argc, char** argv)
 
   harness.run(notify_interleave::run_test);
 
-  // Here we ensure single-core so that we can assert the number of times
+  // Here we ensure single-core so that we can check the number of times
   // `notified` is called.
   if (harness.cores == 1)
     harness.run(notify_coalesce::run_test);

--- a/src/rt/test/func/notify/notify_coalesce.h
+++ b/src/rt/test/func/notify/notify_coalesce.h
@@ -39,7 +39,7 @@ namespace notify_coalesce
 
     void trace(ObjectStack& st) const
     {
-      assert(a);
+      check(a);
       st.push(a);
     }
   };
@@ -84,8 +84,8 @@ namespace notify_coalesce
 
         case CHECK:
         {
-          // If this assert fails, check if BATCH_COUNT is lower than 100.
-          assert(g_called == 1);
+          // If this check fails, check if BATCH_COUNT is lower than 100.
+          check(g_called == 1);
           Cown::release(ThreadAlloc::get(), b);
           break;
         }

--- a/src/rt/test/func/notify/notify_interleave.h
+++ b/src/rt/test/func/notify/notify_interleave.h
@@ -37,7 +37,7 @@ namespace notify_interleave
 
     void trace(ObjectStack& st) const
     {
-      assert(a);
+      check(a);
       st.push(a);
     }
   };

--- a/src/rt/test/harness.h
+++ b/src/rt/test/harness.h
@@ -7,7 +7,6 @@
 #include <test/opt.h>
 #include <verona.h>
 
-using namespace snmalloc;
 using namespace verona::rt;
 using namespace std::chrono;
 
@@ -117,7 +116,7 @@ public:
 
   size_t current_seed()
   {
-    assert(seed != 0);
+    check(seed != 0);
     return seed;
   }
 };

--- a/src/rt/test/perf/ubench/ubench.cc
+++ b/src/rt/test/perf/ubench/ubench.cc
@@ -22,6 +22,7 @@
 #include "verona.h"
 
 #include <chrono>
+#include <test/harness.h>
 
 namespace sn = snmalloc;
 namespace rt = verona::rt;
@@ -29,193 +30,198 @@ namespace rt = verona::rt;
 static rt::Cown** all_cowns = nullptr;
 static size_t all_cowns_count = 0;
 
-struct Pinger : public rt::VCown<Pinger>
+namespace ubench
 {
-  vector<Pinger*>& pingers;
-  xoroshiro::p128r32 rng;
-  size_t select_mod = 0;
-  bool running = false;
-  size_t count = 0;
-
-  Pinger(vector<Pinger*>& pingers_, size_t seed, size_t percent_multimessage)
-  : pingers(pingers_), rng(seed)
+  struct Pinger : public rt::VCown<Pinger>
   {
-    if (percent_multimessage != 0)
-      select_mod = (size_t)((double)100.00 / (double)percent_multimessage);
-  }
-};
+    vector<Pinger*>& pingers;
+    xoroshiro::p128r32 rng;
+    size_t select_mod = 0;
+    bool running = false;
+    size_t count = 0;
 
-struct Monitor : public rt::VCown<Monitor>
-{
-  vector<Pinger*>& pingers;
-  size_t initial_pings;
-  std::chrono::seconds report_interval;
-  size_t report_count;
-  size_t waiting = 0;
-  uint64_t start = 0;
-
-  Monitor(
-    vector<Pinger*>& pingers_,
-    size_t initial_pings_,
-    std::chrono::seconds report_interval_,
-    size_t report_count_)
-  : pingers(pingers_),
-    initial_pings(initial_pings_),
-    report_interval(report_interval_),
-    report_count(report_count_)
-  {}
-
-  void trace(rt::ObjectStack& st) const
-  {
-    for (auto* p : pingers)
-      st.push(p);
-  }
-};
-
-struct Ping : public rt::VBehaviour<Ping>
-{
-  Pinger* pinger;
-  std::array<Pinger*, 2> recipients;
-
-  Ping(Pinger* pinger_) : pinger(pinger_) {}
-
-  void f()
-  {
-    if (!pinger->running)
-      return;
-
-    pinger->count++;
-
-    size_t cowns = 1;
-    recipients[1] = pinger;
-    recipients[0] =
-      pinger->pingers[pinger->rng.next() % pinger->pingers.size()];
-
-    if ((pinger->pingers.size() > 1) && (pinger->select_mod != 0))
+    Pinger(vector<Pinger*>& pingers_, size_t seed, size_t percent_multimessage)
+    : pingers(pingers_), rng(seed)
     {
-      while (recipients[0] == pinger)
+      if (percent_multimessage != 0)
+        select_mod = (size_t)((double)100.00 / (double)percent_multimessage);
+    }
+  };
+
+  struct Monitor : public rt::VCown<Monitor>
+  {
+    vector<Pinger*>& pingers;
+    size_t initial_pings;
+    std::chrono::seconds report_interval;
+    size_t report_count;
+    size_t waiting = 0;
+    uint64_t start = 0;
+
+    Monitor(
+      vector<Pinger*>& pingers_,
+      size_t initial_pings_,
+      std::chrono::seconds report_interval_,
+      size_t report_count_)
+    : pingers(pingers_),
+      initial_pings(initial_pings_),
+      report_interval(report_interval_),
+      report_count(report_count_)
+    {}
+
+    void trace(rt::ObjectStack& st) const
+    {
+      for (auto* p : pingers)
+        st.push(p);
+    }
+  };
+
+  struct Ping : public rt::VBehaviour<Ping>
+  {
+    Pinger* pinger;
+    std::array<Pinger*, 2> recipients;
+
+    Ping(Pinger* pinger_) : pinger(pinger_) {}
+
+    void f()
+    {
+      if (!pinger->running)
+        return;
+
+      pinger->count++;
+
+      size_t cowns = 1;
+      recipients[1] = pinger;
+      recipients[0] =
+        pinger->pingers[pinger->rng.next() % pinger->pingers.size()];
+
+      if ((pinger->pingers.size() > 1) && (pinger->select_mod != 0))
       {
-        recipients[0] =
-          pinger->pingers[pinger->rng.next() % pinger->pingers.size()];
+        while (recipients[0] == pinger)
+        {
+          recipients[0] =
+            pinger->pingers[pinger->rng.next() % pinger->pingers.size()];
+        }
+        if ((pinger->rng.next() % pinger->select_mod) == 0)
+          cowns = 2;
       }
-      if ((pinger->rng.next() % pinger->select_mod) == 0)
-        cowns = 2;
+
+      rt::Cown::schedule<Ping>(
+        cowns, (rt::Cown**)recipients.data(), recipients[0]);
+    }
+  };
+
+  struct Stop;
+  struct StopPinger;
+  struct NotifyStopped;
+  struct Report;
+
+  static void start_timer(Monitor* monitor, std::chrono::milliseconds timeout)
+  {
+    rt::Cown::acquire(monitor);
+    rt::Scheduler::add_external_event_source();
+    std::thread([=]() mutable {
+      std::this_thread::sleep_for(timeout);
+      rt::Cown::schedule<Stop, rt::YesTransfer>((rt::Cown*)monitor, monitor);
+      rt::Scheduler::remove_external_event_source();
+    }).detach();
+  }
+
+  struct Start : public rt::VBehaviour<Start>
+  {
+    Monitor* monitor;
+
+    Start(Monitor* monitor_) : monitor(monitor_) {}
+
+    void f()
+    {
+      for (auto* p : monitor->pingers)
+      {
+        p->count = 0;
+        p->running = true;
+        for (size_t i = 0; i < monitor->initial_pings; i++)
+          rt::Cown::schedule<Ping>(p, p);
+      }
+
+      monitor->start = sn::Aal::tick();
+      start_timer(monitor, monitor->report_interval);
+    }
+  };
+
+  struct Stop : public rt::VBehaviour<Stop>
+  {
+    Monitor* monitor;
+
+    Stop(Monitor* monitor_) : monitor(monitor_) {}
+
+    void f()
+    {
+      monitor->waiting = monitor->pingers.size();
+      for (auto* pinger : monitor->pingers)
+        rt::Cown::schedule<StopPinger>(pinger, pinger, monitor);
+    }
+  };
+
+  struct StopPinger : public rt::VBehaviour<StopPinger>
+  {
+    Pinger* pinger;
+    Monitor* monitor;
+
+    StopPinger(Pinger* pinger_, Monitor* monitor_)
+    : pinger(pinger_), monitor(monitor_)
+    {}
+
+    void f()
+    {
+      pinger->running = false;
+      rt::Cown::schedule<NotifyStopped>(monitor, monitor);
+    }
+  };
+
+  struct NotifyStopped : public rt::VBehaviour<NotifyStopped>
+  {
+    Monitor* monitor;
+
+    NotifyStopped(Monitor* monitor_) : monitor(monitor_) {}
+
+    void f()
+    {
+      if (--monitor->waiting != 0)
+        return;
+
+      rt::Cown::schedule<Report>(all_cowns_count, all_cowns, monitor);
+
+      if (--monitor->report_count != 0)
+        rt::Cown::schedule<Start>(all_cowns_count, all_cowns, monitor);
+      else
+        rt::Cown::release(sn::ThreadAlloc::get(), monitor);
+    }
+  };
+
+  struct Report : public rt::VBehaviour<Report>
+  {
+    Monitor* monitor;
+
+    Report(Monitor* monitor_) : monitor(monitor_) {}
+
+    void trace(rt::ObjectStack& st) const
+    {
+      st.push(monitor);
     }
 
-    rt::Cown::schedule<Ping>(
-      cowns, (rt::Cown**)recipients.data(), recipients[0]);
-  }
-};
+    void f()
+    {
+      uint64_t t = sn::Aal::tick() - monitor->start;
+      uint64_t sum = 0;
+      for (auto* p : monitor->pingers)
+        sum += p->count;
 
-struct Stop;
-struct StopPinger;
-struct NotifyStopped;
-struct Report;
-
-static void start_timer(Monitor* monitor, std::chrono::milliseconds timeout)
-{
-  rt::Cown::acquire(monitor);
-  rt::Scheduler::add_external_event_source();
-  std::thread([=]() mutable {
-    std::this_thread::sleep_for(timeout);
-    rt::Cown::schedule<Stop, rt::YesTransfer>((rt::Cown*)monitor, monitor);
-    rt::Scheduler::remove_external_event_source();
-  }).detach();
+      uint64_t rate = (sum * 1'000'000'000) / t;
+      logger::cout() << t << " ns, " << rate << " msgs/s" << std::endl;
+    }
+  };
 }
 
-struct Start : public rt::VBehaviour<Start>
-{
-  Monitor* monitor;
-
-  Start(Monitor* monitor_) : monitor(monitor_) {}
-
-  void f()
-  {
-    for (auto* p : monitor->pingers)
-    {
-      p->count = 0;
-      p->running = true;
-      for (size_t i = 0; i < monitor->initial_pings; i++)
-        rt::Cown::schedule<Ping>(p, p);
-    }
-
-    monitor->start = sn::Aal::tick();
-    start_timer(monitor, monitor->report_interval);
-  }
-};
-
-struct Stop : public rt::VBehaviour<Stop>
-{
-  Monitor* monitor;
-
-  Stop(Monitor* monitor_) : monitor(monitor_) {}
-
-  void f()
-  {
-    monitor->waiting = monitor->pingers.size();
-    for (auto* pinger : monitor->pingers)
-      rt::Cown::schedule<StopPinger>(pinger, pinger, monitor);
-  }
-};
-
-struct StopPinger : public rt::VBehaviour<StopPinger>
-{
-  Pinger* pinger;
-  Monitor* monitor;
-
-  StopPinger(Pinger* pinger_, Monitor* monitor_)
-  : pinger(pinger_), monitor(monitor_)
-  {}
-
-  void f()
-  {
-    pinger->running = false;
-    rt::Cown::schedule<NotifyStopped>(monitor, monitor);
-  }
-};
-
-struct NotifyStopped : public rt::VBehaviour<NotifyStopped>
-{
-  Monitor* monitor;
-
-  NotifyStopped(Monitor* monitor_) : monitor(monitor_) {}
-
-  void f()
-  {
-    if (--monitor->waiting != 0)
-      return;
-
-    rt::Cown::schedule<Report>(all_cowns_count, all_cowns, monitor);
-
-    if (--monitor->report_count != 0)
-      rt::Cown::schedule<Start>(all_cowns_count, all_cowns, monitor);
-    else
-      rt::Cown::release(sn::ThreadAlloc::get(), monitor);
-  }
-};
-
-struct Report : public rt::VBehaviour<Report>
-{
-  Monitor* monitor;
-
-  Report(Monitor* monitor_) : monitor(monitor_) {}
-
-  void trace(rt::ObjectStack& st) const
-  {
-    st.push(monitor);
-  }
-
-  void f()
-  {
-    uint64_t t = sn::Aal::tick() - monitor->start;
-    uint64_t sum = 0;
-    for (auto* p : monitor->pingers)
-      sum += p->count;
-
-    uint64_t rate = (sum * 1'000'000'000) / t;
-    logger::cout() << t << " ns, " << rate << " msgs/s" << std::endl;
-  }
-};
+using namespace ubench;
 
 int main(int argc, char** argv)
 {
@@ -228,7 +234,7 @@ int main(int argc, char** argv)
   const auto report_count = opt.is<size_t>("--report_count", 10);
   const auto initial_pings = opt.is<size_t>("--initial_pings", 5);
   const auto percent_multimessage = opt.is<size_t>("--percent_multimessage", 5);
-  assert(percent_multimessage <= 100);
+  check(percent_multimessage <= 100);
 
   logger::cout() << "cores: " << cores << ", pingers: " << pingers
                  << ", report_interval: " << report_interval.count()
@@ -260,7 +266,7 @@ int main(int argc, char** argv)
   memcpy(all_cowns, pinger_set.data(), pinger_set.size() * sizeof(rt::Cown*));
   all_cowns[pinger_set.size()] = monitor;
 
-  rt::Cown::schedule<Start>(all_cowns_count, all_cowns, monitor);
+  rt::Cown::schedule<ubench::Start>(all_cowns_count, all_cowns, monitor);
 
   sched.run();
   alloc->dealloc(all_cowns, all_cowns_count * sizeof(rt::Cown*));


### PR DESCRIPTION
This adds an extra field to the region meta-data for keeping a stack of additional roots.  These are intended to be references from higher stack frames that must be kept alive during a region gc operation.

The additional roots must be empty if the region is dropped or merged into another region.  The target region of a merge may contain additional roots.