### PR TITLE
Implement `invoke` ast node in MLIR

### DIFF
--- a/src/mlir/generator.cc
+++ b/src/mlir/generator.cc
@@ -338,6 +338,7 @@ namespace mlir::verona
       case AST::NodeKind::Assign:
         return parseAssign(ast);
       case AST::NodeKind::Call:
+      case AST::NodeKind::Invoke:
       case AST::NodeKind::StaticCall:
         return parseCall(ast);
       case AST::NodeKind::Return:
@@ -439,8 +440,10 @@ namespace mlir::verona
   llvm::Expected<ReturnValue> Generator::parseCall(const ::ast::Ast& ast)
   {
     // All operations are calls, including arithmetic, comparison, casts
-    // but they're either `call` or `static-call`.
-    assert((AST::isCall(ast) || AST::isStaticCall(ast)) && "Bad node");
+    // but they can be: `invoke`, `call` or `static-call`.
+    assert(
+      (AST::isCall(ast) || AST::isInvoke(ast) || AST::isStaticCall(ast)) &&
+      "Bad node");
     auto name = AST::getID(ast);
     auto loc = getLocation(ast);
 
@@ -475,7 +478,7 @@ namespace mlir::verona
     // argument.
     // Both need a descriptor, to know where to find the function to call.
     mlir::Value descriptor;
-    if (AST::isCall(ast))
+    if (AST::isCall(ast) || AST::isInvoke(ast))
     {
       // Dynamic call: `a op b` | `a.op(b...)`
       assert(args.size() >= 1 && "Too few arguments for dynamic call");

--- a/testsuite/mlir/mlir-parse/call.verona
+++ b/testsuite/mlir/mlir-parse/call.verona
@@ -11,6 +11,10 @@ foo(a: N, b: U64 & imm): R
   {
     return foo(x, y);
   }
+  else if (a != 0)
+  {
+    return a.method(b);
+  }
   return x + y;
 }
 

--- a/testsuite/mlir/mlir-parse/call/mlir.txt
+++ b/testsuite/mlir/mlir-parse/call/mlir.txt
@@ -28,11 +28,25 @@ module @"$module" {
     %21 = "verona.cast"(%20) : (!verona.unknown) -> !verona.meet<class<"U64">, imm>
     return %21 : !verona.meet<class<"U64">, imm>
   ^bb2:  // pred: ^bb0
-    %22 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
-    %23 = "verona.load"(%12) : (!verona.unknown) -> !verona.unknown
-    %24 = verona.call "+"[%22 : !verona.unknown] (%23 : !verona.unknown) : !verona.unknown
-    %25 = "verona.cast"(%24) : (!verona.unknown) -> !verona.meet<class<"U64">, imm>
-    return %25 : !verona.meet<class<"U64">, imm>
+    %22 = "verona.load"(%0) : (!verona.imm) -> !verona.unknown
+    %23 = "verona.constant(0)"() : () -> !verona.class<"int">
+    %24 = verona.call "!="[%22 : !verona.unknown] (%23 : !verona.class<"int">) : !verona.unknown
+    %25 = "verona.cast"(%24) : (!verona.unknown) -> i1
+    cond_br %25, ^bb4, ^bb5
+  ^bb3:  // pred: ^bb5
+    %26 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
+    %27 = "verona.load"(%12) : (!verona.unknown) -> !verona.unknown
+    %28 = verona.call "+"[%26 : !verona.unknown] (%27 : !verona.unknown) : !verona.unknown
+    %29 = "verona.cast"(%28) : (!verona.unknown) -> !verona.meet<class<"U64">, imm>
+    return %29 : !verona.meet<class<"U64">, imm>
+  ^bb4:  // pred: ^bb2
+    %30 = "verona.load"(%0) : (!verona.imm) -> !verona.unknown
+    %31 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
+    %32 = verona.call "method"[%30 : !verona.unknown] (%31 : !verona.unknown) : !verona.unknown
+    %33 = "verona.cast"(%32) : (!verona.unknown) -> !verona.meet<class<"U64">, imm>
+    return %33 : !verona.meet<class<"U64">, imm>
+  ^bb5:  // pred: ^bb2
+    br ^bb3
   }
   func @apply() attributes {class = !verona.class<"$module">} {
     %0 = "verona.constant(10)"() : () -> !verona.class<"int">


### PR DESCRIPTION
Invoke is similar to `call`, where the first argument is a `member`
instead of a reference to an object. But the reference to the object is
in the member, together with the method's name.

Adapting the ast-utils methods to work around that made the MLIR
implementation identical and therefore unchanged. Added test for invoke
on existing file.