### PR TITLE
Fix alloca values not being loaded

### DIFF
--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -125,7 +125,7 @@ namespace mlir::verona
     : context(context), builder(context), unkLoc(builder.getUnknownLoc())
     {
       // Initialise boolean / unknown types for convenience coding
-      unkTy = generateType("unk");
+      unkTy = UnknownType::get(context);
       boolTy = builder.getI1Type();
     }
 

--- a/testsuite/mlir/mlir-parse/call/mlir.txt
+++ b/testsuite/mlir/mlir-parse/call/mlir.txt
@@ -6,29 +6,33 @@ module @"$module" {
     %1 = "verona.store"(%arg0, %0) : (!verona.imm, !verona.imm) -> !verona.unknown
     %2 = "verona.alloca"() : () -> !verona.meet<class<"U64">, imm>
     %3 = "verona.store"(%arg1, %2) : (!verona.meet<class<"U64">, imm>, !verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %4 = verona.call "+"[%0 : !verona.imm] (%2 : !verona.meet<class<"U64">, imm>) : !verona.unknown
-    %5 = "verona.alloca"() : () -> !verona.unknown
-    %6 = "verona.store"(%4, %5) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    %7 = verona.call "-"[%0 : !verona.imm] (%2 : !verona.meet<class<"U64">, imm>) : !verona.unknown
-    %8 = "verona.alloca"() : () -> !verona.unknown
-    %9 = "verona.store"(%7, %8) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    %10 = "verona.load"(%5) : (!verona.unknown) -> !verona.unknown
-    %11 = "verona.constant(100)"() : () -> !verona.class<"int">
-    %12 = verona.call "<"[%10 : !verona.unknown] (%11 : !verona.class<"int">) : !verona.unknown
-    %13 = "verona.cast"(%12) : (!verona.unknown) -> i1
-    cond_br %13, ^bb1, ^bb2
+    %4 = "verona.load"(%0) : (!verona.imm) -> !verona.unknown
+    %5 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
+    %6 = verona.call "+"[%4 : !verona.unknown] (%5 : !verona.unknown) : !verona.unknown
+    %7 = "verona.alloca"() : () -> !verona.unknown
+    %8 = "verona.store"(%6, %7) : (!verona.unknown, !verona.unknown) -> !verona.unknown
+    %9 = "verona.load"(%0) : (!verona.imm) -> !verona.unknown
+    %10 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
+    %11 = verona.call "-"[%9 : !verona.unknown] (%10 : !verona.unknown) : !verona.unknown
+    %12 = "verona.alloca"() : () -> !verona.unknown
+    %13 = "verona.store"(%11, %12) : (!verona.unknown, !verona.unknown) -> !verona.unknown
+    %14 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
+    %15 = "verona.constant(100)"() : () -> !verona.class<"int">
+    %16 = verona.call "<"[%14 : !verona.unknown] (%15 : !verona.class<"int">) : !verona.unknown
+    %17 = "verona.cast"(%16) : (!verona.unknown) -> i1
+    cond_br %17, ^bb1, ^bb2
   ^bb1:  // pred: ^bb0
-    %14 = "verona.load"(%5) : (!verona.unknown) -> !verona.unknown
-    %15 = "verona.load"(%8) : (!verona.unknown) -> !verona.unknown
-    %16 = verona.call "foo"[%14 : !verona.unknown] (%15 : !verona.unknown) : !verona.unknown
-    %17 = "verona.cast"(%16) : (!verona.unknown) -> !verona.meet<class<"U64">, imm>
-    return %17 : !verona.meet<class<"U64">, imm>
-  ^bb2:  // pred: ^bb0
-    %18 = "verona.load"(%5) : (!verona.unknown) -> !verona.unknown
-    %19 = "verona.load"(%8) : (!verona.unknown) -> !verona.unknown
-    %20 = verona.call "+"[%18 : !verona.unknown] (%19 : !verona.unknown) : !verona.unknown
+    %18 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
+    %19 = "verona.load"(%12) : (!verona.unknown) -> !verona.unknown
+    %20 = verona.call "foo"[%18 : !verona.unknown] (%19 : !verona.unknown) : !verona.unknown
     %21 = "verona.cast"(%20) : (!verona.unknown) -> !verona.meet<class<"U64">, imm>
     return %21 : !verona.meet<class<"U64">, imm>
+  ^bb2:  // pred: ^bb0
+    %22 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
+    %23 = "verona.load"(%12) : (!verona.unknown) -> !verona.unknown
+    %24 = verona.call "+"[%22 : !verona.unknown] (%23 : !verona.unknown) : !verona.unknown
+    %25 = "verona.cast"(%24) : (!verona.unknown) -> !verona.meet<class<"U64">, imm>
+    return %25 : !verona.meet<class<"U64">, imm>
   }
   func @apply() attributes {class = !verona.class<"$module">} {
     %0 = "verona.constant(10)"() : () -> !verona.class<"int">
@@ -37,7 +41,9 @@ module @"$module" {
     %3 = "verona.constant(20)"() : () -> !verona.class<"int">
     %4 = "verona.alloca"() : () -> !verona.meet<class<"U64">, imm>
     %5 = "verona.store"(%3, %4) : (!verona.class<"int">, !verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %6 = verona.call "foo"[%1 : !verona.imm] (%4 : !verona.meet<class<"U64">, imm>) : !verona.unknown
+    %6 = "verona.load"(%1) : (!verona.imm) -> !verona.unknown
+    %7 = "verona.load"(%4) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
+    %8 = verona.call "foo"[%6 : !verona.unknown] (%7 : !verona.unknown) : !verona.unknown
     return
   }
 }

--- a/testsuite/mlir/mlir-parse/class/mlir.txt
+++ b/testsuite/mlir/mlir-parse/class/mlir.txt
@@ -22,12 +22,13 @@ module @"$module" {
     func @baz(%arg0: !verona.class<"F32">) -> !verona.class<"F32"> attributes {class = !verona.class<"G", "$parent" : class<"$module">>, qualifiers = ["static"]} {
       %0 = "verona.alloca"() : () -> !verona.class<"F32">
       %1 = "verona.store"(%arg0, %0) : (!verona.class<"F32">, !verona.class<"F32">) -> !verona.unknown
-      %2 = "verona.constant(42)"() : () -> !verona.class<"int">
-      %3 = verona.static !verona.class<"G", "$parent" : class<"$module">> : !verona<"">
-      %4 = verona.call "foo"[%3 : !verona<"">] (%2 : !verona.class<"int">) : !verona.unknown
-      %5 = verona.call "+"[%0 : !verona.class<"F32">] (%4 : !verona.unknown) : !verona.unknown
-      %6 = "verona.cast"(%5) : (!verona.unknown) -> !verona.class<"F32">
-      return %6 : !verona.class<"F32">
+      %2 = "verona.load"(%0) : (!verona.class<"F32">) -> !verona.unknown
+      %3 = "verona.constant(42)"() : () -> !verona.class<"int">
+      %4 = verona.static !verona.class<"G", "$parent" : class<"$module">> : !verona<"">
+      %5 = verona.call "foo"[%4 : !verona<"">] (%3 : !verona.class<"int">) : !verona.unknown
+      %6 = verona.call "+"[%2 : !verona.unknown] (%5 : !verona.unknown) : !verona.unknown
+      %7 = "verona.cast"(%6) : (!verona.unknown) -> !verona.class<"F32">
+      return %7 : !verona.class<"F32">
     }
   }
   module @POD {
@@ -48,44 +49,51 @@ module @"$module" {
     %12 = verona.new_region @C [] : !verona.class<"C", "$parent" : class<"$module">>
     %13 = "verona.alloca"() : () -> !verona.meet<class<"C", "$parent" : class<"$module">>, iso>
     %14 = "verona.store"(%12, %13) : (!verona.class<"C", "$parent" : class<"$module">>, !verona.meet<class<"C", "$parent" : class<"$module">>, iso>) -> !verona.unknown
-    %15 = verona.new_object @C [] in(%13 : !verona.meet<class<"C", "$parent" : class<"$module">>, iso>) : !verona.class<"C", "$parent" : class<"$module">>
-    %16 = "verona.alloca"() : () -> !verona.meet<class<"C", "$parent" : class<"$module">>, iso>
-    %17 = "verona.store"(%15, %16) : (!verona.class<"C", "$parent" : class<"$module">>, !verona.meet<class<"C", "$parent" : class<"$module">>, iso>) -> !verona.unknown
-    %18 = "verona.constant(42)"() : () -> !verona.class<"int">
-    %19 = "verona.constant(3.14)"() : () -> !verona.class<"float">
-    %20 = verona.new_region @POD ["a", "b"](%18, %19 : !verona.class<"int">, !verona.class<"float">) : !verona.class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>
-    %21 = "verona.alloca"() : () -> !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso>
-    %22 = "verona.store"(%20, %21) : (!verona.class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso>) -> !verona.unknown
-    %23 = "verona.constant(21)"() : () -> !verona.class<"int">
-    %24 = "verona.constant(2.72)"() : () -> !verona.class<"float">
-    %25 = verona.new_object @POD ["a", "b"](%23, %24 : !verona.class<"int">, !verona.class<"float">) in(%21 : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso>) : !verona.class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>
-    %26 = "verona.alloca"() : () -> !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso>
-    %27 = "verona.store"(%25, %26) : (!verona.class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso>) -> !verona.unknown
-    %28 = verona.field_read %21["a"] : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown
-    %29 = "verona.alloca"() : () -> !verona.meet<class<"U32">, mut>
-    %30 = "verona.store"(%28, %29) : (!verona.unknown, !verona.meet<class<"U32">, mut>) -> !verona.unknown
-    %31 = verona.field_read %26["a"] : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown
-    %32 = "verona.alloca"() : () -> !verona.meet<class<"U32">, mut>
-    %33 = "verona.store"(%31, %32) : (!verona.unknown, !verona.meet<class<"U32">, mut>) -> !verona.unknown
-    %34 = verona.call "+"[%29 : !verona.meet<class<"U32">, mut>] (%32 : !verona.meet<class<"U32">, mut>) : !verona.unknown
-    %35 = verona.field_write %26["a"], %34 : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown -> !verona.unknown
-    %36 = verona.field_read %26["a"] : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown
-    %37 = verona.field_write %21["a"], %36 : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown -> !verona.unknown
-    %38 = "verona.constant(1337)"() : () -> !verona.class<"int">
-    %39 = "verona.cast"(%38) : (!verona.class<"int">) -> !verona.unknown
-    %40 = verona.field_write %21["a"], %39 : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown -> !verona.unknown
-    %41 = verona.field_write %26["a"], %40 : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown -> !verona.unknown
-    %42 = "verona.constant(13)"() : () -> !verona.class<"int">
-    %43 = verona.static !verona.class<"G", "$parent" : class<"$module">> : !verona<"">
-    %44 = verona.call "foo"[%43 : !verona<"">] (%42 : !verona.class<"int">) : !verona.unknown
-    %45 = "verona.alloca"() : () -> !verona.class<"F32">
-    %46 = "verona.store"(%44, %45) : (!verona.unknown, !verona.class<"F32">) -> !verona.unknown
+    %15 = "verona.load"(%13) : (!verona.meet<class<"C", "$parent" : class<"$module">>, iso>) -> !verona.unknown
+    %16 = verona.new_object @C [] in(%15 : !verona.unknown) : !verona.class<"C", "$parent" : class<"$module">>
+    %17 = "verona.alloca"() : () -> !verona.meet<class<"C", "$parent" : class<"$module">>, iso>
+    %18 = "verona.store"(%16, %17) : (!verona.class<"C", "$parent" : class<"$module">>, !verona.meet<class<"C", "$parent" : class<"$module">>, iso>) -> !verona.unknown
+    %19 = "verona.constant(42)"() : () -> !verona.class<"int">
+    %20 = "verona.constant(3.14)"() : () -> !verona.class<"float">
+    %21 = verona.new_region @POD ["a", "b"](%19, %20 : !verona.class<"int">, !verona.class<"float">) : !verona.class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>
+    %22 = "verona.alloca"() : () -> !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso>
+    %23 = "verona.store"(%21, %22) : (!verona.class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso>) -> !verona.unknown
+    %24 = "verona.constant(21)"() : () -> !verona.class<"int">
+    %25 = "verona.constant(2.72)"() : () -> !verona.class<"float">
+    %26 = "verona.load"(%22) : (!verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso>) -> !verona.unknown
+    %27 = verona.new_object @POD ["a", "b"](%24, %25 : !verona.class<"int">, !verona.class<"float">) in(%26 : !verona.unknown) : !verona.class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>
+    %28 = "verona.alloca"() : () -> !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso>
+    %29 = "verona.store"(%27, %28) : (!verona.class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso>) -> !verona.unknown
+    %30 = verona.field_read %22["a"] : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown
+    %31 = "verona.alloca"() : () -> !verona.meet<class<"U32">, mut>
+    %32 = "verona.store"(%30, %31) : (!verona.unknown, !verona.meet<class<"U32">, mut>) -> !verona.unknown
+    %33 = verona.field_read %28["a"] : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown
+    %34 = "verona.alloca"() : () -> !verona.meet<class<"U32">, mut>
+    %35 = "verona.store"(%33, %34) : (!verona.unknown, !verona.meet<class<"U32">, mut>) -> !verona.unknown
+    %36 = "verona.load"(%31) : (!verona.meet<class<"U32">, mut>) -> !verona.unknown
+    %37 = "verona.load"(%34) : (!verona.meet<class<"U32">, mut>) -> !verona.unknown
+    %38 = verona.call "+"[%36 : !verona.unknown] (%37 : !verona.unknown) : !verona.unknown
+    %39 = verona.field_write %28["a"], %38 : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown -> !verona.unknown
+    %40 = verona.field_read %28["a"] : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown
+    %41 = verona.field_write %22["a"], %40 : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown -> !verona.unknown
+    %42 = "verona.constant(1337)"() : () -> !verona.class<"int">
+    %43 = "verona.cast"(%42) : (!verona.class<"int">) -> !verona.unknown
+    %44 = verona.field_write %22["a"], %43 : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown -> !verona.unknown
+    %45 = verona.field_write %28["a"], %44 : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown -> !verona.unknown
+    %46 = "verona.constant(13)"() : () -> !verona.class<"int">
     %47 = verona.static !verona.class<"G", "$parent" : class<"$module">> : !verona<"">
-    %48 = verona.call "baz"[%47 : !verona<"">] (%45 : !verona.class<"F32">) : !verona.unknown
+    %48 = verona.call "foo"[%47 : !verona<"">] (%46 : !verona.class<"int">) : !verona.unknown
     %49 = "verona.alloca"() : () -> !verona.class<"F32">
     %50 = "verona.store"(%48, %49) : (!verona.unknown, !verona.class<"F32">) -> !verona.unknown
-    verona.tidy %0 : !verona.class<"C", "$parent" : class<"$module">>
-    verona.drop %2 : !verona.class<"D", "$parent" : class<"$module">, "f" : meet<class<"U64">, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : class<"F32">, "i" : class<"F64">, "j" : class<"bool">>
+    %51 = "verona.load"(%49) : (!verona.class<"F32">) -> !verona.unknown
+    %52 = verona.static !verona.class<"G", "$parent" : class<"$module">> : !verona<"">
+    %53 = verona.call "baz"[%52 : !verona<"">] (%51 : !verona.unknown) : !verona.unknown
+    %54 = "verona.alloca"() : () -> !verona.class<"F32">
+    %55 = "verona.store"(%53, %54) : (!verona.unknown, !verona.class<"F32">) -> !verona.unknown
+    %56 = "verona.load"(%0) : (!verona.class<"C", "$parent" : class<"$module">>) -> !verona.unknown
+    verona.tidy %56 : !verona.unknown
+    %57 = "verona.load"(%2) : (!verona.class<"D", "$parent" : class<"$module">, "f" : meet<class<"U64">, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : class<"F32">, "i" : class<"F64">, "j" : class<"bool">>) -> !verona.unknown
+    verona.drop %57 : !verona.unknown
     return
   }
 }

--- a/testsuite/mlir/mlir-parse/conditional/mlir.txt
+++ b/testsuite/mlir/mlir-parse/conditional/mlir.txt
@@ -4,30 +4,34 @@ module @"$module" {
   func @f(%arg0: !verona.class<"U16">) -> !verona.class<"S16"> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.class<"U16">
     %1 = "verona.store"(%arg0, %0) : (!verona.class<"U16">, !verona.class<"U16">) -> !verona.unknown
-    %2 = "verona.constant(2)"() : () -> !verona.class<"int">
-    %3 = verona.call "<"[%0 : !verona.class<"U16">] (%2 : !verona.class<"int">) : !verona.unknown
-    %4 = "verona.cast"(%3) : (!verona.unknown) -> i1
-    cond_br %4, ^bb1, ^bb2
+    %2 = "verona.load"(%0) : (!verona.class<"U16">) -> !verona.unknown
+    %3 = "verona.constant(2)"() : () -> !verona.class<"int">
+    %4 = verona.call "<"[%2 : !verona.unknown] (%3 : !verona.class<"int">) : !verona.unknown
+    %5 = "verona.cast"(%4) : (!verona.unknown) -> i1
+    cond_br %5, ^bb1, ^bb2
   ^bb1:  // pred: ^bb0
-    %5 = "verona.constant(1)"() : () -> !verona.class<"int">
-    %6 = verona.call "+"[%0 : !verona.class<"U16">] (%5 : !verona.class<"int">) : !verona.unknown
-    %7 = "verona.store"(%6, %0) : (!verona.unknown, !verona.class<"U16">) -> !verona.unknown
+    %6 = "verona.load"(%0) : (!verona.class<"U16">) -> !verona.unknown
+    %7 = "verona.constant(1)"() : () -> !verona.class<"int">
+    %8 = verona.call "+"[%6 : !verona.unknown] (%7 : !verona.class<"int">) : !verona.unknown
+    %9 = "verona.store"(%8, %0) : (!verona.unknown, !verona.class<"U16">) -> !verona.unknown
     br ^bb3
   ^bb2:  // pred: ^bb0
-    %8 = "verona.constant(true)"() : () -> !verona.class<"bool">
-    %9 = "verona.cast"(%8) : (!verona.class<"bool">) -> i1
-    cond_br %9, ^bb4, ^bb5
+    %10 = "verona.constant(true)"() : () -> !verona.class<"bool">
+    %11 = "verona.cast"(%10) : (!verona.class<"bool">) -> i1
+    cond_br %11, ^bb4, ^bb5
   ^bb3:  // 2 preds: ^bb1, ^bb6
-    %10 = "verona.cast"(%0) : (!verona.class<"U16">) -> !verona.class<"S16">
-    return %10 : !verona.class<"S16">
+    %12 = "verona.load"(%0) : (!verona.class<"U16">) -> !verona.unknown
+    %13 = "verona.cast"(%12) : (!verona.unknown) -> !verona.class<"S16">
+    return %13 : !verona.class<"S16">
   ^bb4:  // pred: ^bb2
-    %11 = "verona.constant(1)"() : () -> !verona.class<"int">
-    %12 = verona.call "-"[%0 : !verona.class<"U16">] (%11 : !verona.class<"int">) : !verona.unknown
-    %13 = "verona.store"(%12, %0) : (!verona.unknown, !verona.class<"U16">) -> !verona.unknown
+    %14 = "verona.load"(%0) : (!verona.class<"U16">) -> !verona.unknown
+    %15 = "verona.constant(1)"() : () -> !verona.class<"int">
+    %16 = verona.call "-"[%14 : !verona.unknown] (%15 : !verona.class<"int">) : !verona.unknown
+    %17 = "verona.store"(%16, %0) : (!verona.unknown, !verona.class<"U16">) -> !verona.unknown
     br ^bb6
   ^bb5:  // pred: ^bb2
-    %14 = "verona.constant(0)"() : () -> !verona.class<"int">
-    %15 = "verona.store"(%14, %0) : (!verona.class<"int">, !verona.class<"U16">) -> !verona.unknown
+    %18 = "verona.constant(0)"() : () -> !verona.class<"int">
+    %19 = "verona.store"(%18, %0) : (!verona.class<"int">, !verona.class<"U16">) -> !verona.unknown
     br ^bb6
   ^bb6:  // 2 preds: ^bb4, ^bb5
     br ^bb3

--- a/testsuite/mlir/mlir-parse/for/mlir.txt
+++ b/testsuite/mlir/mlir-parse/for/mlir.txt
@@ -8,17 +8,17 @@ module @"$module" {
     %2 = "verona.constant(0)"() : () -> !verona.class<"int">
     %3 = "verona.alloca"() : () -> !verona.class<"S32">
     %4 = "verona.store"(%2, %3) : (!verona.class<"int">, !verona.class<"S32">) -> !verona.unknown
+    %5 = "verona.load"(%0) : (!verona.class<"U64">) -> !verona.unknown
     br ^bb2
   ^bb1:  // pred: ^bb3
-    %5 = verona.call "next"[%0 : !verona.class<"U64">] ( : ) : !verona.class<"U64">
+    %6 = verona.call "next"[%5 : !verona.unknown] ( : ) : !verona.unknown
     br ^bb2
   ^bb2:  // 2 preds: ^bb0, ^bb1
-    %6 = verona.call "has_value"[%0 : !verona.class<"U64">] ( : ) : !verona.unknown
-    %7 = "verona.cast"(%6) : (!verona.unknown) -> i1
-    cond_br %7, ^bb3, ^bb4
+    %7 = verona.call "has_value"[%5 : !verona.unknown] ( : ) : !verona.unknown
+    %8 = "verona.cast"(%7) : (!verona.unknown) -> i1
+    cond_br %8, ^bb3, ^bb4
   ^bb3:  // pred: ^bb2
-    %8 = verona.call "apply"[%0 : !verona.class<"U64">] ( : ) : !verona.unknown
-    %9 = "verona.load"(%8) : (!verona.unknown) -> !verona.unknown
+    %9 = verona.call "apply"[%5 : !verona.unknown] ( : ) : !verona.unknown
     %10 = verona.call "foo"[%9 : !verona.unknown] ( : ) : !verona.unknown
     br ^bb1
   ^bb4:  // pred: ^bb2
@@ -30,40 +30,37 @@ module @"$module" {
     %2 = "verona.constant(0)"() : () -> !verona.class<"int">
     %3 = "verona.alloca"() : () -> !verona.class<"S32">
     %4 = "verona.store"(%2, %3) : (!verona.class<"int">, !verona.class<"S32">) -> !verona.unknown
+    %5 = "verona.load"(%0) : (!verona.class<"U64">) -> !verona.unknown
     br ^bb2
   ^bb1:  // 2 preds: ^bb7, ^bb8
-    %5 = verona.call "next"[%0 : !verona.class<"U64">] ( : ) : !verona.class<"U64">
+    %6 = verona.call "next"[%5 : !verona.unknown] ( : ) : !verona.unknown
     br ^bb2
   ^bb2:  // 2 preds: ^bb0, ^bb1
-    %6 = verona.call "has_value"[%0 : !verona.class<"U64">] ( : ) : !verona.unknown
-    %7 = "verona.cast"(%6) : (!verona.unknown) -> i1
-    cond_br %7, ^bb3, ^bb4
+    %7 = verona.call "has_value"[%5 : !verona.unknown] ( : ) : !verona.unknown
+    %8 = "verona.cast"(%7) : (!verona.unknown) -> i1
+    cond_br %8, ^bb3, ^bb4
   ^bb3:  // pred: ^bb2
-    %8 = verona.call "apply"[%0 : !verona.class<"U64">] ( : ) : !verona.unknown
-    %9 = "verona.load"(%8) : (!verona.unknown) -> !verona.unknown
+    %9 = verona.call "apply"[%5 : !verona.unknown] ( : ) : !verona.unknown
     %10 = verona.call "foo"[%9 : !verona.unknown] ( : ) : !verona.unknown
-    %11 = "verona.load"(%8) : (!verona.unknown) -> !verona.unknown
-    %12 = "verona.constant(5)"() : () -> !verona.class<"int">
-    %13 = verona.call ">"[%11 : !verona.unknown] (%12 : !verona.class<"int">) : !verona.unknown
-    %14 = "verona.cast"(%13) : (!verona.unknown) -> i1
-    cond_br %14, ^bb5, ^bb6
+    %11 = "verona.constant(5)"() : () -> !verona.class<"int">
+    %12 = verona.call ">"[%9 : !verona.unknown] (%11 : !verona.class<"int">) : !verona.unknown
+    %13 = "verona.cast"(%12) : (!verona.unknown) -> i1
+    cond_br %13, ^bb5, ^bb6
   ^bb4:  // 2 preds: ^bb2, ^bb5
     return
   ^bb5:  // pred: ^bb3
     br ^bb4
   ^bb6:  // pred: ^bb3
-    %15 = "verona.load"(%8) : (!verona.unknown) -> !verona.unknown
-    %16 = "verona.constant(2)"() : () -> !verona.class<"int">
-    %17 = verona.call "<"[%15 : !verona.unknown] (%16 : !verona.class<"int">) : !verona.unknown
-    %18 = "verona.cast"(%17) : (!verona.unknown) -> i1
-    cond_br %18, ^bb8, ^bb9
+    %14 = "verona.constant(2)"() : () -> !verona.class<"int">
+    %15 = verona.call "<"[%9 : !verona.unknown] (%14 : !verona.class<"int">) : !verona.unknown
+    %16 = "verona.cast"(%15) : (!verona.unknown) -> i1
+    cond_br %16, ^bb8, ^bb9
   ^bb7:  // pred: ^bb10
     br ^bb1
   ^bb8:  // pred: ^bb6
     br ^bb1
   ^bb9:  // pred: ^bb6
-    %19 = "verona.load"(%8) : (!verona.unknown) -> !verona.unknown
-    %20 = verona.call "foo"[%19 : !verona.unknown] ( : ) : !verona.unknown
+    %17 = verona.call "foo"[%9 : !verona.unknown] ( : ) : !verona.unknown
     br ^bb10
   ^bb10:  // pred: ^bb9
     br ^bb7

--- a/testsuite/mlir/mlir-parse/function/mlir.txt
+++ b/testsuite/mlir/mlir-parse/function/mlir.txt
@@ -24,15 +24,17 @@ module @"$module" {
     %1 = "verona.store"(%arg0, %0) : (!verona.imm, !verona.imm) -> !verona.unknown
     %2 = "verona.alloca"() : () -> !verona.meet<class<"U64">, imm>
     %3 = "verona.store"(%arg1, %2) : (!verona.meet<class<"U64">, imm>, !verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %4 = verona.call "+"[%0 : !verona.imm] (%2 : !verona.meet<class<"U64">, imm>) : !verona.unknown
-    %5 = "verona.alloca"() : () -> !verona.unknown
-    %6 = "verona.store"(%4, %5) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    %7 = "verona.load"(%5) : (!verona.unknown) -> !verona.unknown
-    %8 = "verona.alloca"() : () -> !verona.meet<class<"U64">, imm>
-    %9 = "verona.store"(%7, %8) : (!verona.unknown, !verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %10 = "verona.load"(%5) : (!verona.unknown) -> !verona.unknown
-    %11 = "verona.cast"(%10) : (!verona.unknown) -> !verona.meet<class<"U64">, imm>
-    return %11 : !verona.meet<class<"U64">, imm>
+    %4 = "verona.load"(%0) : (!verona.imm) -> !verona.unknown
+    %5 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
+    %6 = verona.call "+"[%4 : !verona.unknown] (%5 : !verona.unknown) : !verona.unknown
+    %7 = "verona.alloca"() : () -> !verona.unknown
+    %8 = "verona.store"(%6, %7) : (!verona.unknown, !verona.unknown) -> !verona.unknown
+    %9 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
+    %10 = "verona.alloca"() : () -> !verona.meet<class<"U64">, imm>
+    %11 = "verona.store"(%9, %10) : (!verona.unknown, !verona.meet<class<"U64">, imm>) -> !verona.unknown
+    %12 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
+    %13 = "verona.cast"(%12) : (!verona.unknown) -> !verona.meet<class<"U64">, imm>
+    return %13 : !verona.meet<class<"U64">, imm>
   }
   func @apply() attributes {class = !verona.class<"$module">} {
     return

--- a/testsuite/mlir/mlir-parse/nested-conditional/mlir.txt
+++ b/testsuite/mlir/mlir-parse/nested-conditional/mlir.txt
@@ -4,76 +4,88 @@ module @"$module" {
   func @f(%arg0: !verona.class<"U32">) -> !verona.class<"U32"> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.class<"U32">
     %1 = "verona.store"(%arg0, %0) : (!verona.class<"U32">, !verona.class<"U32">) -> !verona.unknown
-    %2 = "verona.constant(2)"() : () -> !verona.class<"int">
-    %3 = verona.call "<"[%0 : !verona.class<"U32">] (%2 : !verona.class<"int">) : !verona.unknown
-    %4 = "verona.cast"(%3) : (!verona.unknown) -> i1
-    cond_br %4, ^bb1, ^bb2
+    %2 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
+    %3 = "verona.constant(2)"() : () -> !verona.class<"int">
+    %4 = verona.call "<"[%2 : !verona.unknown] (%3 : !verona.class<"int">) : !verona.unknown
+    %5 = "verona.cast"(%4) : (!verona.unknown) -> i1
+    cond_br %5, ^bb1, ^bb2
   ^bb1:  // pred: ^bb0
-    %5 = "verona.constant(1)"() : () -> !verona.class<"int">
-    %6 = verona.call "+"[%0 : !verona.class<"U32">] (%5 : !verona.class<"int">) : !verona.unknown
-    %7 = "verona.store"(%6, %0) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
+    %6 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
+    %7 = "verona.constant(1)"() : () -> !verona.class<"int">
+    %8 = verona.call "+"[%6 : !verona.unknown] (%7 : !verona.class<"int">) : !verona.unknown
+    %9 = "verona.store"(%8, %0) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
     br ^bb3
   ^bb2:  // pred: ^bb0
-    %8 = "verona.constant(100)"() : () -> !verona.class<"int">
-    %9 = verona.call ">"[%0 : !verona.class<"U32">] (%8 : !verona.class<"int">) : !verona.unknown
-    %10 = "verona.cast"(%9) : (!verona.unknown) -> i1
-    cond_br %10, ^bb4, ^bb5
+    %10 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
+    %11 = "verona.constant(100)"() : () -> !verona.class<"int">
+    %12 = verona.call ">"[%10 : !verona.unknown] (%11 : !verona.class<"int">) : !verona.unknown
+    %13 = "verona.cast"(%12) : (!verona.unknown) -> i1
+    cond_br %13, ^bb4, ^bb5
   ^bb3:  // 2 preds: ^bb1, ^bb6
-    return %0 : !verona.class<"U32">
+    %14 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
+    %15 = "verona.cast"(%14) : (!verona.unknown) -> !verona.class<"U32">
+    return %15 : !verona.class<"U32">
   ^bb4:  // pred: ^bb2
-    %11 = "verona.constant(1)"() : () -> !verona.class<"int">
-    %12 = verona.call "-"[%0 : !verona.class<"U32">] (%11 : !verona.class<"int">) : !verona.unknown
-    %13 = "verona.store"(%12, %0) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
+    %16 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
+    %17 = "verona.constant(1)"() : () -> !verona.class<"int">
+    %18 = verona.call "-"[%16 : !verona.unknown] (%17 : !verona.class<"int">) : !verona.unknown
+    %19 = "verona.store"(%18, %0) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
     br ^bb6
   ^bb5:  // pred: ^bb2
-    %14 = "verona.constant(20)"() : () -> !verona.class<"int">
-    %15 = verona.call "<="[%0 : !verona.class<"U32">] (%14 : !verona.class<"int">) : !verona.unknown
-    %16 = "verona.cast"(%15) : (!verona.unknown) -> i1
-    cond_br %16, ^bb7, ^bb8
+    %20 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
+    %21 = "verona.constant(20)"() : () -> !verona.class<"int">
+    %22 = verona.call "<="[%20 : !verona.unknown] (%21 : !verona.class<"int">) : !verona.unknown
+    %23 = "verona.cast"(%22) : (!verona.unknown) -> i1
+    cond_br %23, ^bb7, ^bb8
   ^bb6:  // 2 preds: ^bb4, ^bb9
     br ^bb3
   ^bb7:  // pred: ^bb5
-    %17 = "verona.constant(2)"() : () -> !verona.class<"int">
-    %18 = verona.call "*"[%0 : !verona.class<"U32">] (%17 : !verona.class<"int">) : !verona.unknown
-    %19 = "verona.store"(%18, %0) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
+    %24 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
+    %25 = "verona.constant(2)"() : () -> !verona.class<"int">
+    %26 = verona.call "*"[%24 : !verona.unknown] (%25 : !verona.class<"int">) : !verona.unknown
+    %27 = "verona.store"(%26, %0) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
     br ^bb9
   ^bb8:  // pred: ^bb5
-    %20 = "verona.constant(50)"() : () -> !verona.class<"int">
-    %21 = verona.call ">="[%0 : !verona.class<"U32">] (%20 : !verona.class<"int">) : !verona.unknown
-    %22 = "verona.cast"(%21) : (!verona.unknown) -> i1
-    cond_br %22, ^bb10, ^bb11
+    %28 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
+    %29 = "verona.constant(50)"() : () -> !verona.class<"int">
+    %30 = verona.call ">="[%28 : !verona.unknown] (%29 : !verona.class<"int">) : !verona.unknown
+    %31 = "verona.cast"(%30) : (!verona.unknown) -> i1
+    cond_br %31, ^bb10, ^bb11
   ^bb9:  // 2 preds: ^bb7, ^bb12
     br ^bb6
   ^bb10:  // pred: ^bb8
-    %23 = "verona.constant(10)"() : () -> !verona.class<"int">
-    %24 = verona.call "/"[%0 : !verona.class<"U32">] (%23 : !verona.class<"int">) : !verona.unknown
-    %25 = "verona.store"(%24, %0) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
+    %32 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
+    %33 = "verona.constant(10)"() : () -> !verona.class<"int">
+    %34 = verona.call "/"[%32 : !verona.unknown] (%33 : !verona.class<"int">) : !verona.unknown
+    %35 = "verona.store"(%34, %0) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
     br ^bb12
   ^bb11:  // pred: ^bb8
-    %26 = "verona.constant(10)"() : () -> !verona.class<"int">
-    %27 = verona.call "=="[%0 : !verona.class<"U32">] (%26 : !verona.class<"int">) : !verona.unknown
-    %28 = "verona.cast"(%27) : (!verona.unknown) -> i1
-    cond_br %28, ^bb13, ^bb14
+    %36 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
+    %37 = "verona.constant(10)"() : () -> !verona.class<"int">
+    %38 = verona.call "=="[%36 : !verona.unknown] (%37 : !verona.class<"int">) : !verona.unknown
+    %39 = "verona.cast"(%38) : (!verona.unknown) -> i1
+    cond_br %39, ^bb13, ^bb14
   ^bb12:  // 2 preds: ^bb10, ^bb15
     br ^bb9
   ^bb13:  // pred: ^bb11
-    %29 = "verona.constant(10)"() : () -> !verona.class<"int">
-    %30 = "verona.store"(%29, %0) : (!verona.class<"int">, !verona.class<"U32">) -> !verona.unknown
+    %40 = "verona.constant(10)"() : () -> !verona.class<"int">
+    %41 = "verona.store"(%40, %0) : (!verona.class<"int">, !verona.class<"U32">) -> !verona.unknown
     br ^bb15
   ^bb14:  // pred: ^bb11
-    %31 = "verona.constant(20)"() : () -> !verona.class<"int">
-    %32 = verona.call "!="[%0 : !verona.class<"U32">] (%31 : !verona.class<"int">) : !verona.unknown
-    %33 = "verona.cast"(%32) : (!verona.unknown) -> i1
-    cond_br %33, ^bb16, ^bb17
+    %42 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
+    %43 = "verona.constant(20)"() : () -> !verona.class<"int">
+    %44 = verona.call "!="[%42 : !verona.unknown] (%43 : !verona.class<"int">) : !verona.unknown
+    %45 = "verona.cast"(%44) : (!verona.unknown) -> i1
+    cond_br %45, ^bb16, ^bb17
   ^bb15:  // 2 preds: ^bb13, ^bb18
     br ^bb12
   ^bb16:  // pred: ^bb14
-    %34 = "verona.constant(42)"() : () -> !verona.class<"int">
-    %35 = "verona.store"(%34, %0) : (!verona.class<"int">, !verona.class<"U32">) -> !verona.unknown
+    %46 = "verona.constant(42)"() : () -> !verona.class<"int">
+    %47 = "verona.store"(%46, %0) : (!verona.class<"int">, !verona.class<"U32">) -> !verona.unknown
     br ^bb18
   ^bb17:  // pred: ^bb14
-    %36 = "verona.constant(0)"() : () -> !verona.class<"int">
-    %37 = "verona.store"(%36, %0) : (!verona.class<"int">, !verona.class<"U32">) -> !verona.unknown
+    %48 = "verona.constant(0)"() : () -> !verona.class<"int">
+    %49 = "verona.store"(%48, %0) : (!verona.class<"int">, !verona.class<"U32">) -> !verona.unknown
     br ^bb18
   ^bb18:  // 2 preds: ^bb16, ^bb17
     br ^bb15

--- a/testsuite/mlir/mlir-parse/nested-while/mlir.txt
+++ b/testsuite/mlir/mlir-parse/nested-while/mlir.txt
@@ -6,31 +6,35 @@ module @"$module" {
     %1 = "verona.store"(%arg0, %0) : (!verona.class<"S64">, !verona.class<"S64">) -> !verona.unknown
     br ^bb1
   ^bb1:  // 2 preds: ^bb0, ^bb6
-    %2 = "verona.constant(50)"() : () -> !verona.class<"int">
-    %3 = verona.call "<"[%0 : !verona.class<"S64">] (%2 : !verona.class<"int">) : !verona.unknown
-    %4 = "verona.cast"(%3) : (!verona.unknown) -> i1
-    cond_br %4, ^bb2, ^bb3
+    %2 = "verona.load"(%0) : (!verona.class<"S64">) -> !verona.unknown
+    %3 = "verona.constant(50)"() : () -> !verona.class<"int">
+    %4 = verona.call "<"[%2 : !verona.unknown] (%3 : !verona.class<"int">) : !verona.unknown
+    %5 = "verona.cast"(%4) : (!verona.unknown) -> i1
+    cond_br %5, ^bb2, ^bb3
   ^bb2:  // pred: ^bb1
-    %5 = "verona.constant(1)"() : () -> !verona.class<"int">
-    %6 = "verona.alloca"() : () -> !verona.unknown
-    %7 = "verona.store"(%5, %6) : (!verona.class<"int">, !verona.unknown) -> !verona.unknown
+    %6 = "verona.constant(1)"() : () -> !verona.class<"int">
+    %7 = "verona.alloca"() : () -> !verona.unknown
+    %8 = "verona.store"(%6, %7) : (!verona.class<"int">, !verona.unknown) -> !verona.unknown
     br ^bb4
   ^bb3:  // pred: ^bb1
-    return %0 : !verona.class<"S64">
+    %9 = "verona.load"(%0) : (!verona.class<"S64">) -> !verona.unknown
+    %10 = "verona.cast"(%9) : (!verona.unknown) -> !verona.class<"S64">
+    return %10 : !verona.class<"S64">
   ^bb4:  // 2 preds: ^bb2, ^bb5
-    %8 = "verona.load"(%6) : (!verona.unknown) -> !verona.unknown
-    %9 = "verona.constant(10)"() : () -> !verona.class<"int">
-    %10 = verona.call "<"[%8 : !verona.unknown] (%9 : !verona.class<"int">) : !verona.unknown
-    %11 = "verona.cast"(%10) : (!verona.unknown) -> i1
-    cond_br %11, ^bb5, ^bb6
+    %11 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
+    %12 = "verona.constant(10)"() : () -> !verona.class<"int">
+    %13 = verona.call "<"[%11 : !verona.unknown] (%12 : !verona.class<"int">) : !verona.unknown
+    %14 = "verona.cast"(%13) : (!verona.unknown) -> i1
+    cond_br %14, ^bb5, ^bb6
   ^bb5:  // pred: ^bb4
-    %12 = "verona.load"(%6) : (!verona.unknown) -> !verona.unknown
-    %13 = verona.call "+"[%12 : !verona.unknown] (%0 : !verona.class<"S64">) : !verona.unknown
-    %14 = "verona.store"(%13, %6) : (!verona.unknown, !verona.unknown) -> !verona.unknown
+    %15 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
+    %16 = "verona.load"(%0) : (!verona.class<"S64">) -> !verona.unknown
+    %17 = verona.call "+"[%15 : !verona.unknown] (%16 : !verona.unknown) : !verona.unknown
+    %18 = "verona.store"(%17, %7) : (!verona.unknown, !verona.unknown) -> !verona.unknown
     br ^bb4
   ^bb6:  // pred: ^bb4
-    %15 = "verona.load"(%6) : (!verona.unknown) -> !verona.unknown
-    %16 = "verona.store"(%15, %0) : (!verona.unknown, !verona.class<"S64">) -> !verona.unknown
+    %19 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
+    %20 = "verona.store"(%19, %0) : (!verona.unknown, !verona.class<"S64">) -> !verona.unknown
     br ^bb1
   }
 }

--- a/testsuite/mlir/mlir-parse/types/mlir.txt
+++ b/testsuite/mlir/mlir-parse/types/mlir.txt
@@ -6,8 +6,10 @@ module @"$module" {
     %1 = "verona.store"(%arg0, %0) : (!verona.meet<class<"S32">, iso>, !verona.meet<class<"S32">, iso>) -> !verona.unknown
     %2 = "verona.alloca"() : () -> !verona.meet<class<"U64">, imm>
     %3 = "verona.store"(%arg1, %2) : (!verona.meet<class<"U64">, imm>, !verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %4 = verona.call "+"[%0 : !verona.meet<class<"S32">, iso>] (%2 : !verona.meet<class<"U64">, imm>) : !verona.unknown
-    %5 = "verona.cast"(%4) : (!verona.unknown) -> !verona.join<meet<class<"S32">, iso>, meet<class<"U64">, imm>, meet<class<"U32">, mut>>
-    return %5 : !verona.join<meet<class<"S32">, iso>, meet<class<"U64">, imm>, meet<class<"U32">, mut>>
+    %4 = "verona.load"(%0) : (!verona.meet<class<"S32">, iso>) -> !verona.unknown
+    %5 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
+    %6 = verona.call "+"[%4 : !verona.unknown] (%5 : !verona.unknown) : !verona.unknown
+    %7 = "verona.cast"(%6) : (!verona.unknown) -> !verona.join<meet<class<"S32">, iso>, meet<class<"U64">, imm>, meet<class<"U32">, mut>>
+    return %7 : !verona.join<meet<class<"S32">, iso>, meet<class<"U64">, imm>, meet<class<"U32">, mut>>
   }
 }

--- a/testsuite/mlir/mlir-parse/variables/mlir.txt
+++ b/testsuite/mlir/mlir-parse/variables/mlir.txt
@@ -6,15 +6,21 @@ module @"$module" {
     %1 = "verona.store"(%arg0, %0) : (!verona.meet<class<"S32">, iso>, !verona.meet<class<"S32">, iso>) -> !verona.unknown
     %2 = "verona.alloca"() : () -> !verona.meet<class<"U64">, imm>
     %3 = "verona.store"(%arg1, %2) : (!verona.meet<class<"U64">, imm>, !verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %4 = verona.call "+"[%0 : !verona.meet<class<"S32">, iso>] (%2 : !verona.meet<class<"U64">, imm>) : !verona.unknown
-    %5 = "verona.alloca"() : () -> !verona.unknown
-    %6 = "verona.store"(%4, %5) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    %7 = verona.call "*"[%0 : !verona.meet<class<"S32">, iso>] (%2 : !verona.meet<class<"U64">, imm>) : !verona.unknown
-    %8 = "verona.alloca"() : () -> !verona.unknown
-    %9 = "verona.store"(%7, %8) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    %10 = verona.call "-"[%0 : !verona.meet<class<"S32">, iso>] (%2 : !verona.meet<class<"U64">, imm>) : !verona.unknown
-    %11 = "verona.store"(%10, %5) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    %12 = "verona.cast"(%11) : (!verona.unknown) -> !verona.class<"S64">
-    return %12 : !verona.class<"S64">
+    %4 = "verona.load"(%0) : (!verona.meet<class<"S32">, iso>) -> !verona.unknown
+    %5 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
+    %6 = verona.call "+"[%4 : !verona.unknown] (%5 : !verona.unknown) : !verona.unknown
+    %7 = "verona.alloca"() : () -> !verona.unknown
+    %8 = "verona.store"(%6, %7) : (!verona.unknown, !verona.unknown) -> !verona.unknown
+    %9 = "verona.load"(%0) : (!verona.meet<class<"S32">, iso>) -> !verona.unknown
+    %10 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
+    %11 = verona.call "*"[%9 : !verona.unknown] (%10 : !verona.unknown) : !verona.unknown
+    %12 = "verona.alloca"() : () -> !verona.unknown
+    %13 = "verona.store"(%11, %12) : (!verona.unknown, !verona.unknown) -> !verona.unknown
+    %14 = "verona.load"(%0) : (!verona.meet<class<"S32">, iso>) -> !verona.unknown
+    %15 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
+    %16 = verona.call "-"[%14 : !verona.unknown] (%15 : !verona.unknown) : !verona.unknown
+    %17 = "verona.store"(%16, %7) : (!verona.unknown, !verona.unknown) -> !verona.unknown
+    %18 = "verona.cast"(%17) : (!verona.unknown) -> !verona.class<"S64">
+    return %18 : !verona.class<"S64">
   }
 }

--- a/testsuite/mlir/mlir-parse/while-cont-brk/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while-cont-brk/mlir.txt
@@ -8,26 +8,33 @@ module @"$module" {
     %3 = "verona.store"(%arg1, %2) : (!verona.class<"S32">, !verona.class<"S32">) -> !verona.unknown
     br ^bb1
   ^bb1:  // 3 preds: ^bb0, ^bb4, ^bb7
-    %4 = "verona.constant(5)"() : () -> !verona.class<"int">
-    %5 = verona.call "<"[%0 : !verona.class<"U32">] (%4 : !verona.class<"int">) : !verona.unknown
-    %6 = "verona.cast"(%5) : (!verona.unknown) -> i1
-    cond_br %6, ^bb2, ^bb3
+    %4 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
+    %5 = "verona.constant(5)"() : () -> !verona.class<"int">
+    %6 = verona.call "<"[%4 : !verona.unknown] (%5 : !verona.class<"int">) : !verona.unknown
+    %7 = "verona.cast"(%6) : (!verona.unknown) -> i1
+    cond_br %7, ^bb2, ^bb3
   ^bb2:  // pred: ^bb1
-    %7 = "verona.constant(1)"() : () -> !verona.class<"int">
-    %8 = verona.call "+"[%0 : !verona.class<"U32">] (%7 : !verona.class<"int">) : !verona.unknown
-    %9 = "verona.store"(%8, %0) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
-    %10 = verona.call "<"[%0 : !verona.class<"U32">] (%2 : !verona.class<"S32">) : !verona.unknown
-    %11 = "verona.cast"(%10) : (!verona.unknown) -> i1
-    cond_br %11, ^bb4, ^bb5
+    %8 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
+    %9 = "verona.constant(1)"() : () -> !verona.class<"int">
+    %10 = verona.call "+"[%8 : !verona.unknown] (%9 : !verona.class<"int">) : !verona.unknown
+    %11 = "verona.store"(%10, %0) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
+    %12 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
+    %13 = "verona.load"(%2) : (!verona.class<"S32">) -> !verona.unknown
+    %14 = verona.call "<"[%12 : !verona.unknown] (%13 : !verona.unknown) : !verona.unknown
+    %15 = "verona.cast"(%14) : (!verona.unknown) -> i1
+    cond_br %15, ^bb4, ^bb5
   ^bb3:  // 2 preds: ^bb1, ^bb6
-    %12 = "verona.cast"(%0) : (!verona.class<"U32">) -> !verona.class<"F16">
-    return %12 : !verona.class<"F16">
+    %16 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
+    %17 = "verona.cast"(%16) : (!verona.unknown) -> !verona.class<"F16">
+    return %17 : !verona.class<"F16">
   ^bb4:  // pred: ^bb2
     br ^bb1
   ^bb5:  // pred: ^bb2
-    %13 = verona.call ">"[%0 : !verona.class<"U32">] (%2 : !verona.class<"S32">) : !verona.unknown
-    %14 = "verona.cast"(%13) : (!verona.unknown) -> i1
-    cond_br %14, ^bb6, ^bb7
+    %18 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
+    %19 = "verona.load"(%2) : (!verona.class<"S32">) -> !verona.unknown
+    %20 = verona.call ">"[%18 : !verona.unknown] (%19 : !verona.unknown) : !verona.unknown
+    %21 = "verona.cast"(%20) : (!verona.unknown) -> i1
+    cond_br %21, ^bb6, ^bb7
   ^bb6:  // pred: ^bb5
     br ^bb3
   ^bb7:  // pred: ^bb5

--- a/testsuite/mlir/mlir-parse/while-context/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while-context/mlir.txt
@@ -9,25 +9,28 @@ module @"$module" {
     %4 = "verona.store"(%2, %3) : (!verona.class<"int">, !verona.unknown) -> !verona.unknown
     br ^bb1
   ^bb1:  // 2 preds: ^bb0, ^bb2
-    %5 = "verona.constant(5)"() : () -> !verona.class<"int">
-    %6 = verona.call "<"[%0 : !verona.class<"F32">] (%5 : !verona.class<"int">) : !verona.unknown
-    %7 = "verona.cast"(%6) : (!verona.unknown) -> i1
-    cond_br %7, ^bb2, ^bb3
+    %5 = "verona.load"(%0) : (!verona.class<"F32">) -> !verona.unknown
+    %6 = "verona.constant(5)"() : () -> !verona.class<"int">
+    %7 = verona.call "<"[%5 : !verona.unknown] (%6 : !verona.class<"int">) : !verona.unknown
+    %8 = "verona.cast"(%7) : (!verona.unknown) -> i1
+    cond_br %8, ^bb2, ^bb3
   ^bb2:  // pred: ^bb1
-    %8 = "verona.constant(2)"() : () -> !verona.class<"int">
-    %9 = "verona.alloca"() : () -> !verona.unknown
-    %10 = "verona.store"(%8, %9) : (!verona.class<"int">, !verona.unknown) -> !verona.unknown
-    %11 = "verona.load"(%9) : (!verona.unknown) -> !verona.unknown
-    %12 = "verona.constant(3)"() : () -> !verona.class<"int">
-    %13 = verona.call "+"[%11 : !verona.unknown] (%12 : !verona.class<"int">) : !verona.unknown
-    %14 = "verona.alloca"() : () -> !verona.unknown
-    %15 = "verona.store"(%13, %14) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    %16 = "verona.load"(%14) : (!verona.unknown) -> !verona.unknown
-    %17 = verona.call "+"[%0 : !verona.class<"F32">] (%16 : !verona.unknown) : !verona.unknown
-    %18 = "verona.store"(%17, %0) : (!verona.unknown, !verona.class<"F32">) -> !verona.unknown
+    %9 = "verona.constant(2)"() : () -> !verona.class<"int">
+    %10 = "verona.alloca"() : () -> !verona.unknown
+    %11 = "verona.store"(%9, %10) : (!verona.class<"int">, !verona.unknown) -> !verona.unknown
+    %12 = "verona.load"(%10) : (!verona.unknown) -> !verona.unknown
+    %13 = "verona.constant(3)"() : () -> !verona.class<"int">
+    %14 = verona.call "+"[%12 : !verona.unknown] (%13 : !verona.class<"int">) : !verona.unknown
+    %15 = "verona.alloca"() : () -> !verona.unknown
+    %16 = "verona.store"(%14, %15) : (!verona.unknown, !verona.unknown) -> !verona.unknown
+    %17 = "verona.load"(%0) : (!verona.class<"F32">) -> !verona.unknown
+    %18 = "verona.load"(%15) : (!verona.unknown) -> !verona.unknown
+    %19 = verona.call "+"[%17 : !verona.unknown] (%18 : !verona.unknown) : !verona.unknown
+    %20 = "verona.store"(%19, %0) : (!verona.unknown, !verona.class<"F32">) -> !verona.unknown
     br ^bb1
   ^bb3:  // pred: ^bb1
-    %19 = "verona.cast"(%0) : (!verona.class<"F32">) -> !verona.class<"F64">
-    return %19 : !verona.class<"F64">
+    %21 = "verona.load"(%0) : (!verona.class<"F32">) -> !verona.unknown
+    %22 = "verona.cast"(%21) : (!verona.unknown) -> !verona.class<"F64">
+    return %22 : !verona.class<"F64">
   }
 }

--- a/testsuite/mlir/mlir-parse/while-if/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while-if/mlir.txt
@@ -8,20 +8,26 @@ module @"$module" {
     %3 = "verona.store"(%arg1, %2) : (!verona.class<"S32">, !verona.class<"S32">) -> !verona.unknown
     br ^bb1
   ^bb1:  // 2 preds: ^bb0, ^bb5
-    %4 = "verona.constant(5)"() : () -> !verona.class<"int">
-    %5 = verona.call "<"[%0 : !verona.class<"U32">] (%4 : !verona.class<"int">) : !verona.unknown
-    %6 = "verona.cast"(%5) : (!verona.unknown) -> i1
-    cond_br %6, ^bb2, ^bb3
+    %4 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
+    %5 = "verona.constant(5)"() : () -> !verona.class<"int">
+    %6 = verona.call "<"[%4 : !verona.unknown] (%5 : !verona.class<"int">) : !verona.unknown
+    %7 = "verona.cast"(%6) : (!verona.unknown) -> i1
+    cond_br %7, ^bb2, ^bb3
   ^bb2:  // pred: ^bb1
-    %7 = verona.call "!="[%0 : !verona.class<"U32">] (%2 : !verona.class<"S32">) : !verona.unknown
-    %8 = "verona.cast"(%7) : (!verona.unknown) -> i1
-    cond_br %8, ^bb4, ^bb5
+    %8 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
+    %9 = "verona.load"(%2) : (!verona.class<"S32">) -> !verona.unknown
+    %10 = verona.call "!="[%8 : !verona.unknown] (%9 : !verona.unknown) : !verona.unknown
+    %11 = "verona.cast"(%10) : (!verona.unknown) -> i1
+    cond_br %11, ^bb4, ^bb5
   ^bb3:  // pred: ^bb1
-    return %0 : !verona.class<"U32">
+    %12 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
+    %13 = "verona.cast"(%12) : (!verona.unknown) -> !verona.class<"U32">
+    return %13 : !verona.class<"U32">
   ^bb4:  // pred: ^bb2
-    %9 = "verona.constant(1)"() : () -> !verona.class<"int">
-    %10 = verona.call "+"[%0 : !verona.class<"U32">] (%9 : !verona.class<"int">) : !verona.unknown
-    %11 = "verona.store"(%10, %0) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
+    %14 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
+    %15 = "verona.constant(1)"() : () -> !verona.class<"int">
+    %16 = verona.call "+"[%14 : !verona.unknown] (%15 : !verona.class<"int">) : !verona.unknown
+    %17 = "verona.store"(%16, %0) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
     br ^bb5
   ^bb5:  // 2 preds: ^bb2, ^bb4
     br ^bb1

--- a/testsuite/mlir/mlir-parse/while/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while/mlir.txt
@@ -6,27 +6,32 @@ module @"$module" {
     %1 = "verona.store"(%arg0, %0) : (!verona.class<"U32">, !verona.class<"U32">) -> !verona.unknown
     br ^bb1
   ^bb1:  // 2 preds: ^bb0, ^bb2
-    %2 = "verona.constant(5)"() : () -> !verona.class<"int">
-    %3 = verona.call "<"[%0 : !verona.class<"U32">] (%2 : !verona.class<"int">) : !verona.unknown
-    %4 = "verona.cast"(%3) : (!verona.unknown) -> i1
-    cond_br %4, ^bb2, ^bb3
+    %2 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
+    %3 = "verona.constant(5)"() : () -> !verona.class<"int">
+    %4 = verona.call "<"[%2 : !verona.unknown] (%3 : !verona.class<"int">) : !verona.unknown
+    %5 = "verona.cast"(%4) : (!verona.unknown) -> i1
+    cond_br %5, ^bb2, ^bb3
   ^bb2:  // pred: ^bb1
-    %5 = "verona.constant(1)"() : () -> !verona.class<"int">
-    %6 = verona.call "+"[%0 : !verona.class<"U32">] (%5 : !verona.class<"int">) : !verona.unknown
-    %7 = "verona.store"(%6, %0) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
+    %6 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
+    %7 = "verona.constant(1)"() : () -> !verona.class<"int">
+    %8 = verona.call "+"[%6 : !verona.unknown] (%7 : !verona.class<"int">) : !verona.unknown
+    %9 = "verona.store"(%8, %0) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
     br ^bb1
   ^bb3:  // pred: ^bb1
     br ^bb4
   ^bb4:  // 2 preds: ^bb3, ^bb5
-    %8 = "verona.constant(false)"() : () -> !verona.class<"bool">
-    %9 = "verona.cast"(%8) : (!verona.class<"bool">) -> i1
-    cond_br %9, ^bb5, ^bb6
+    %10 = "verona.constant(false)"() : () -> !verona.class<"bool">
+    %11 = "verona.cast"(%10) : (!verona.class<"bool">) -> i1
+    cond_br %11, ^bb5, ^bb6
   ^bb5:  // pred: ^bb4
-    %10 = "verona.constant(1)"() : () -> !verona.class<"int">
-    %11 = verona.call "-"[%0 : !verona.class<"U32">] (%10 : !verona.class<"int">) : !verona.unknown
-    %12 = "verona.store"(%11, %0) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
+    %12 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
+    %13 = "verona.constant(1)"() : () -> !verona.class<"int">
+    %14 = verona.call "-"[%12 : !verona.unknown] (%13 : !verona.class<"int">) : !verona.unknown
+    %15 = "verona.store"(%14, %0) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
     br ^bb4
   ^bb6:  // pred: ^bb4
-    return %0 : !verona.class<"U32">
+    %16 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
+    %17 = "verona.cast"(%16) : (!verona.unknown) -> !verona.class<"U32">
+    return %17 : !verona.class<"U32">
   }
 }


### PR DESCRIPTION
During the type refactoring, the comparison to load a value moved to
`unkTy` which was the wrong way of querying an alloca.

While the real fix is to not need those in the first place, they help
simplify condition/loop lowering. Once we simplify `for` loops, for
example, and we get to a single loop lowering, we should expand it to
carry free variables as arguments to basic blocks, and then we can get
rid of the alloca/store/load mode.

Most test changes are the introduction of loads before calls, but the
re-numbering of SSA values make it look like it's a big thing.

Partially implements #303.

Based on #316.