### PR TITLE
Update LLVM and use new ODS Type definitions

### DIFF
--- a/src/mlir/dialect/CMakeLists.txt
+++ b/src/mlir/dialect/CMakeLists.txt
@@ -1,6 +1,15 @@
-add_mlir_dialect(VeronaOps verona)
-add_mlir_doc(VeronaDialect -gen-dialect-doc VeronaDialect Verona/)
-add_mlir_doc(VeronaOps -gen-op-doc VeronaOps Verona/)
+set(LLVM_TARGET_DEFINITIONS VeronaOps.td)
+mlir_tablegen(VeronaOps.h.inc -gen-op-decls)
+mlir_tablegen(VeronaOps.cpp.inc -gen-op-defs)
+
+set(LLVM_TARGET_DEFINITIONS VeronaTypes.td)
+mlir_tablegen(VeronaTypes.h.inc -gen-typedef-decls)
+mlir_tablegen(VeronaTypes.cpp.inc -gen-typedef-defs)
+
+set(LLVM_TARGET_DEFINITIONS VeronaDialect.td)
+mlir_tablegen(VeronaDialect.h.inc -gen-dialect-decls -dialect=verona)
+
+add_public_tablegen_target(VeronaIncGen)
 
 add_mlir_interface(TypecheckInterface)
 
@@ -13,7 +22,7 @@ add_mlir_dialect_library(MLIRVerona
     TypeSyntax.cc
 
     DEPENDS
-    MLIRVeronaOpsIncGen
+    VeronaIncGen
     MLIRTypecheckInterfaceIncGen
 
     LINK_LIBS PUBLIC

--- a/src/mlir/dialect/TypecheckInterface.cc
+++ b/src/mlir/dialect/TypecheckInterface.cc
@@ -3,7 +3,4 @@
 
 #include "dialect/TypecheckInterface.h"
 
-namespace mlir::verona
-{
 #include "dialect/TypecheckInterface.cpp.inc"
-}

--- a/src/mlir/dialect/TypecheckInterface.h
+++ b/src/mlir/dialect/TypecheckInterface.h
@@ -4,7 +4,6 @@
 #pragma once
 #include "mlir/IR/OpDefinition.h"
 
-namespace mlir::verona
-{
+// This line must come after "normal" includes.
+// Having this comment prevents clang-format from re-ordering it.
 #include "dialect/TypecheckInterface.h.inc"
-}

--- a/src/mlir/dialect/TypecheckInterface.td
+++ b/src/mlir/dialect/TypecheckInterface.td
@@ -30,10 +30,11 @@ def TypecheckInterface : OpInterface<"TypecheckInterface"> {
     that don't are considered always valid. In the future, we will most likely 
     require all statement-like operations to implement this interface.
   }];
+  let cppNamespace = "::mlir::verona";
   let methods = [
     InterfaceMethod<
       "Check the types of this operation against typing rules.",
-      "LogicalResult", "typecheck"
+      "::mlir::LogicalResult", "typecheck"
     >,
   ];
 }

--- a/src/mlir/dialect/VeronaDialect.cc
+++ b/src/mlir/dialect/VeronaDialect.cc
@@ -18,13 +18,12 @@ namespace mlir::verona
       >();
 
     addTypes<
-      MeetType,
-      JoinType,
-      UnknownType,
-      DescriptorType,
-      CapabilityType,
-      ClassType,
-      ViewpointType>();
+#define GET_TYPEDEF_LIST
+#include "dialect/VeronaTypes.cpp.inc"
+      >();
+
+    // ClassType isn't defined by ODS yet.
+    addTypes<ClassType>();
 
     allowUnknownOperations();
     allowUnknownTypes();

--- a/src/mlir/dialect/VeronaDialect.cc
+++ b/src/mlir/dialect/VeronaDialect.cc
@@ -4,42 +4,39 @@
 #include "VeronaDialect.h"
 
 #include "VeronaOps.h"
+#include "VeronaTypes.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/StandardTypes.h"
 
-using namespace mlir;
-using namespace mlir::verona;
-
-//===----------------------------------------------------------------------===//
-// Verona dialect.
-//===----------------------------------------------------------------------===//
-
-void VeronaDialect::initialize()
+namespace mlir::verona
 {
-  addOperations<
+  void VeronaDialect::initialize()
+  {
+    addOperations<
 #define GET_OP_LIST
 #include "dialect/VeronaOps.cpp.inc"
-    >();
+      >();
 
-  addTypes<
-    MeetType,
-    JoinType,
-    UnknownType,
-    DescriptorType,
-    CapabilityType,
-    ClassType,
-    ViewpointType>();
+    addTypes<
+      MeetType,
+      JoinType,
+      UnknownType,
+      DescriptorType,
+      CapabilityType,
+      ClassType,
+      ViewpointType>();
 
-  allowUnknownOperations();
-  allowUnknownTypes();
-}
+    allowUnknownOperations();
+    allowUnknownTypes();
+  }
 
-Type VeronaDialect::parseType(DialectAsmParser& parser) const
-{
-  return parseVeronaType(parser);
-}
+  Type VeronaDialect::parseType(DialectAsmParser& parser) const
+  {
+    return parseVeronaType(parser);
+  }
 
-void VeronaDialect::printType(Type type, DialectAsmPrinter& os) const
-{
-  return printVeronaType(type, os);
+  void VeronaDialect::printType(Type type, DialectAsmPrinter& os) const
+  {
+    return printVeronaType(type, os);
+  }
 }

--- a/src/mlir/dialect/VeronaDialect.h
+++ b/src/mlir/dialect/VeronaDialect.h
@@ -7,4 +7,4 @@
 
 // This line must come after "normal" includes.
 // Having this comment prevents clang-format from re-ordering it.
-#include "dialect/VeronaOpsDialect.h.inc"
+#include "dialect/VeronaDialect.h.inc"

--- a/src/mlir/dialect/VeronaDialect.h
+++ b/src/mlir/dialect/VeronaDialect.h
@@ -3,11 +3,8 @@
 
 #pragma once
 
-#include "dialect/VeronaTypes.h"
 #include "mlir/IR/Dialect.h"
 
-namespace mlir::verona
-{
+// This line must come after "normal" includes.
+// Having this comment prevents clang-format from re-ordering it.
 #include "dialect/VeronaOpsDialect.h.inc"
-
-} // namespace mlir::verona

--- a/src/mlir/dialect/VeronaDialect.td
+++ b/src/mlir/dialect/VeronaDialect.td
@@ -27,18 +27,9 @@ class Verona_Op<string mnemonic, list<OpTrait> traits = []> :
     let verifier = [{ return ::verify(*this); }];
 }
 
+class Verona_TypeDef<string name> : TypeDef<Verona_Dialect, name> { }
+
 def Verona_Type : DialectType<Verona_Dialect,
     CPred<"isaVeronaType($_self)">, "Verona type">;
-
-def Verona_TypeAttr :
-    Attr<And<
-      [CPred<"$_self.isa<TypeAttr>()">,
-       CPred<"isaVeronaType($_self.cast<TypeAttr>().getValue())">]>>
-{
-  let storageType = [{ TypeAttr }];
-  let returnType = [{ Type }];
-  let valueType = NoneType;
-  let convertFromStorage = "$_self.getValue().cast<Type>()";
-}
 
 #endif // VERONA_DIALECT

--- a/src/mlir/dialect/VeronaDialect.td
+++ b/src/mlir/dialect/VeronaDialect.td
@@ -13,7 +13,7 @@ include "mlir/IR/OpBase.td"
 def Verona_Dialect : Dialect {
     let name = "verona";
     let summary = "A prototype Verona language MLIR dialect.";
-    let cppNamespace = "verona";
+    let cppNamespace = "::mlir::verona";
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/mlir/dialect/VeronaOps.cc
+++ b/src/mlir/dialect/VeronaOps.cc
@@ -56,8 +56,7 @@ namespace mlir::verona
   {
     return lookupFieldType(origin().getType(), field());
   }
+} // namespace mlir::verona
 
 #define GET_OP_CLASSES
 #include "dialect/VeronaOps.cpp.inc"
-
-} // namespace mlir::verona

--- a/src/mlir/dialect/VeronaOps.h
+++ b/src/mlir/dialect/VeronaOps.h
@@ -11,9 +11,5 @@
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
-namespace mlir::verona
-{
 #define GET_OP_CLASSES
 #include "dialect/VeronaOps.h.inc"
-
-} // namespace mlir::verona

--- a/src/mlir/dialect/VeronaTypes.td
+++ b/src/mlir/dialect/VeronaTypes.td
@@ -1,0 +1,73 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#ifndef VERONA_TYPES
+#define VERONA_TYPES
+
+include "VeronaDialect.td"
+
+def JoinType : Verona_TypeDef<"Join"> {
+  let description = [{
+    Join types are unions between types (A | B).
+  }];
+
+  let parameters = (ins ArrayRefParameter<"Type", "Elements">:$elements);
+  let genVerifyInvariantsDecl = 1;
+}
+
+def MeetType : Verona_TypeDef<"Meet"> {
+  let description = [{
+    Meet types are intersections between types (A & B).
+  }];
+
+  let parameters = (ins ArrayRefParameter<"Type", "Elements">:$elements);
+  let genVerifyInvariantsDecl = 1;
+}
+
+def UnknownType : Verona_TypeDef<"Unknown"> {
+  let description = [{
+    Unknown types are derived types from operations that cannot define the type
+    at lowering stage, but will later be replaced by other types during type
+    inference.
+  }];
+}
+
+def CapabilityType : Verona_TypeDef<"Capability"> {
+  let description = [{
+    Capability types represents properties of individual references eg.
+    a `String & iso` and a `String & mut` could point to the same object.
+   
+    Isolated: An entry point to a new region. There can be more than one
+    reference to the entrypoint, but only one of them can be Isolated ie.
+    the others must be Mutable.
+   
+    Immutable: A stronger property than Read-Only. It guarantees that no
+    mutable aliases to that object exist anywhere else.
+  }];
+
+  let parameters = (ins "Capability":$capability);
+}
+
+def DescriptorType : Verona_TypeDef<"Descriptor"> {
+  let description = [{
+    A static class descriptor type, used for access to static members of the
+    class, including fields and methods.
+  }];
+
+  let parameters = (ins "Type":$describedType);
+  let genVerifyInvariantsDecl = 1;
+}
+
+def ViewpointType : Verona_TypeDef<"Viewpoint"> {
+  let description = [{
+    Viewpoint is a view of a type through another type.
+    
+    For examples, reading a mut field from a imm object gives you a
+    `viewpoint<mut, imm> = imm` reference.
+  }];
+
+  let parameters = (ins "Type":$leftType, "Type":$rightType);
+  let genVerifyInvariantsDecl = 1;
+}
+
+#endif

--- a/src/mlir/driver.cc
+++ b/src/mlir/driver.cc
@@ -20,9 +20,7 @@
 namespace mlir::verona
 {
   Driver::Driver(unsigned optLevel)
-  : context(/*loadAllDialects=*/false),
-    passManager(&context),
-    diagnosticHandler(sourceManager, &context)
+  : passManager(&context), diagnosticHandler(sourceManager, &context)
   {
     context.getOrLoadDialect<mlir::StandardOpsDialect>();
     context.getOrLoadDialect<mlir::verona::VeronaDialect>();

--- a/testsuite/mlir/mlir-parse/call/mlir.txt
+++ b/testsuite/mlir/mlir-parse/call/mlir.txt
@@ -1,5 +1,3 @@
-
-
 module @"$module" {
   func @foo(%arg0: !verona.imm, %arg1: !verona.meet<class<"U64">, imm>) -> !verona.meet<class<"U64">, imm> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.imm

--- a/testsuite/mlir/mlir-parse/class/mlir.txt
+++ b/testsuite/mlir/mlir-parse/class/mlir.txt
@@ -1,5 +1,3 @@
-
-
 module @"$module" {
   module @C {
   }

--- a/testsuite/mlir/mlir-parse/conditional/mlir.txt
+++ b/testsuite/mlir/mlir-parse/conditional/mlir.txt
@@ -1,5 +1,3 @@
-
-
 module @"$module" {
   func @f(%arg0: !verona.class<"U16">) -> !verona.class<"S16"> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.class<"U16">

--- a/testsuite/mlir/mlir-parse/constant/mlir.txt
+++ b/testsuite/mlir/mlir-parse/constant/mlir.txt
@@ -1,5 +1,3 @@
-
-
 module @"$module" {
   func @f() attributes {class = !verona.class<"$module">} {
     %0 = "verona.constant(42)"() : () -> !verona.class<"int">

--- a/testsuite/mlir/mlir-parse/dialect/mlir.txt
+++ b/testsuite/mlir/mlir-parse/dialect/mlir.txt
@@ -1,5 +1,3 @@
-
-
 module {
   func @bar(%arg0: !verona.meet<class<"U64">, imm>, %arg1: !verona.meet<class<"U64">, imm>) {
     %0 = verona.new_region @C [] : !verona.meet<class<"C", "$parent" : class<"$module">>, iso>

--- a/testsuite/mlir/mlir-parse/for-sugar/mlir.txt
+++ b/testsuite/mlir/mlir-parse/for-sugar/mlir.txt
@@ -1,5 +1,3 @@
-
-
 module @"$module" {
   func @for_sum(%arg0: !verona.class<"List">) -> !verona.class<"U32"> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.class<"List">

--- a/testsuite/mlir/mlir-parse/for/mlir.txt
+++ b/testsuite/mlir/mlir-parse/for/mlir.txt
@@ -1,5 +1,3 @@
-
-
 module @"$module" {
   func @foo(!verona.class<"S32">) attributes {class = !verona.class<"$module">}
   func @f(%arg0: !verona.class<"U64">) attributes {class = !verona.class<"$module">} {

--- a/testsuite/mlir/mlir-parse/function/mlir.txt
+++ b/testsuite/mlir/mlir-parse/function/mlir.txt
@@ -1,5 +1,3 @@
-
-
 module @"$module" {
   module @A {
     func @foo() -> !verona.class<"bool"> attributes {class = !verona.class<"A", "$parent" : class<"$module">>, qualifiers = ["static"]} {

--- a/testsuite/mlir/mlir-parse/lookup/mlir.txt
+++ b/testsuite/mlir/mlir-parse/lookup/mlir.txt
@@ -1,5 +1,3 @@
-
-
 module {
   func @test_class_mut(%arg0: !verona.meet<class<"C1", "f" : meet<class<"D1">, mut>>, mut>) -> !verona.meet<class<"D1">, mut> {
     %0 = verona.field_read %arg0["f"] : !verona.meet<class<"C1", "f" : meet<class<"D1">, mut>>, mut> -> !verona.meet<class<"D1">, mut>

--- a/testsuite/mlir/mlir-parse/nested-conditional/mlir.txt
+++ b/testsuite/mlir/mlir-parse/nested-conditional/mlir.txt
@@ -1,5 +1,3 @@
-
-
 module @"$module" {
   func @f(%arg0: !verona.class<"U32">) -> !verona.class<"U32"> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.class<"U32">

--- a/testsuite/mlir/mlir-parse/nested-while/mlir.txt
+++ b/testsuite/mlir/mlir-parse/nested-while/mlir.txt
@@ -1,5 +1,3 @@
-
-
 module @"$module" {
   func @f(%arg0: !verona.class<"S64">) -> !verona.class<"S64"> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.class<"S64">

--- a/testsuite/mlir/mlir-parse/subsumption/mlir.txt
+++ b/testsuite/mlir/mlir-parse/subsumption/mlir.txt
@@ -1,5 +1,3 @@
-
-
 module {
   func @test1(%arg0: !verona.meet<class<"U64">, imm>) {
     %0 = verona.copy %arg0 : !verona.meet<class<"U64">, imm> -> !verona.class<"U64">

--- a/testsuite/mlir/mlir-parse/types/mlir.txt
+++ b/testsuite/mlir/mlir-parse/types/mlir.txt
@@ -1,5 +1,3 @@
-
-
 module @"$module" {
   func @foo(%arg0: !verona.meet<class<"S32">, iso>, %arg1: !verona.meet<class<"U64">, imm>) -> !verona.join<meet<class<"S32">, iso>, meet<class<"U64">, imm>, meet<class<"U32">, mut>> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.meet<class<"S32">, iso>

--- a/testsuite/mlir/mlir-parse/variables/mlir.txt
+++ b/testsuite/mlir/mlir-parse/variables/mlir.txt
@@ -1,5 +1,3 @@
-
-
 module @"$module" {
   func @foo(%arg0: !verona.meet<class<"S32">, iso>, %arg1: !verona.meet<class<"U64">, imm>) -> !verona.class<"S64"> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.meet<class<"S32">, iso>

--- a/testsuite/mlir/mlir-parse/while-cont-brk/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while-cont-brk/mlir.txt
@@ -1,5 +1,3 @@
-
-
 module @"$module" {
   func @f(%arg0: !verona.class<"U32">, %arg1: !verona.class<"S32">) -> !verona.class<"F16"> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.class<"U32">

--- a/testsuite/mlir/mlir-parse/while-context/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while-context/mlir.txt
@@ -1,5 +1,3 @@
-
-
 module @"$module" {
   func @f(%arg0: !verona.class<"F32">) -> !verona.class<"F64"> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.class<"F32">

--- a/testsuite/mlir/mlir-parse/while-if/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while-if/mlir.txt
@@ -1,5 +1,3 @@
-
-
 module @"$module" {
   func @f(%arg0: !verona.class<"U32">, %arg1: !verona.class<"S32">) -> !verona.class<"U32"> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.class<"U32">

--- a/testsuite/mlir/mlir-parse/while/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while/mlir.txt
@@ -1,5 +1,3 @@
-
-
 module @"$module" {
   func @f(%arg0: !verona.class<"U32">) -> !verona.class<"U32"> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.class<"U32">


### PR DESCRIPTION
This cuts down on a lot of boilerplate around the definition of types, accessors and storage classes.

Because of complications due to its recursive structure, we can't use ODS with ClassType yet. We may be able to use ODS with a custom storage class and extra class declarations, but it leads to a messy Frankenstein definition, so it is easier to keep it all in C++.

Similarly, we can't use the parsing/printing code ODS generates, because our implementations need extra context about recursive classes (ie. the class_stack fields of TypePrinter and TypeParser).

Fixes #331