### PR TITLE
Make cown logs more consistent

### DIFF
--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -260,14 +260,14 @@ namespace verona::rt
 
     static void acquire(Object* o)
     {
-      Systematic::cout() << "Cown acquire: " << o << std::endl;
+      Systematic::cout() << "Cown " << o << " acquire" << std::endl;
       assert(o->debug_is_cown());
       o->incref();
     }
 
     static void release(Alloc* alloc, Cown* o)
     {
-      Systematic::cout() << "Cown release: " << o << std::endl;
+      Systematic::cout() << "Cown " << o << " release" << std::endl;
       assert(o->debug_is_cown());
       Cown* a = ((Cown*)o);
 
@@ -281,7 +281,7 @@ namespace verona::rt
       // All paths from this point must release the weak count owned by the
       // strong count.
 
-      Systematic::cout() << "Cown dealloc: " << o << std::endl;
+      Systematic::cout() << "Cown " << o << " dealloc" << std::endl;
 
       // During teardown don't recursively delete.
       if (Scheduler::is_teardown_in_progress())
@@ -481,7 +481,7 @@ namespace verona::rt
 
           case RegionMD::COWN:
             Systematic::cout()
-              << "Object Scan: reaches cown: " << o << std::endl;
+              << "Object Scan: reaches cown " << o << std::endl;
             Cown::mark_for_scan(o, epoch);
             break;
 
@@ -672,7 +672,7 @@ namespace verona::rt
           for (size_t i = 0; i < body.count; i++)
           {
             Systematic::cout()
-              << "Scanning cown: " << body.cowns[i] << std::endl;
+              << "Scanning cown " << body.cowns[i] << std::endl;
             body.cowns[i]->scan(alloc, Scheduler::local()->send_epoch);
           }
 
@@ -926,7 +926,7 @@ namespace verona::rt
       yield();
       if (curr == nullptr)
       {
-        Systematic::cout() << "Reached message token on cown: " << this
+        Systematic::cout() << "Reached message token on cown " << this
                            << std::endl;
         assert(stat.has_token());
         stat.set_has_token(false);
@@ -1071,7 +1071,8 @@ namespace verona::rt
           }
 
           Systematic::cout()
-            << "Cown has no work this time: " << this << std::endl;
+            << "Cown " << this << " has no work this time" << std::endl;
+
           // Deschedule the cown.
           Cown::release(alloc, this);
           return false;

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -139,13 +139,13 @@ namespace verona::rt
 
     inline void schedule_fifo(T* a)
     {
-      Systematic::cout() << "Enqueue cown: " << a << " (" << a->get_epoch_mark()
+      Systematic::cout() << "Enqueue cown " << a << " (" << a->get_epoch_mark()
                          << ")" << std::endl;
 
       // Scheduling on this thread, from this thread.
       if (!a->scanned(send_epoch))
       {
-        Systematic::cout() << "Enqueue unscanned cown: " << a << std::endl;
+        Systematic::cout() << "Enqueue unscanned cown " << a << std::endl;
         scheduled_unscanned_cown = true;
       }
       assert(!a->queue.is_sleeping());
@@ -163,7 +163,7 @@ namespace verona::rt
     {
       // A lifo scheduled cown is coming from an external source, such as
       // asynchronous I/O.
-      Systematic::cout() << "LIFO schedule cown: " << a << std::endl;
+      Systematic::cout() << "LIFO schedule cown " << a << std::endl;
 
       q.enqueue_front(ThreadAlloc::get(), a);
       stats.lifo();
@@ -344,7 +344,7 @@ namespace verona::rt
         {
           cown = q.dequeue(alloc);
           if (cown != nullptr)
-            Systematic::cout() << "Pop cown: " << cown << std::endl;
+            Systematic::cout() << "Pop cown " << cown << std::endl;
         }
 
         if (cown == nullptr)
@@ -363,7 +363,7 @@ namespace verona::rt
           continue;
         }
 
-        Systematic::cout() << "Schedule cown: " << cown << " ("
+        Systematic::cout() << "Schedule cown " << cown << " ("
                            << cown->get_epoch_mark() << ")" << std::endl;
 
         // This prevents the LD protocol advancing if this cown has not been
@@ -381,7 +381,7 @@ namespace verona::rt
 
         ld_protocol();
 
-        Systematic::cout() << "Running cown: " << cown << std::endl;
+        Systematic::cout() << "Running cown " << cown << std::endl;
 
         bool reschedule = cown->run(alloc, state, send_epoch);
 
@@ -425,7 +425,7 @@ namespace verona::rt
               if (!has_thread_bit(cown))
               {
                 Systematic::cout()
-                  << "Reschedule cown: " << cown << " ("
+                  << "Reschedule cown " << cown << " ("
                   << cown->get_epoch_mark() << ")" << std::endl;
               }
             }
@@ -433,7 +433,7 @@ namespace verona::rt
         }
         else
         {
-          Systematic::cout() << "Unschedule cown: " << cown << std::endl;
+          Systematic::cout() << "Unschedule cown " << cown << std::endl;
           // Don't reschedule.
           cown = nullptr;
         }
@@ -484,7 +484,7 @@ namespace verona::rt
         if (cown != nullptr)
         {
           // stats.steal();
-          Systematic::cout() << "Fast-steal cown: " << cown << " from "
+          Systematic::cout() << "Fast-steal cown " << cown << " from "
                              << victim->systematic_id << std::endl;
           result = cown;
           return true;
@@ -556,7 +556,7 @@ namespace verona::rt
           if (cown != nullptr)
           {
             stats.steal();
-            Systematic::cout() << "Stole cown: " << cown << " from "
+            Systematic::cout() << "Stole cown " << cown << " from "
                                << victim->systematic_id << std::endl;
             return cown;
           }
@@ -886,7 +886,7 @@ namespace verona::rt
         {
           if (c->weak_count != 0)
           {
-            Systematic::cout() << "Leaking cown: " << c << std::endl;
+            Systematic::cout() << "Leaking cown " << c << std::endl;
             if (Scheduler::get_detect_leaks())
             {
               *p = c->next;


### PR DESCRIPTION
The systematic log entries now refer to cowns in the form "cown <id>". This makes it easier to search through logs for all of the events that have been logged for a specific cown.