### PR TITLE
Three changes to the ast parser: comments on ast.h, new pass.h, ast_dump

### DIFF
--- a/src/ast/ast.cc
+++ b/src/ast/ast.cc
@@ -4,6 +4,7 @@
 
 namespace ast
 {
+  // Include PEG's ""_ operator for string-switches
   using namespace peg::udl;
 
   Ast token(const Ast& ast, const char* name, const std::string& token)

--- a/src/ast/ast.cc
+++ b/src/ast/ast.cc
@@ -201,3 +201,8 @@ namespace ast
     return index;
   }
 }
+
+void ast_dump(const ::ast::Ast& ast)
+{
+  std::cout << peg::ast_to_s(ast);
+}

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -9,41 +9,68 @@ namespace ast
   struct SymbolScope;
   struct Annotation;
 
-  using Scope = std::shared_ptr<SymbolScope>;
+  /// Ast nodes
   using AstImpl = peg::AstBase<Annotation>;
   using Ast = std::shared_ptr<AstImpl>;
+  /// Weak reference to an Ast node
   using WeakAst = std::weak_ptr<AstImpl>;
+  /// IDs: (variable, function, etc) names
   using Ident = std::string;
+  /// Numeric tag from "name"_ operator
   using Tag = unsigned int;
 
+  /// Annotation wrapper for AstBase with Symbol scope
+  using Scope = std::shared_ptr<SymbolScope>;
   struct Annotation
   {
     Scope scope;
   };
 
+  /// Symbol scope (ID -> Ast)
   struct SymbolScope
   {
     std::map<Ident, WeakAst> sym;
   };
 
+  /// Create a new token (value node) with name and token value
+  /// using a previous token's source location, position and length.
   Ast token(const Ast& ast, const char* name, const std::string& token);
+  /// Create a new node with name and no children
+  /// using a previous token's source location, position and length.
   Ast node(const Ast& ast, const char* name);
+  /// Add a child to an existing node
   void push_back(Ast& ast, Ast& child);
+  /// Replace prev with next node, updating prev's parent
   void replace(Ast& prev, Ast next);
+  /// Remove node from its parent without invalidating existing iterators.
   void remove(Ast ast);
+  /// Rename a node/token by creating a new node and replacing the old.
   void rename(Ast& ast, const char* name);
+  /// Replaces node with single child with its child.
   void elide(Ast& ast);
 
+  /// Find the closest ancestor with a specific tag, which could be itself.
   Ast get_closest(Ast ast, Tag tag);
+  /// Find the closest ancestor with a scope, which could be itself.
   Ast get_scope(Ast ast);
+  /// Find the closest 'expr' ancestor, which could be itself.
   Ast get_expr(Ast ast);
+  /// Find the 'id' in any scope above the `ast` node. Returns empty Ast
+  /// if not found.
   Ast get_def(Ast ast, Ident id);
+  /// Find previous child in 'expr' parent.
   Ast get_prev_in_expr(Ast ast);
+  /// Find next child in 'expr' parent.
   Ast get_next_in_expr(Ast ast);
 
+  /// For exclusive use of 'for_each' function to avoid invalidating iterators.
+  /// Returns the iteration's parent.
   Ast& iteration_parent();
+  /// For exclusive use of 'for_each' function to avoid invalidating iterators.
+  /// Returns the iteration's index.
   size_t& iteration_index();
 
+  /// Apply function 'f(child, args...)' onto each child of 'ast'.
   template<typename Func, typename... Args>
   void for_each(Ast ast, Func f, Args&... args)
   {

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -97,3 +97,12 @@ namespace ast
     iteration_index() = prev_index;
   }
 }
+
+extern "C"
+{
+  /// This method is for debug only,
+  /// when needing to dump ast trees inside a debugger.
+  /// This is needed because `peg::ast_to_s` is templated.
+  /// Needs to be in the global namespace to be found by LLDB
+  void ast_dump(const ast::Ast& ast);
+}

--- a/src/ast/cli.cc
+++ b/src/ast/cli.cc
@@ -14,6 +14,10 @@ namespace cli
 
     Opt opt;
     app.add_flag("-a,--ast", opt.ast, "Emit an abstract syntax tree.");
+    app.add_option(
+      "-s,--stopat",
+      opt.stopAt,
+      "Stop after stage ('gen': before any pass || <pass-name>)");
     app.add_option("-g,--grammar", opt.grammar, "Grammar to use.");
     app.add_option("file", opt.filename, "File to compile.")->required();
 

--- a/src/ast/cli.h
+++ b/src/ast/cli.h
@@ -6,12 +6,22 @@
 
 namespace cli
 {
+  /// Ast generation pass (before all others)
+  const std::string stopAtGen = "gen";
+
+  /// Command line options
   struct Opt
   {
+    /// Dumps the AST at the end
     bool ast = false;
+    /// Stop after a particular step (ast gen, pass, end)
+    std::string stopAt;
+    /// Grammar file
     std::string grammar;
+    /// Output filename
     std::string filename;
   };
 
+  /// Parse all options
   Opt parse(int argc, char** argv);
 }

--- a/src/ast/main.cc
+++ b/src/ast/main.cc
@@ -2,17 +2,20 @@
 // SPDX-License-Identifier: MIT
 #include "cli.h"
 #include "module.h"
+#include "pass.h"
 #include "prec.h"
 #include "ref.h"
 #include "sym.h"
 
 int main(int argc, char** argv)
 {
-  module::Passes passes = {sym::build, ref::build, prec::build};
+  pass::Passes passes = {
+    {"sym", sym::build}, {"ref", ref::build}, {"prec", prec::build}};
   err::Errors err;
 
   auto opt = cli::parse(argc, argv);
-  auto m = module::build(opt.grammar, passes, opt.filename, "verona", err);
+  auto m =
+    module::build(opt.grammar, opt.stopAt, passes, opt.filename, "verona", err);
 
   if (opt.ast)
     std::cout << m;

--- a/src/ast/module.h
+++ b/src/ast/module.h
@@ -6,12 +6,10 @@
 #include "dfs.h"
 #include "err.h"
 #include "parser.h"
+#include "pass.h"
 
 namespace module
 {
-  using Pass = void (*)(ast::Ast& ast, err::Errors& err);
-  using Passes = std::vector<Pass>;
-
   struct Module
   {
     std::string name;
@@ -27,14 +25,15 @@ namespace module
 
   ModulePtr build(
     peg::parser& parser,
-    const Passes& passes,
+    const pass::Passes& passes,
     const std::string& path,
     const std::string& ext,
     err::Errors& err);
 
   ModulePtr build(
     const std::string& grammar,
-    const Passes& passes,
+    const std::string& stopAt,
+    const pass::Passes& passes,
     const std::string& path,
     const std::string& ext,
     err::Errors& err);

--- a/src/ast/pass.h
+++ b/src/ast/pass.h
@@ -1,0 +1,34 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "ast.h"
+#include "err.h"
+
+#include <vector>
+
+namespace pass
+{
+  /// A Pass object has a name and an operation, that is executed on AST nodes.
+  class Pass
+  {
+    // The pass itself.
+    using PassPtr = void (*)(ast::Ast& ast, err::Errors& err);
+    PassPtr pass;
+
+  public:
+    Pass(const char* name, PassPtr pass) : pass(pass), name(name) {}
+
+    /// The pass name, for debug purposes.
+    const char* name;
+
+    /// Runs the pass on an ast node.
+    void operator()(ast::Ast& ast, err::Errors& err) const
+    {
+      pass(ast, err);
+    }
+  };
+
+  /// A list of passes.
+  using Passes = std::vector<Pass>;
+}

--- a/src/mlir/verona-mlir.cc
+++ b/src/mlir/verona-mlir.cc
@@ -4,6 +4,7 @@
 #include "CLI/CLI.hpp"
 #include "ast/module.h"
 #include "ast/parser.h"
+#include "ast/pass.h"
 #include "ast/path.h"
 #include "ast/prec.h"
 #include "ast/ref.h"
@@ -125,8 +126,10 @@ int main(int argc, char** argv)
     {
       // Parse the file
       err::Errors err;
-      module::Passes passes = {sym::build, ref::build, prec::build};
-      auto m = module::build(grammarFile, passes, inputFile, "verona", err);
+      pass::Passes passes = {
+        {"sym", sym::build}, {"ref", ref::build}, {"prec", prec::build}};
+      auto m = module::build(
+        grammarFile, /*stopAt*/ "", passes, inputFile, "verona", err);
       if (!err.empty())
       {
         std::cerr << "ERROR: cannot parse Verona file " << inputFile


### PR DESCRIPTION
This PR adds three things:
1. Comments to all `ast.h` methods, to help clarify what they do and what are the inter-dependencies.
2. A `Pass` class wrapper for the function pointers of each pass to have a name, so that we can print an `after-tree` with a name associated.
3. An `ast_dump` method, for use in debuggers.

It's not possible to create tests yet due to the nature of our (hard-coded) test runner (in CMake).