### PR TITLE
Replace backpressure state with priority

### DIFF
--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -322,7 +322,7 @@ namespace verona::rt
      **/
     void weak_release(Alloc* alloc)
     {
-      Systematic::cout() << "Weak release " << this << std::endl;
+      Systematic::cout() << "Cown " << this << " weak release" << std::endl;
       if (weak_count.fetch_sub(1) == 1)
       {
         auto* t = owning_thread();
@@ -350,8 +350,8 @@ namespace verona::rt
 
     void weak_acquire()
     {
+      Systematic::cout() << "Cown " << this << " weak acquire" << std::endl;
       assert(weak_count > 0);
-
       weak_count++;
     }
 
@@ -796,9 +796,7 @@ namespace verona::rt
         // This condition prevents a situation where a message triggering
         // prioritization on this cown has already been processed and this cown
         // has gone back to sleep by the time this state change is requested.
-        if (
-          (state == Priority::High) && (prev == Priority::Sleeping) &&
-          queue.is_sleeping())
+        if ((state == Priority::High) && (prev == Priority::Sleeping))
           return prev;
 
         if (prev == state)
@@ -1043,15 +1041,14 @@ namespace verona::rt
           // Reschedule if cown does not go to sleep.
           if (!queue.mark_sleeping(notify))
           {
+            backpressure_transition(Priority::Normal);
             if (notify)
             {
-              assert(
-                !notified_called); // We must have run something to get here.
+              // We must have run something to get here.
+              assert(!notified_called);
               cown_notified();
               // Treat notification as a message and don't deschedule
-              return true;
             }
-
             return true;
           }
 

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -1038,6 +1038,8 @@ namespace verona::rt
           if (batch_size != 0)
             return true;
 
+          backpressure_transition(Priority::Sleeping);
+
           // Reschedule if cown does not go to sleep.
           if (!queue.mark_sleeping(notify))
           {
@@ -1055,7 +1057,6 @@ namespace verona::rt
 
           Systematic::cout()
             << "Cown " << this << " has no work this time" << std::endl;
-          backpressure_transition(Priority::Sleeping);
 
           // Deschedule the cown.
           Cown::release(alloc, this);

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -218,7 +218,7 @@ namespace verona::rt
           // The scheduler thread needs to take a reference count on the Cown
           // The sending Cown must have had a reference count for this Cown
           // already
-          incref();
+          Cown::acquire(this);
         }
 
         if constexpr (try_fast == NoTryFast)
@@ -241,7 +241,7 @@ namespace verona::rt
     {
       if (queue.wake())
       {
-        incref();
+        Cown::acquire(this);
         schedule();
       }
     }
@@ -393,7 +393,7 @@ namespace verona::rt
     {
       if (queue.mark_notify())
       {
-        incref();
+        Cown::acquire(this);
         schedule();
       }
       yield();
@@ -1061,7 +1061,7 @@ namespace verona::rt
 
         batch_size++;
 
-        Systematic::cout() << "Running Message " << curr << " on " << this
+        Systematic::cout() << "Running Message " << curr << " on cown " << this
                            << std::endl;
 
         auto* senders = curr->get_body()->cowns;
@@ -1116,7 +1116,7 @@ namespace verona::rt
         Scheduler::yield_my_turn();
 #endif
 
-        Systematic::cout() << "Collecting (sweep) " << this << std::endl;
+        Systematic::cout() << "Collecting (sweep) cown " << this << std::endl;
 
         collect(alloc);
       }
@@ -1177,7 +1177,7 @@ namespace verona::rt
 #ifdef USE_SYSTEMATIC_TESTING_WEAK_NOTICEBOARDS
       flush_all(alloc);
 #endif
-      Systematic::cout() << "Collecting: " << this << std::endl;
+      Systematic::cout() << "Collecting cown " << this << std::endl;
 
       ObjectStack dummy(alloc);
       // Run finaliser before releasing our data.

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -1024,13 +1024,12 @@ namespace verona::rt
           // Reschedule if cown does not go to sleep.
           if (!queue.mark_sleeping(notify))
           {
-            backpressure_transition(Priority::Normal);
             if (notify)
             {
               // We must have run something to get here.
               assert(!notified_called);
               cown_notified();
-              // Treat notification as a message and don't deschedule
+              // Treat notification as a message and don't deschedule.
             }
             return true;
           }

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -245,8 +245,7 @@ namespace verona::rt
           assert(bp != Priority::Low);
           cown->schedule();
           mute_set.erase(ins.second);
-          if (ins.first)
-            T::release(alloc, cown);
+          T::release(alloc, cown);
 
           continue;
         }
@@ -274,7 +273,8 @@ namespace verona::rt
           auto& mute_set = *entry.value();
           for (auto it = mute_set.begin(); it != mute_set.end(); ++it)
           {
-            Systematic::cout() << "Mute map remove " << it.key() << std::endl;
+            Systematic::cout()
+              << "Mute map remove cown " << it.key() << std::endl;
             it.key()->unmute();
             T::release(alloc, it.key());
             mute_set.erase(it);
@@ -892,7 +892,7 @@ namespace verona::rt
               continue;
             }
           }
-          Systematic::cout() << "Stub collect: " << c << std::endl;
+          Systematic::cout() << "Stub collect cown " << c << std::endl;
           // TODO: Investigate systematic testing coverage here.
           auto epoch = c->epoch_when_popped;
           auto outdated =
@@ -901,7 +901,7 @@ namespace verona::rt
           {
             count++;
             *p = c->next;
-            Systematic::cout() << "Stub collected: " << c << std::endl;
+            Systematic::cout() << "Stub collected cown " << c << std::endl;
             c->dealloc(alloc);
             continue;
           }

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -275,7 +275,7 @@ namespace verona::rt
           {
             Systematic::cout()
               << "Mute map remove cown " << it.key() << std::endl;
-            it.key()->unmute();
+            it.key()->backpressure_transition(Priority::Normal);
             T::release(alloc, it.key());
             mute_set.erase(it);
           }

--- a/src/rt/sched/status.h
+++ b/src/rt/sched/status.h
@@ -12,26 +12,25 @@ namespace verona::rt
   enum struct Priority : uint8_t
   {
     /// Cown is muted. A muted cown must not be scheduled.
-    Low = 0b000,
+    Low = 0b01,
     /// Cown is sleeping. A sleeping cown is in a normal state and cannot change
     /// priority until scheduled.
-    Sleeping = 0b001,
+    // Sleeping = 0b001,
     /// Cown is normal and scheduled.
-    Normal = 0b101,
+    Normal = 0b00,
     /// Cown is temporarily protected from muting. This state may be reached by
     /// becoming overloaded or by being required for a behaviour with another
     /// high priority cown.
-    High = 0b010,
+    High = 0b10,
     /// Cown is high priority, but may transition back to normal if another
     /// token message falls out of the queue.
-    MaybeHigh = 0b011,
+    MaybeHigh = 0b11,
   };
 
   enum struct PriorityMask : uint8_t
   {
-    All = 0b111,
-    Normal = 0b001,
-    High = 0b010,
+    All = 0b11,
+    High = 0b10,
   };
 
   constexpr inline bool operator&(Priority p, PriorityMask m)
@@ -45,8 +44,6 @@ namespace verona::rt
     {
       case Priority::Low:
         return os << "Low";
-      case Priority::Sleeping:
-        return os << "Sleeping";
       case Priority::Normal:
         return os << "Normal";
       case Priority::High:


### PR DESCRIPTION
This is the first step towards implementing the full backpressure system, as described by the TLA+ spec. This is mostly cosmetic, except that prioritization via overloading is a state transition that may occur before a message is processed by a cown. Also, cowns are now lowered to a normal priority when their queue becomes empty and goes to sleep.