### PR TITLE
AST utils to use Ast instead of WeakAst

### DIFF
--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -162,7 +162,7 @@ namespace mlir::verona
     // MLIR nodes.
 
     /// Get location of an ast node.
-    mlir::Location getLocation(const ::ast::WeakAst& ast);
+    mlir::Location getLocation(const ::ast::Ast& ast);
 
     // ================================================================= Parsers
     // These methods parse the AST into MLIR constructs, then either return the


### PR DESCRIPTION
When creating this utility class, I didn't quite know what to expect.
But now, after enough commits, I can see it won't be more than just a
bunch of wrappers.

The ownership model was made "weak" to make sure we don't hold objects
for longer than they need, and don't create cycles in the reference
model. But since we hold nothing in the class itself, and all methods
are static, this will never happen anyway.

Moving to Ast shared pointers avoids all calls to `lock()` during the
interplay between weak_ptr and shared_ptr, and removes the need to
create `ptr` objects for multiple accesses. It also makes debugging the
code easier, as you can print the object with `*ast.get()`, while trying
to lock first won't work on most cases.