### PR TITLE
Lexical blocks add variable scope

### DIFF
--- a/src/mlir/generator.cc
+++ b/src/mlir/generator.cc
@@ -319,6 +319,9 @@ namespace mlir::verona
 
   llvm::Expected<ReturnValue> Generator::parseBlock(const ::ast::Ast& ast)
   {
+    // Blocks add lexical context
+    SymbolScopeT var_scope{symbolTable};
+
     ReturnValue last;
     llvm::SmallVector<::ast::WeakAst, 4> nodes;
     AST::getSubNodes(nodes, ast);

--- a/testsuite/mlir/mlir-parse/variables.verona
+++ b/testsuite/mlir/mlir-parse/variables.verona
@@ -1,0 +1,14 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+foo(a: S32 & iso, b: U64 & imm): S64
+{
+  // New variable, new name
+  let var = a + b;
+  {
+    // New scope, different variable
+    let var = a * b;
+  }
+  // Re-assignment of the first variable
+  var = a - b;
+}

--- a/testsuite/mlir/mlir-parse/variables/mlir.txt
+++ b/testsuite/mlir/mlir-parse/variables/mlir.txt
@@ -1,0 +1,20 @@
+
+
+module {
+  func @foo(%arg0: !verona.meet<class<"S32">, iso>, %arg1: !verona.meet<class<"U64">, imm>) -> !verona.class<"S64"> attributes {class = !verona.class<"$module">} {
+    %0 = "verona.alloca"() : () -> !verona.meet<class<"S32">, iso>
+    %1 = "verona.store"(%arg0, %0) : (!verona.meet<class<"S32">, iso>, !verona.meet<class<"S32">, iso>) -> !verona.unknown
+    %2 = "verona.alloca"() : () -> !verona.meet<class<"U64">, imm>
+    %3 = "verona.store"(%arg1, %2) : (!verona.meet<class<"U64">, imm>, !verona.meet<class<"U64">, imm>) -> !verona.unknown
+    %4 = verona.call "+"[%0 : !verona.meet<class<"S32">, iso>] (%2 : !verona.meet<class<"U64">, imm>) : !verona.unknown
+    %5 = "verona.alloca"() : () -> !verona.unknown
+    %6 = "verona.store"(%4, %5) : (!verona.unknown, !verona.unknown) -> !verona.unknown
+    %7 = verona.call "*"[%0 : !verona.meet<class<"S32">, iso>] (%2 : !verona.meet<class<"U64">, imm>) : !verona.unknown
+    %8 = "verona.alloca"() : () -> !verona.unknown
+    %9 = "verona.store"(%7, %8) : (!verona.unknown, !verona.unknown) -> !verona.unknown
+    %10 = verona.call "-"[%0 : !verona.meet<class<"S32">, iso>] (%2 : !verona.meet<class<"U64">, imm>) : !verona.unknown
+    %11 = "verona.store"(%10, %5) : (!verona.unknown, !verona.unknown) -> !verona.unknown
+    %12 = "verona.cast"(%11) : (!verona.unknown) -> !verona.class<"S64">
+    return %12 : !verona.class<"S64">
+  }
+}


### PR DESCRIPTION
With a test to make sure we can create nested scope variables with the
same name but access after the scope is still done to the original
variable.