### PR TITLE
Add support for the shadow root stack in the VM

### DIFF
--- a/src/compiler/codegen/builtins.cc
+++ b/src/compiler/codegen/builtins.cc
@@ -85,26 +85,24 @@ namespace verona::compiler
     assert(abi_.arguments >= 2);
     assert(abi_.returns == 1);
 
-    size_t value_count = abi_.arguments - 2;
-    uint8_t value_count_trunc = truncate<uint8_t>(value_count);
+    std::vector<Register> args;
+    for (uint8_t i = 0; i < abi_.arguments - 2; i++)
+    {
+      args.push_back(Register(2 + i));
+    }
+
     gen_.opcode(Opcode::Print);
     gen_.reg(Register(1));
-    gen_.u8(value_count_trunc);
-    for (uint8_t i = 0; i < value_count_trunc; i++)
-    {
-      gen_.reg(Register(2 + i));
-    }
+    gen_.reglist(args);
 
-    gen_.opcode(Opcode::Clear);
-    gen_.reg(Register(1));
-    for (uint8_t i = 0; i < value_count_trunc; i++)
-    {
-      gen_.opcode(Opcode::Clear);
-      gen_.reg(Register(2 + i));
-    }
+    // Re-use the args vector for the clear OP, but this time we want to include
+    // the first two parameters.
+    args.push_back(Register(1));
+    args.push_back(Register(0));
 
-    gen_.opcode(Opcode::Clear);
-    gen_.reg(Register(0));
+    gen_.opcode(Opcode::ClearList);
+    gen_.reglist(args);
+
     gen_.opcode(Opcode::Return);
   }
 
@@ -128,10 +126,8 @@ namespace verona::compiler
 
     gen_.opcode(Opcode::TraceRegion);
     gen_.reg(Register(1));
-    gen_.opcode(Opcode::Clear);
-    gen_.reg(Register(0));
-    gen_.opcode(Opcode::Clear);
-    gen_.reg(Register(1));
+    gen_.opcode(Opcode::ClearList);
+    gen_.reglist({Register(0), Register(1)});
     gen_.opcode(Opcode::Return);
   }
 
@@ -188,10 +184,8 @@ namespace verona::compiler
     gen_.opcode(Opcode::FulfillSleepingCown);
     gen_.reg(Register(0));
     gen_.reg(Register(1));
-    gen_.opcode(Opcode::Clear);
-    gen_.reg(Register(0));
-    gen_.opcode(Opcode::Clear);
-    gen_.reg(Register(1));
+    gen_.opcode(Opcode::ClearList);
+    gen_.reglist({Register(0), Register(1)});
     gen_.opcode(Opcode::Return);
   }
 }

--- a/src/compiler/codegen/function.cc
+++ b/src/compiler/codegen/function.cc
@@ -127,6 +127,7 @@ namespace verona::compiler
         abi,
         method,
         *analysis.typecheck,
+        *analysis.liveness,
         closure_labels);
 
       std::string name = method.instantiated_path();

--- a/src/compiler/codegen/generator.cc
+++ b/src/compiler/codegen/generator.cc
@@ -39,6 +39,16 @@ namespace verona::compiler
     u8(reg.index);
   }
 
+  void Generator::reglist(bytecode::RegisterSpan regs)
+  {
+    size_t size = regs.size();
+    u8(truncate<uint8_t>(size));
+    for (bytecode::Register r : regs)
+    {
+      reg(r);
+    }
+  }
+
   void Generator::opcode(bytecode::Opcode opcode)
   {
     u8((uint8_t)opcode);

--- a/src/compiler/codegen/generator.h
+++ b/src/compiler/codegen/generator.h
@@ -56,6 +56,11 @@ namespace verona::compiler
     void descriptor(Descriptor descriptor);
 
     /**
+     * Emit a list of registers, prefixed by an 8-bit length.
+     */
+    void reglist(bytecode::RegisterSpan regs);
+
+    /**
      * Write relocatable integer values in little endian format, with an
      * optional added.
      *

--- a/src/compiler/codegen/ir.h
+++ b/src/compiler/codegen/ir.h
@@ -266,11 +266,17 @@ namespace verona::compiler
 
     void visit_stmt(const EndScopeStmt& stmt)
     {
+      std::vector<Register> regs;
       // TODO: This could be omitted for variables with a non-linear type.
       for (Variable v : stmt.dead_variables)
       {
-        gen_.opcode(Opcode::Clear);
-        gen_.reg(variable(v));
+        regs.push_back(variable(v));
+      }
+
+      if (!regs.empty())
+      {
+        gen_.opcode(Opcode::ClearList);
+        gen_.reglist(regs);
       }
     }
 

--- a/src/interpreter/bytecode.h
+++ b/src/interpreter/bytecode.h
@@ -217,9 +217,11 @@ namespace verona::bytecode
     NewRegion, // dst(u8), descriptor(u8)
     NewSleepingCown, // dst(u8), descriptor(u8)
     Print, // format(u8), argc(u8), args(u8)...
+    Protect, // argc(u8), args(u8)...
     Return,
     Store, // dst(u8), base(u8), selector(u32), src(u8)
     TraceRegion, // region(u8)
+    Unprotect, // argc(u8), args(u8)...
     Unreachable,
     When, // codepointer(u32), cown count(u8), capture count(u8)
 
@@ -401,6 +403,13 @@ namespace verona::bytecode
   };
 
   template<>
+  struct OpcodeSpec<Opcode::Protect>
+  {
+    using Operands = OpcodeOperands<RegisterSpan>;
+    constexpr static std::string_view format = "PROTECT {}";
+  };
+
+  template<>
   struct OpcodeSpec<Opcode::Store>
   {
     using Operands = OpcodeOperands<Register, Register, SelectorIdx, Register>;
@@ -433,6 +442,13 @@ namespace verona::bytecode
   {
     using Operands = OpcodeOperands<CodePtr, uint8_t, uint8_t>;
     constexpr static std::string_view format = "WHEN {}, {:#x}, {:#x}";
+  };
+
+  template<>
+  struct OpcodeSpec<Opcode::Unprotect>
+  {
+    using Operands = OpcodeOperands<RegisterSpan>;
+    constexpr static std::string_view format = "UNPROTECT {}";
   };
 
   template<>

--- a/src/interpreter/bytecode.h
+++ b/src/interpreter/bytecode.h
@@ -7,6 +7,7 @@
 #include <limits>
 #include <ostream>
 #include <string_view>
+#include <vector>
 
 /**
  * # Program Layout
@@ -144,6 +145,52 @@ namespace verona::bytecode
     explicit Register(uint8_t index) : index(index) {}
     uint8_t index;
   };
+
+  /**
+   * Contiguous sequence of Register values. It is used to encode and decode
+   * opcodes that accept a variable number of operands.
+   *
+   * This is a restricted subset of a C++20 `std::span<const Register>`
+   */
+  class RegisterSpan
+  {
+  public:
+    explicit RegisterSpan(const Register* begin, const Register* end)
+    : begin_(begin), end_(end)
+    {}
+
+    explicit RegisterSpan(const Register* begin, size_t size)
+    : RegisterSpan(begin, begin + size)
+    {}
+
+    RegisterSpan(const std::vector<Register>& regs)
+    : RegisterSpan(regs.data(), regs.size())
+    {}
+
+    RegisterSpan(const std::initializer_list<Register>& regs)
+    : RegisterSpan(regs.begin(), regs.end())
+    {}
+
+    size_t size() const
+    {
+      return end_ - begin_;
+    }
+
+    const Register* begin() const
+    {
+      return begin_;
+    }
+
+    const Register* end() const
+    {
+      return end_;
+    }
+
+  private:
+    const Register* begin_;
+    const Register* end_;
+  };
+
   constexpr static size_t REGISTER_COUNT = 256;
 
   enum class Opcode : uint8_t

--- a/src/interpreter/bytecode.h
+++ b/src/interpreter/bytecode.h
@@ -198,6 +198,7 @@ namespace verona::bytecode
     BinOp, // op(u8), src1(u8), src2(u8)
     Call, // selector(u32), callspace(u8)
     Clear, // dst(u8)
+    ClearList, // argc(u8), dst(u8)...
     Copy, // dst(u8), src(u8)
     FulfillSleepingCown, // cown(u8), val(u8)
     Freeze, // dst(u8), src(u8)
@@ -278,6 +279,13 @@ namespace verona::bytecode
   {
     using Operands = OpcodeOperands<Register>;
     constexpr static std::string_view format = "CLEAR {}";
+  };
+
+  template<>
+  struct OpcodeSpec<Opcode::ClearList>
+  {
+    using Operands = OpcodeOperands<RegisterSpan>;
+    constexpr static std::string_view format = "CLEAR_LIST {}";
   };
 
   template<>

--- a/src/interpreter/bytecode.h
+++ b/src/interpreter/bytecode.h
@@ -396,7 +396,7 @@ namespace verona::bytecode
   template<>
   struct OpcodeSpec<Opcode::Print>
   {
-    using Operands = OpcodeOperands<Register, uint8_t>;
+    using Operands = OpcodeOperands<Register, RegisterSpan>;
     constexpr static std::string_view format = "PRINT {}, {}";
   };
 

--- a/src/interpreter/code.h
+++ b/src/interpreter/code.h
@@ -268,8 +268,8 @@ namespace verona::interpreter
       }
     };
 
-    template<typename Dummy>
-    struct load_helper<std::string_view, Dummy>
+    template<>
+    struct load_helper<std::string_view>
     {
       static std::string_view load(const Code& code, size_t& ip)
       {
@@ -279,6 +279,20 @@ namespace verona::interpreter
           reinterpret_cast<const char*>(&code.data_[ip]), size);
         ip += size;
         return s;
+      }
+    };
+
+    template<>
+    struct load_helper<bytecode::RegisterSpan>
+    {
+      static bytecode::RegisterSpan load(const Code& code, size_t& ip)
+      {
+        uint8_t size = code.u8(ip);
+        code.check(ip, size);
+        const bytecode::Register* data =
+          reinterpret_cast<const bytecode::Register*>(&code.data_[ip]);
+        ip += size;
+        return bytecode::RegisterSpan(data, size);
       }
     };
   };

--- a/src/interpreter/convert.h
+++ b/src/interpreter/convert.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include "interpreter/value_list.h"
 #include "interpreter/vm.h"
 
 namespace verona::interpreter
@@ -133,6 +134,15 @@ namespace verona::interpreter
       const Value& value = vm->read(reg);
       vm->check_type(value, Value::STRING);
       return value->string();
+    }
+  };
+
+  template<bool IsConst>
+  struct convert_operand<BaseValueList<IsConst>>
+  {
+    static BaseValueList<IsConst> convert(VM* vm, RegisterSpan regs)
+    {
+      return BaseValueList<IsConst>(vm, regs);
     }
   };
 

--- a/src/interpreter/value.cc
+++ b/src/interpreter/value.cc
@@ -63,6 +63,14 @@ namespace verona::interpreter
     return v;
   }
 
+  Value Value::unowned_cown(VMCown* cown)
+  {
+    Value v;
+    v.tag = COWN_UNOWNED;
+    v.inner.cown = cown;
+    return v;
+  }
+
   Value Value::descriptor(const VMDescriptor* descriptor)
   {
     Value v;
@@ -124,26 +132,37 @@ namespace verona::interpreter
     tag = UNINIT;
   }
 
-  void Value::consume_cown()
+  VMCown* Value::consume_cown()
   {
     switch (tag)
     {
       case COWN:
-        tag = COWN_UNOWNED;
-        return;
+        tag = UNINIT;
+        return inner.cown;
       default:
         abort();
     }
   }
 
-  void Value::switch_to_cown_body()
+  Value Value::as_unowned_cown() const
   {
     switch (tag)
     {
+      case COWN:
+        return Value::unowned_cown(inner.cown);
+
+      default:
+        abort();
+    }
+  }
+
+  Value Value::cown_body() const
+  {
+    switch (tag)
+    {
+      case COWN:
       case COWN_UNOWNED:
-        tag = MUT;
-        inner.object = inner.cown->contents;
-        return;
+        return Value::mut(inner.cown->contents);
       default:
         abort();
     }

--- a/src/interpreter/value.h
+++ b/src/interpreter/value.h
@@ -92,6 +92,9 @@ namespace verona::interpreter
      * Clear the Value, making it UNINIT.
      *
      * It will release any ownership of regions or reference counts it may have.
+     *
+     * Note that this may cause a re-entrant call onto the VM if an object with
+     * a finaliser is deallocated.
      */
     void clear(rt::Alloc* alloc);
 
@@ -101,6 +104,9 @@ namespace verona::interpreter
      * This moves the contents of `other` into this Value, and releases the old
      * one. It's essentially a move assignment operator, but with access to the
      * memory allocator.
+     *
+     * Note that this may cause a re-entrant call onto the VM if an object with
+     * a finaliser is deallocated.
      */
     void overwrite(rt::Alloc* alloc, Value&& other);
 

--- a/src/interpreter/value.h
+++ b/src/interpreter/value.h
@@ -78,6 +78,7 @@ namespace verona::interpreter
     static Value imm(VMObject* object);
     // Takes ownership of the reference count.
     static Value cown(VMCown* cown);
+    static Value unowned_cown(VMCown* cown);
 
     static Value descriptor(const VMDescriptor* descriptor);
 
@@ -130,17 +131,23 @@ namespace verona::interpreter
     VMObject* consume_iso();
 
     /**
-     * Consume a COWN value, making it unowned. Ownership is released to the
-     * caller.  But the cown is still intact.  This is used when ownership of a
-     * cown is passed to the runtime in a multi-message.
+     * Consume a COWN value, extracting the underlying VMCown*. Ownership is
+     * transferred with the return value.
+     *
+     * This Value is cleared to UNINIT.
      */
-    void consume_cown();
+    VMCown* consume_cown();
 
     /**
-     * On an unowned cown, this converts it to a reference to the underlying
-     * object.
+     * Given a COWN value, get an equivalent COWN_UNOWNED value. This is
      */
-    void switch_to_cown_body();
+    Value as_unowned_cown() const;
+
+    /**
+     * Given a COWN or COWN_UNOWNED value, get a MUT Value referring to the
+     * contents.
+     */
+    Value cown_body() const;
 
     Inner* operator->()
     {

--- a/src/interpreter/value_list.h
+++ b/src/interpreter/value_list.h
@@ -1,0 +1,96 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "interpreter/vm.h"
+
+namespace verona::interpreter
+{
+  using bytecode::Register;
+  using bytecode::RegisterSpan;
+
+  /**
+   * Adaptor around a RegisterSpan, providing iterators that yield a Value for
+   * each register.
+   *
+   * It comes in two variants, ConstValueList and ValueList, depending on
+   * whether it yields const references or not.
+   */
+  template<bool IsConst>
+  class BaseValueList
+  {
+    using vm_pointer = std::conditional_t<IsConst, const VM*, VM*>;
+    using value_type = std::conditional_t<IsConst, const Value, Value>;
+
+    template<bool IsReverse>
+    struct base_iterator
+    {
+      value_type& operator*()
+      {
+        if constexpr (IsReverse)
+          return vm_->read(*(register_ - 1));
+        else
+          return vm_->read(*register_);
+      }
+
+      bool operator!=(const base_iterator& other) const
+      {
+        assert(vm_ == other.vm_);
+        return register_ != other.register_;
+      }
+
+      base_iterator& operator++()
+      {
+        if constexpr (IsReverse)
+          register_--;
+        else
+          register_++;
+        return *this;
+      }
+
+    private:
+      explicit base_iterator(vm_pointer vm, const Register* reg)
+      : vm_(vm), register_(reg)
+      {}
+      vm_pointer vm_;
+      const Register* register_;
+
+      friend class BaseValueList;
+    };
+
+  public:
+    BaseValueList(vm_pointer vm, RegisterSpan registers)
+    : vm_(vm), registers_(registers)
+    {}
+
+    using iterator = base_iterator<false>;
+    using reverse_iterator = base_iterator<true>;
+
+    iterator begin() const
+    {
+      return iterator(vm_, registers_.begin());
+    }
+
+    iterator end() const
+    {
+      return iterator(vm_, registers_.end());
+    }
+
+    reverse_iterator rbegin() const
+    {
+      return reverse_iterator(vm_, registers_.end());
+    }
+
+    reverse_iterator rend() const
+    {
+      return reverse_iterator(vm_, registers_.begin());
+    }
+
+  private:
+    vm_pointer vm_;
+    RegisterSpan registers_;
+  };
+
+  using ValueList = BaseValueList<false>;
+  using ConstValueList = BaseValueList<true>;
+}

--- a/src/interpreter/vm.cc
+++ b/src/interpreter/vm.cc
@@ -516,8 +516,9 @@ namespace verona::interpreter
         header.argc);
     }
 
-    size_t top = frame().base + frame().locals;
-    Value* values = &stack_[top - callspace + 1];
+    // Compute the base of the new "frame", relative to the current frame.
+    // We use this to copy these values into the message
+    size_t base = frame().locals - callspace;
 
     // Prepare the cowns and the arguments for the method invocation.
     std::vector<Value> args;
@@ -531,7 +532,7 @@ namespace verona::interpreter
     // The rest are the cowns
     for (size_t i = 0; i < cown_count; i++)
     {
-      Value& v = values[i];
+      Value& v = read(Register(truncate<uint8_t>(base + 1 + i)));
       trace("Capturing cown {:d}: {}", i, v);
       check_type(v, Value::COWN);
 
@@ -547,7 +548,7 @@ namespace verona::interpreter
     // The rest are the captured values
     for (size_t i = 0; i < capture_count; i++)
     {
-      Value& v = values[i + cown_count];
+      Value& v = read(Register(truncate<uint8_t>(base + 1 + cown_count + i)));
       trace("Capturing variable {:d}: {}", i + cown_count, v);
       args.push_back(std::move(v));
     }

--- a/src/interpreter/vm.cc
+++ b/src/interpreter/vm.cc
@@ -4,6 +4,7 @@
 
 #include "interpreter/convert.h"
 #include "interpreter/format.h"
+#include "interpreter/value_list.h"
 
 #include <fmt/ranges.h>
 
@@ -268,6 +269,14 @@ namespace verona::interpreter
   Value VM::opcode_clear()
   {
     return Value();
+  }
+
+  void VM::opcode_clear_list(ValueList values)
+  {
+    for (Value& value : values)
+    {
+      value.clear(alloc_);
+    }
   }
 
   void VM::opcode_fulfill_sleeping_cown(const Value& cown, Value result)
@@ -574,6 +583,7 @@ namespace verona::interpreter
       OP(BinOp, opcode_binop);
       OP(Call, opcode_call);
       OP(Clear, opcode_clear);
+      OP(ClearList, opcode_clear_list);
       OP(Copy, opcode_copy);
       OP(FulfillSleepingCown, opcode_fulfill_sleeping_cown);
       OP(Freeze, opcode_freeze);

--- a/src/interpreter/vm.cc
+++ b/src/interpreter/vm.cc
@@ -423,13 +423,12 @@ namespace verona::interpreter
     rt::RegionTrace::gc(alloc_, region);
   }
 
-  void VM::opcode_print(std::string_view fmt, uint8_t argc)
+  void VM::opcode_print(std::string_view fmt, ConstValueList values)
   {
     fmt::dynamic_format_arg_store<fmt::format_context> store;
-    for (uint8_t i = 0; i < argc; i++)
+    for (const Value& value : values)
     {
-      Register reg = code_.load<Register>(frame().ip);
-      store.push_back(std::cref(read(reg)));
+      store.push_back(std::cref(value));
     }
     fmt::vprint(fmt, store);
   }

--- a/src/interpreter/vm.h
+++ b/src/interpreter/vm.h
@@ -80,6 +80,8 @@ namespace verona::interpreter
     Value opcode_new_cown(const VMDescriptor* descriptor, Value src);
     Value opcode_new_sleeping_cown(const VMDescriptor* descriptor);
     void opcode_print(std::string_view fmt, ConstValueList values);
+    void opcode_protect(ConstValueList values);
+    void opcode_unprotect(ConstValueList values);
     void opcode_return();
     Value opcode_store(const Value& base, SelectorIdx selector, Value src);
     Value opcode_string(std::string_view imm);

--- a/src/interpreter/vm.h
+++ b/src/interpreter/vm.h
@@ -79,7 +79,7 @@ namespace verona::interpreter
     Value opcode_new_region(const VMDescriptor* descriptor);
     Value opcode_new_cown(const VMDescriptor* descriptor, Value src);
     Value opcode_new_sleeping_cown(const VMDescriptor* descriptor);
-    void opcode_print(std::string_view fmt, uint8_t argc);
+    void opcode_print(std::string_view fmt, ConstValueList values);
     void opcode_return();
     Value opcode_store(const Value& base, SelectorIdx selector, Value src);
     Value opcode_string(std::string_view imm);

--- a/src/interpreter/vm.h
+++ b/src/interpreter/vm.h
@@ -11,6 +11,12 @@ namespace verona::interpreter
 {
   using bytecode::Register;
 
+  template<bool Const>
+  class BaseValueList;
+
+  using ValueList = BaseValueList<false>;
+  using ConstValueList = BaseValueList<true>;
+
   class VM
   {
   public:
@@ -257,6 +263,9 @@ namespace verona::interpreter
     friend struct convert_operand;
     template<typename T>
     friend struct execute_handler;
+
+    template<bool IsConst>
+    friend class BaseValueList;
   };
 
   /**

--- a/src/interpreter/vm.h
+++ b/src/interpreter/vm.h
@@ -62,6 +62,7 @@ namespace verona::interpreter
     opcode_binop(bytecode::BinaryOperator op, uint64_t left, uint64_t right);
     void opcode_call(SelectorIdx selector, uint8_t callspace);
     Value opcode_clear();
+    void opcode_clear_list(ValueList values);
     Value opcode_copy(Value src);
     void opcode_fulfill_sleeping_cown(const Value& cown, Value result);
     Value opcode_freeze(Value src);

--- a/src/interpreter/vm.h
+++ b/src/interpreter/vm.h
@@ -187,8 +187,13 @@ namespace verona::interpreter
      *
      * Each execution frame has a view into this stack. Register access is done
      * within this view.
+     *
+     * Because of finalisers, the VM needs to support re-entrant invocations,
+     * which may cause the stack to grow at unexpected times. We use a deque
+     * rather than a vector to make sure references don't get invalidated when
+     * this happens.
      */
-    std::vector<Value> stack_;
+    std::deque<Value> stack_;
 
     struct Frame
     {

--- a/src/rt/region/region_trace.h
+++ b/src/rt/region/region_trace.h
@@ -279,19 +279,21 @@ namespace verona::rt
       }
     }
 
-    /// Add root to the stack.
+    /// Add object `o` to the additional root stack of the region referenced to
+    /// by `entry`.
     /// Preserves for object for a GC.
-    static void push_additional_root(Object* root, Object* o, Alloc* alloc)
+    static void push_additional_root(Object* entry, Object* o, Alloc* alloc)
     {
-      RegionTrace* reg = get(root);
+      RegionTrace* reg = get(entry);
       reg->additional_entry_points.push(o, alloc);
     }
 
-    /// Remove root from the stack.
+    /// Remove object `o` from the additional root stack of the region
+    /// referenced to by `entry`.
     /// Must be called in reverse order with respect to push_additional_root.
-    static void pop_additional_root(Object* root, Object* o, Alloc* alloc)
+    static void pop_additional_root(Object* entry, Object* o, Alloc* alloc)
     {
-      RegionTrace* reg = get(root);
+      RegionTrace* reg = get(entry);
       auto result = reg->additional_entry_points.pop(alloc);
       assert(result == o);
       UNUSED(result);

--- a/testsuite/features/run-pass/tidy-protect.verona
+++ b/testsuite/features/run-pass/tidy-protect.verona
@@ -1,0 +1,62 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+// This test checks that live variables are added to their region's shadow
+// stack, preventing reachable objects from being garbage collected.
+
+class Node
+{
+  id: U64;
+
+  // Self should really be read-only, but not implemented yet.
+  // This is called when the runtime deallocates this object.
+  final(self: mut)
+  {
+    Builtin.print1("Deallocating: {:#}\n", self);
+  }
+}
+
+class Main
+{
+  drop(x: Node & iso) {}
+  main()
+  {
+    var o1 = new Node;
+    var o2 = new Node in o1;
+    var o3 = new Node in o1;
+    var o4 = new Node in o1;
+    var o5 = new Node in o1;
+
+    o1.id = 1;
+    o2.id = 2;
+    o3.id = 3;
+    o4.id = 4;
+    o5.id = 5;
+
+    // CHECK-L: Before: Node { 1 }, Node { 2 }, Node { 3 }, Node { 4 }, Node { 5 }
+    Builtin.print5("Before: {:#}, {:#}, {:#}, {:#}, {:#}\n", mut-view o1, o2, o3, o4, o5);
+
+    // o1, o2 and o3 are live at this point, due to their use in the next print
+    // call. In contrast, o2 and o4 are unreachable, both from the stack and
+    // from the heap, and therefore are garbage collected by the call to
+    // Builtin.trace.
+
+    // CHECK-L: Deallocating: Node { 4 }
+    // CHECK-L: Deallocating: Node { 2 }
+    Builtin.trace(mut-view o1);
+
+    // CHECK-L: After: Node { 1 }, Node { 3 }, Node { 5 }
+    Builtin.print3("After: {:#}, {:#}, {:#}\n", mut-view o1, o3, o5);
+
+    // Prompt deallocation of the region causes the rest of the objects to be
+    // collected.
+
+    // CHECK-L: Deallocating: Node { 5 }
+    // CHECK-L: Deallocating: Node { 3 }
+    // CHECK-L: Deallocating: Node { 1 }
+    Main.drop(o1);
+
+    // CHECK-L: Done
+    Builtin.print("Done");
+  }
+}


### PR DESCRIPTION
The VM gains two new opcodes, PROTECT and UNPROTECT, which respectively add and remove objects from the shadow root stack of the runtime.

The compiler uses liveness information to insert the operations around every method call. Note that this is very conservative. The compiler makes no attempt to guess whether a reference is in fact in the same region as one of the arguments or not. It just assumes it could and protects everything.

Couple of cleanups and fixes:
- Clarify parameter names of the shadow stack API.
- Fix a bug caused by finalisers, where the value stack grows at unexpected times.
- Add proper support for opcodes with a variable number of arguments. The Print opcode already did this, but in a very ad-hoc way.