### PR TITLE
De-sugar `for` loops + hygienic ids

### DIFF
--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(verona-ast-lib
   prec.cc
   ref.cc
   path.cc
+  sugar.cc
   sym.cc
   )
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -24,6 +24,7 @@ namespace ast
   struct Annotation
   {
     Scope scope;
+    size_t id = 0;
   };
 
   /// Symbol scope (ID -> Ast)
@@ -32,15 +33,24 @@ namespace ast
     std::map<Ident, WeakAst> sym;
   };
 
-  /// Create a new token (value node) with name and token value
+  /// Create a new token (value node) with name and token value,
   /// using a previous token's source location, position and length.
   Ast token(const Ast& ast, const char* name, const std::string& token);
-  /// Create a new node with name and no children
+  /// Create a new node with name and no children,
   /// using a previous token's source location, position and length.
   Ast node(const Ast& ast, const char* name);
-  /// Add a child to an existing node
+
+  /// Add a child to an existing node. Either new or caller cleans it.
   void push_back(Ast& ast, Ast& child);
-  /// Replace prev with next node, updating prev's parent
+  /// Add a node `child` to `before`s parent, before that node.
+  void insert_before(Ast& child, Ast& before);
+  /// Move the `child` node to the `ast` parent.
+  void move_back(Ast& ast, Ast& child);
+  /// Move a node `child` to `before`s parent, before that node.
+  void move_before(Ast& child, Ast& before);
+  /// Move all children of one node onto the end of another node.
+  void move_children(Ast& from, Ast& to);
+  /// Replace prev with next node, updating prev's parent.
   void replace(Ast& prev, Ast next);
   /// Remove node from its parent without invalidating existing iterators.
   void remove(Ast ast);
@@ -55,13 +65,15 @@ namespace ast
   Ast get_scope(Ast ast);
   /// Find the closest 'expr' ancestor, which could be itself.
   Ast get_expr(Ast ast);
-  /// Find the 'id' in any scope above the `ast` node. Returns empty Ast
-  /// if not found.
+  /// Find the 'id' in any scope above the `ast` node. Empty ast if not found.
   Ast get_def(Ast ast, Ident id);
   /// Find previous child in 'expr' parent.
   Ast get_prev_in_expr(Ast ast);
   /// Find next child in 'expr' parent.
   Ast get_next_in_expr(Ast ast);
+
+  /// Returns a hygienic id within the scope of the ast node.
+  std::string hygienic_id(Ast ast, const char* prefix = "");
 
   /// For exclusive use of 'for_each' function to avoid invalidating iterators.
   /// Returns the iteration's parent.
@@ -103,6 +115,6 @@ extern "C"
   /// This method is for debug only,
   /// when needing to dump ast trees inside a debugger.
   /// This is needed because `peg::ast_to_s` is templated.
-  /// Needs to be in the global namespace to be found by LLDB
+  /// Needs to be in the global namespace to be found by LLDB.
   void ast_dump(const ast::Ast& ast);
 }

--- a/src/ast/main.cc
+++ b/src/ast/main.cc
@@ -5,12 +5,15 @@
 #include "pass.h"
 #include "prec.h"
 #include "ref.h"
+#include "sugar.h"
 #include "sym.h"
 
 int main(int argc, char** argv)
 {
-  pass::Passes passes = {
-    {"sym", sym::build}, {"ref", ref::build}, {"prec", prec::build}};
+  pass::Passes passes = {{"sugar", sugar::build},
+                         {"sym", sym::build},
+                         {"ref", ref::build},
+                         {"prec", prec::build}};
   err::Errors err;
 
   auto opt = cli::parse(argc, argv);

--- a/src/ast/sugar.cc
+++ b/src/ast/sugar.cc
@@ -1,0 +1,166 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+#include "sugar.h"
+
+// Include PEG's ""_ operator for string-switches
+using namespace peg::udl;
+
+namespace
+{
+  /// Create an element, append to ast and return it.
+  /// Used to simplify building nested structures.
+  ::ast::Ast append_descend(::ast::Ast& ast, const std::string& name)
+  {
+    auto sub = node(ast, name.c_str());
+    push_back(ast, sub);
+    return sub;
+  }
+
+  /// Append an atom to `ast`, appending `arg` to the atom.
+  void atom(::ast::Ast& ast, ::ast::Ast& arg)
+  {
+    auto atom = node(ast, "atom");
+    move_back(atom, arg);
+    push_back(ast, atom);
+  }
+
+  /// Append an atom to `ast`, appending a token to the atom.
+  void
+  token_atom(::ast::Ast& ast, const std::string& name, const std::string& value)
+  {
+    auto tok = token(ast, name.c_str(), value.c_str());
+    atom(ast, tok);
+  }
+
+  /// Append an atom to `ast`, appending an empty node to the atom.
+  void node_atom(::ast::Ast& ast, const std::string& name)
+  {
+    auto sub = node(ast, name.c_str());
+    atom(ast, sub);
+  }
+
+  /// Add dynamic call with one argument (self) to the node `ast`
+  void call_1(::ast::Ast& ast, const std::string& obj, const std::string& func)
+  {
+    // object
+    token_atom(ast, "id", obj);
+    // dot
+    token_atom(ast, "sym", ".");
+    // function name
+    token_atom(ast, "id", func);
+    // tuple
+    node_atom(ast, "tuple");
+  }
+
+  /// Add assign pattern (var =) to the node `ast`
+  void let_assign(::ast::Ast& ast, ::ast::Ast& var)
+  {
+    // let
+    if (var->tag == "atom"_)
+    {
+      push_back(ast, var);
+    }
+    else
+    {
+      atom(ast, var);
+    }
+    // sym (=)
+    token_atom(ast, "sym", "=");
+  }
+
+  /// Add assign to a variable pattern to the `ast` node, creating a new `let`
+  void assign(::ast::Ast& ast, const std::string& name)
+  {
+    // create a new let
+    auto let = node(ast, "let");
+    auto id = token(let, "id", name.c_str());
+    push_back(let, id);
+    auto type = node(let, "oftype");
+    push_back(let, type);
+    // assign
+    let_assign(ast, let);
+  }
+
+  /// Replace 'for' loop with 'while' loop.
+  void sugar_for(::ast::Ast ast)
+  {
+    // block > seq > term > blockexpr > for (insert iterator in seq before loop)
+    auto seq = get_closest(ast, "seq"_);
+    auto term = get_closest(ast, "term"_);
+    // for > expr > atom (expression that declares the iteration value)
+    auto id = ast->nodes[0]->nodes[0];
+    assert(id->tag == "atom"_);
+    // for > seq > expr (expression that gives an iterator)
+    auto iterExpr = ast->nodes[1]->nodes[0];
+    assert(iterExpr->tag == "expr"_);
+    // for > block > seq (sequence of expressions in the body)
+    auto body = ast->nodes[2]->nodes[0];
+    assert(body->tag == "seq"_);
+
+    // Iterator term ($iter = iterator()), insert before loop's term
+    auto iterTerm = node(ast, "term");
+    std::string iter = hygienic_id(ast, "iter");
+    assign(iterTerm, iter);
+    move_children(iterExpr, iterTerm);
+    insert_before(iterTerm, term);
+    remove(iterExpr);
+
+    // While loop (new, to replace the current ast)
+    auto loop = node(ast, "while");
+
+    // Condition (entirely new iter.has_value call)
+    auto cond = append_descend(loop, "cond");
+    auto seqCond = append_descend(cond, "seq");
+    auto exprCond = append_descend(seqCond, "expr");
+    call_1(exprCond, iter, "has_value");
+
+    // Block (new, with apply, next and remainder of for block)
+    auto block = append_descend(loop, "block");
+    auto seqBlock = append_descend(block, "seq");
+
+    // Apply (new, take the value of the iterator)
+    auto termApply = append_descend(seqBlock, "term");
+    let_assign(termApply, id);
+    call_1(termApply, iter, "apply");
+
+    // Next (new, increment the iterator)
+    auto termNext = append_descend(seqBlock, "term");
+    call_1(termNext, iter, "next");
+
+    // Body (moving, add all terms from old body)
+    move_children(body, seqBlock);
+    remove(body);
+
+    // Replacing old 'for' term 'with' while term
+    replace(ast, loop);
+  }
+}
+
+namespace sugar
+{
+  void build(ast::Ast& ast, err::Errors& err)
+  {
+    switch (ast->tag)
+    {
+      case "for"_:
+        // Replaces the for loop with a while loop.
+        //
+        // Change:
+        // for (tuple in expr) {
+        //   body(tuple);
+        // }
+        //
+        // To:
+        // $iter = expr;
+        // while ($iter.has_value()) {
+        //   tuple = $iter.apply();
+        //   $iter.next();
+        //   body(tuple);
+        // }
+        sugar_for(ast);
+        break;
+    }
+
+    ast::for_each(ast, build, err);
+  }
+}

--- a/src/ast/sugar.h
+++ b/src/ast/sugar.h
@@ -1,0 +1,11 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "ast.h"
+#include "err.h"
+
+namespace sugar
+{
+  void build(ast::Ast& ast, err::Errors& err);
+}

--- a/src/mlir/verona-mlir.cc
+++ b/src/mlir/verona-mlir.cc
@@ -8,6 +8,7 @@
 #include "ast/path.h"
 #include "ast/prec.h"
 #include "ast/ref.h"
+#include "ast/sugar.h"
 #include "ast/sym.h"
 #include "driver.h"
 #include "mlir/InitAllDialects.h"
@@ -126,8 +127,10 @@ int main(int argc, char** argv)
     {
       // Parse the file
       err::Errors err;
-      pass::Passes passes = {
-        {"sym", sym::build}, {"ref", ref::build}, {"prec", prec::build}};
+      pass::Passes passes = {{"sugar", sugar::build},
+                             {"sym", sym::build},
+                             {"ref", ref::build},
+                             {"prec", prec::build}};
       auto m = module::build(
         grammarFile, /*stopAt*/ "", passes, inputFile, "verona", err);
       if (!err.empty())

--- a/testsuite/mlir/mlir-parse/for-sugar.verona
+++ b/testsuite/mlir/mlir-parse/for-sugar.verona
@@ -1,0 +1,35 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+// This for loop
+
+for_sum(x: List) : U32
+{
+  let sum: U32 = 0;
+  // `a` is a local variable in the loop's context
+  // `x.values()` is any expression that yields an iterator
+  for (let a in x.values()) {
+    sum = sum + a;
+  }
+  return sum;
+}
+
+// maps to this while loop
+
+while_sum(x: List) : U32
+{
+  let sum: U32 = 0;
+  // The iterator will have a hygienic name in the compiler
+  let iter = x.values();
+  // This is the while version of that for loop
+  while(iter.has_value())
+  {
+    // This has to be `a`, same as in the for loop above
+    let a = iter.apply();
+    // Increments the iterator (move this before apply?)
+    iter.next();
+    // This is the body of the for loop
+    sum = sum + a;
+  }
+  return sum;
+}

--- a/testsuite/mlir/mlir-parse/for-sugar/mlir.txt
+++ b/testsuite/mlir/mlir-parse/for-sugar/mlir.txt
@@ -1,0 +1,70 @@
+
+
+module @"$module" {
+  func @for_sum(%arg0: !verona.class<"List">) -> !verona.class<"U32"> attributes {class = !verona.class<"$module">} {
+    %0 = "verona.alloca"() : () -> !verona.class<"List">
+    %1 = "verona.store"(%arg0, %0) : (!verona.class<"List">, !verona.class<"List">) -> !verona.unknown
+    %2 = "verona.constant(0)"() : () -> !verona.class<"int">
+    %3 = "verona.alloca"() : () -> !verona.class<"U32">
+    %4 = "verona.store"(%2, %3) : (!verona.class<"int">, !verona.class<"U32">) -> !verona.unknown
+    %5 = "verona.load"(%0) : (!verona.class<"List">) -> !verona.unknown
+    %6 = verona.call "values"[%5 : !verona.unknown] ( : ) : !verona.unknown
+    %7 = "verona.alloca"() : () -> !verona.unknown
+    %8 = "verona.store"(%6, %7) : (!verona.unknown, !verona.unknown) -> !verona.unknown
+    br ^bb1
+  ^bb1:  // 2 preds: ^bb0, ^bb2
+    %9 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
+    %10 = verona.call "has_value"[%9 : !verona.unknown] ( : ) : !verona.unknown
+    %11 = "verona.cast"(%10) : (!verona.unknown) -> i1
+    cond_br %11, ^bb2, ^bb3
+  ^bb2:  // pred: ^bb1
+    %12 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
+    %13 = verona.call "apply"[%12 : !verona.unknown] ( : ) : !verona.unknown
+    %14 = "verona.alloca"() : () -> !verona.unknown
+    %15 = "verona.store"(%13, %14) : (!verona.unknown, !verona.unknown) -> !verona.unknown
+    %16 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
+    %17 = verona.call "next"[%16 : !verona.unknown] ( : ) : !verona.unknown
+    %18 = "verona.load"(%3) : (!verona.class<"U32">) -> !verona.unknown
+    %19 = "verona.load"(%14) : (!verona.unknown) -> !verona.unknown
+    %20 = verona.call "+"[%18 : !verona.unknown] (%19 : !verona.unknown) : !verona.unknown
+    %21 = "verona.store"(%20, %3) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
+    br ^bb1
+  ^bb3:  // pred: ^bb1
+    %22 = "verona.load"(%3) : (!verona.class<"U32">) -> !verona.unknown
+    %23 = "verona.cast"(%22) : (!verona.unknown) -> !verona.class<"U32">
+    return %23 : !verona.class<"U32">
+  }
+  func @while_sum(%arg0: !verona.class<"List">) -> !verona.class<"U32"> attributes {class = !verona.class<"$module">} {
+    %0 = "verona.alloca"() : () -> !verona.class<"List">
+    %1 = "verona.store"(%arg0, %0) : (!verona.class<"List">, !verona.class<"List">) -> !verona.unknown
+    %2 = "verona.constant(0)"() : () -> !verona.class<"int">
+    %3 = "verona.alloca"() : () -> !verona.class<"U32">
+    %4 = "verona.store"(%2, %3) : (!verona.class<"int">, !verona.class<"U32">) -> !verona.unknown
+    %5 = "verona.load"(%0) : (!verona.class<"List">) -> !verona.unknown
+    %6 = verona.call "values"[%5 : !verona.unknown] ( : ) : !verona.unknown
+    %7 = "verona.alloca"() : () -> !verona.unknown
+    %8 = "verona.store"(%6, %7) : (!verona.unknown, !verona.unknown) -> !verona.unknown
+    br ^bb1
+  ^bb1:  // 2 preds: ^bb0, ^bb2
+    %9 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
+    %10 = verona.call "has_value"[%9 : !verona.unknown] ( : ) : !verona.unknown
+    %11 = "verona.cast"(%10) : (!verona.unknown) -> i1
+    cond_br %11, ^bb2, ^bb3
+  ^bb2:  // pred: ^bb1
+    %12 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
+    %13 = verona.call "apply"[%12 : !verona.unknown] ( : ) : !verona.unknown
+    %14 = "verona.alloca"() : () -> !verona.unknown
+    %15 = "verona.store"(%13, %14) : (!verona.unknown, !verona.unknown) -> !verona.unknown
+    %16 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
+    %17 = verona.call "next"[%16 : !verona.unknown] ( : ) : !verona.unknown
+    %18 = "verona.load"(%3) : (!verona.class<"U32">) -> !verona.unknown
+    %19 = "verona.load"(%14) : (!verona.unknown) -> !verona.unknown
+    %20 = verona.call "+"[%18 : !verona.unknown] (%19 : !verona.unknown) : !verona.unknown
+    %21 = "verona.store"(%20, %3) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
+    br ^bb1
+  ^bb3:  // pred: ^bb1
+    %22 = "verona.load"(%3) : (!verona.class<"U32">) -> !verona.unknown
+    %23 = "verona.cast"(%22) : (!verona.unknown) -> !verona.class<"U32">
+    return %23 : !verona.class<"U32">
+  }
+}

--- a/testsuite/mlir/mlir-parse/for/mlir.txt
+++ b/testsuite/mlir/mlir-parse/for/mlir.txt
@@ -9,19 +9,24 @@ module @"$module" {
     %3 = "verona.alloca"() : () -> !verona.class<"S32">
     %4 = "verona.store"(%2, %3) : (!verona.class<"int">, !verona.class<"S32">) -> !verona.unknown
     %5 = "verona.load"(%0) : (!verona.class<"U64">) -> !verona.unknown
-    br ^bb2
-  ^bb1:  // pred: ^bb3
-    %6 = verona.call "next"[%5 : !verona.unknown] ( : ) : !verona.unknown
-    br ^bb2
-  ^bb2:  // 2 preds: ^bb0, ^bb1
-    %7 = verona.call "has_value"[%5 : !verona.unknown] ( : ) : !verona.unknown
-    %8 = "verona.cast"(%7) : (!verona.unknown) -> i1
-    cond_br %8, ^bb3, ^bb4
-  ^bb3:  // pred: ^bb2
-    %9 = verona.call "apply"[%5 : !verona.unknown] ( : ) : !verona.unknown
-    %10 = verona.call "foo"[%9 : !verona.unknown] ( : ) : !verona.unknown
+    %6 = "verona.alloca"() : () -> !verona.unknown
+    %7 = "verona.store"(%5, %6) : (!verona.unknown, !verona.unknown) -> !verona.unknown
     br ^bb1
-  ^bb4:  // pred: ^bb2
+  ^bb1:  // 2 preds: ^bb0, ^bb2
+    %8 = "verona.load"(%6) : (!verona.unknown) -> !verona.unknown
+    %9 = verona.call "has_value"[%8 : !verona.unknown] ( : ) : !verona.unknown
+    %10 = "verona.cast"(%9) : (!verona.unknown) -> i1
+    cond_br %10, ^bb2, ^bb3
+  ^bb2:  // pred: ^bb1
+    %11 = "verona.load"(%6) : (!verona.unknown) -> !verona.unknown
+    %12 = verona.call "apply"[%11 : !verona.unknown] ( : ) : !verona.unknown
+    %13 = "verona.store"(%12, %3) : (!verona.unknown, !verona.class<"S32">) -> !verona.unknown
+    %14 = "verona.load"(%6) : (!verona.unknown) -> !verona.unknown
+    %15 = verona.call "next"[%14 : !verona.unknown] ( : ) : !verona.unknown
+    %16 = "verona.load"(%3) : (!verona.class<"S32">) -> !verona.unknown
+    %17 = verona.call "foo"[%16 : !verona.unknown] ( : ) : !verona.unknown
+    br ^bb1
+  ^bb3:  // pred: ^bb1
     return
   }
   func @f2(%arg0: !verona.class<"U64">) attributes {class = !verona.class<"$module">} {
@@ -31,38 +36,46 @@ module @"$module" {
     %3 = "verona.alloca"() : () -> !verona.class<"S32">
     %4 = "verona.store"(%2, %3) : (!verona.class<"int">, !verona.class<"S32">) -> !verona.unknown
     %5 = "verona.load"(%0) : (!verona.class<"U64">) -> !verona.unknown
-    br ^bb2
-  ^bb1:  // 2 preds: ^bb7, ^bb8
-    %6 = verona.call "next"[%5 : !verona.unknown] ( : ) : !verona.unknown
-    br ^bb2
-  ^bb2:  // 2 preds: ^bb0, ^bb1
-    %7 = verona.call "has_value"[%5 : !verona.unknown] ( : ) : !verona.unknown
-    %8 = "verona.cast"(%7) : (!verona.unknown) -> i1
-    cond_br %8, ^bb3, ^bb4
-  ^bb3:  // pred: ^bb2
-    %9 = verona.call "apply"[%5 : !verona.unknown] ( : ) : !verona.unknown
-    %10 = verona.call "foo"[%9 : !verona.unknown] ( : ) : !verona.unknown
-    %11 = "verona.constant(5)"() : () -> !verona.class<"int">
-    %12 = verona.call ">"[%9 : !verona.unknown] (%11 : !verona.class<"int">) : !verona.unknown
-    %13 = "verona.cast"(%12) : (!verona.unknown) -> i1
-    cond_br %13, ^bb5, ^bb6
-  ^bb4:  // 2 preds: ^bb2, ^bb5
+    %6 = "verona.alloca"() : () -> !verona.unknown
+    %7 = "verona.store"(%5, %6) : (!verona.unknown, !verona.unknown) -> !verona.unknown
+    br ^bb1
+  ^bb1:  // 3 preds: ^bb0, ^bb6, ^bb7
+    %8 = "verona.load"(%6) : (!verona.unknown) -> !verona.unknown
+    %9 = verona.call "has_value"[%8 : !verona.unknown] ( : ) : !verona.unknown
+    %10 = "verona.cast"(%9) : (!verona.unknown) -> i1
+    cond_br %10, ^bb2, ^bb3
+  ^bb2:  // pred: ^bb1
+    %11 = "verona.load"(%6) : (!verona.unknown) -> !verona.unknown
+    %12 = verona.call "apply"[%11 : !verona.unknown] ( : ) : !verona.unknown
+    %13 = "verona.store"(%12, %3) : (!verona.unknown, !verona.class<"S32">) -> !verona.unknown
+    %14 = "verona.load"(%6) : (!verona.unknown) -> !verona.unknown
+    %15 = verona.call "next"[%14 : !verona.unknown] ( : ) : !verona.unknown
+    %16 = "verona.load"(%3) : (!verona.class<"S32">) -> !verona.unknown
+    %17 = verona.call "foo"[%16 : !verona.unknown] ( : ) : !verona.unknown
+    %18 = "verona.load"(%3) : (!verona.class<"S32">) -> !verona.unknown
+    %19 = "verona.constant(5)"() : () -> !verona.class<"int">
+    %20 = verona.call ">"[%18 : !verona.unknown] (%19 : !verona.class<"int">) : !verona.unknown
+    %21 = "verona.cast"(%20) : (!verona.unknown) -> i1
+    cond_br %21, ^bb4, ^bb5
+  ^bb3:  // 2 preds: ^bb1, ^bb4
     return
-  ^bb5:  // pred: ^bb3
-    br ^bb4
-  ^bb6:  // pred: ^bb3
-    %14 = "verona.constant(2)"() : () -> !verona.class<"int">
-    %15 = verona.call "<"[%9 : !verona.unknown] (%14 : !verona.class<"int">) : !verona.unknown
-    %16 = "verona.cast"(%15) : (!verona.unknown) -> i1
-    cond_br %16, ^bb8, ^bb9
-  ^bb7:  // pred: ^bb10
+  ^bb4:  // pred: ^bb2
+    br ^bb3
+  ^bb5:  // pred: ^bb2
+    %22 = "verona.load"(%3) : (!verona.class<"S32">) -> !verona.unknown
+    %23 = "verona.constant(2)"() : () -> !verona.class<"int">
+    %24 = verona.call "<"[%22 : !verona.unknown] (%23 : !verona.class<"int">) : !verona.unknown
+    %25 = "verona.cast"(%24) : (!verona.unknown) -> i1
+    cond_br %25, ^bb7, ^bb8
+  ^bb6:  // pred: ^bb9
     br ^bb1
-  ^bb8:  // pred: ^bb6
+  ^bb7:  // pred: ^bb5
     br ^bb1
-  ^bb9:  // pred: ^bb6
-    %17 = verona.call "foo"[%9 : !verona.unknown] ( : ) : !verona.unknown
-    br ^bb10
-  ^bb10:  // pred: ^bb9
-    br ^bb7
+  ^bb8:  // pred: ^bb5
+    %26 = "verona.load"(%3) : (!verona.class<"S32">) -> !verona.unknown
+    %27 = verona.call "foo"[%26 : !verona.unknown] ( : ) : !verona.unknown
+    br ^bb9
+  ^bb9:  // pred: ^bb8
+    br ^bb6
   }
 }

--- a/testsuite/parse/ast-parse/for-sugar.verona
+++ b/testsuite/parse/ast-parse/for-sugar.verona
@@ -1,0 +1,35 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+// This for loop
+
+for_sum(x: List) : U32
+{
+  let sum: U32 = 0;
+  // `a` is a local variable in the loop's context
+  // `x.values()` is any expression that yields an iterator
+  for (let a in x.values()) {
+    sum = sum + a;
+  }
+  return sum;
+}
+
+// maps to this while loop
+
+while_sum(x: List) : U32
+{
+  let sum: U32 = 0;
+  // The iterator will have a hygienic name in the compiler
+  let iter = x.values();
+  // This is the while version of that for loop
+  while(iter.has_value())
+  {
+    // This has to be `a`, same as in the for loop above
+    let a = iter.apply();
+    // Increments the iterator (move this before apply?)
+    iter.next();
+    // This is the body of the for loop
+    sum = sum + a;
+  }
+  return sum;
+}

--- a/testsuite/parse/ast-parse/for-sugar/ast.txt
+++ b/testsuite/parse/ast-parse/for-sugar/ast.txt
@@ -1,0 +1,166 @@
++ classdef
+  - id ($module)
+  + typeparams
+  + oftype
+  + constraints
+  + typebody
+    + function
+      + qualifier
+      + funcname
+        - id (for_sum)
+      + sig
+        + typeparams
+        + params
+          + param/0
+            + namedparam
+              - id (x)
+              + oftype
+                + type
+                  + type_one/1
+                    + type_ref
+                      - id (List)
+              + initexpr
+        + oftype
+          + type
+            + type_one/1
+              + type_ref
+                - id (U32)
+        + constraints
+      + block
+        + seq
+          + assign
+            + let
+              - local (sum)
+              + oftype
+                + type
+                  + type_one/1
+                    + type_ref
+                      - id (U32)
+            - int (0)
+          + assign
+            + let
+              - local (iter$0)
+              + oftype
+            + invoke
+              + member
+                - localref (x)
+                - lookup (values)
+              + typeargs
+              + args
+          + while
+            + cond
+              + seq
+                + invoke
+                  + member
+                    - localref (iter$0)
+                    - lookup (has_value)
+                  + typeargs
+                  + args
+            + block
+              + seq
+                + assign
+                  + let
+                    - local (a)
+                    + oftype
+                  + invoke
+                    + member
+                      - localref (iter$0)
+                      - lookup (apply)
+                    + typeargs
+                    + args
+                + invoke
+                  + member
+                    - localref (iter$0)
+                    - lookup (next)
+                  + typeargs
+                  + args
+                + assign
+                  - localref (sum)
+                  + call
+                    - function (+)
+                    + typeargs
+                    - localref (sum)
+                    + args
+                      - localref (a)
+          + return
+            - localref (sum)
+    + function
+      + qualifier
+      + funcname
+        - id (while_sum)
+      + sig
+        + typeparams
+        + params
+          + param/0
+            + namedparam
+              - id (x)
+              + oftype
+                + type
+                  + type_one/1
+                    + type_ref
+                      - id (List)
+              + initexpr
+        + oftype
+          + type
+            + type_one/1
+              + type_ref
+                - id (U32)
+        + constraints
+      + block
+        + seq
+          + assign
+            + let
+              - local (sum)
+              + oftype
+                + type
+                  + type_one/1
+                    + type_ref
+                      - id (U32)
+            - int (0)
+          + assign
+            + let
+              - local (iter)
+              + oftype
+            + invoke
+              + member
+                - localref (x)
+                - lookup (values)
+              + typeargs
+              + args
+          + while
+            + cond
+              + seq
+                + invoke
+                  + member
+                    - localref (iter)
+                    - lookup (has_value)
+                  + typeargs
+                  + args
+            + block
+              + seq
+                + assign
+                  + let
+                    - local (a)
+                    + oftype
+                  + invoke
+                    + member
+                      - localref (iter)
+                      - lookup (apply)
+                    + typeargs
+                    + args
+                + invoke
+                  + member
+                    - localref (iter)
+                    - lookup (next)
+                  + typeargs
+                  + args
+                + assign
+                  - localref (sum)
+                  + call
+                    - function (+)
+                    + typeargs
+                    - localref (sum)
+                    + args
+                      - localref (a)
+          + return
+            - localref (sum)

--- a/testsuite/parse/ast-parse/hygienic-id.verona
+++ b/testsuite/parse/ast-parse/hygienic-id.verona
@@ -1,0 +1,38 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+// Test hygienic ids are module-wide
+
+for_sum(x: List) : U32
+{
+  let sum: U32 = 0;
+  // $0
+  for (let a in x.values()) {
+    sum = sum + a;
+  }
+  // $1
+  for (let a in x.values()) {
+    sum = sum + a;
+    // $2
+    for (let a in x.values()) {
+      sum = sum + a;
+    }
+  }
+  if (x.has_values())
+  {
+    // $3
+    for (let a in x.values()) {
+      sum = sum + a;
+    }
+  }
+  else
+  {
+    // $4
+    for (let a in x.values()) {
+      sum = sum + a;
+    }
+  }
+
+  return sum;
+}
+

--- a/testsuite/parse/ast-parse/hygienic-id/ast.txt
+++ b/testsuite/parse/ast-parse/hygienic-id/ast.txt
@@ -1,0 +1,280 @@
++ classdef
+  - id ($module)
+  + typeparams
+  + oftype
+  + constraints
+  + typebody
+    + function
+      + qualifier
+      + funcname
+        - id (for_sum)
+      + sig
+        + typeparams
+        + params
+          + param/0
+            + namedparam
+              - id (x)
+              + oftype
+                + type
+                  + type_one/1
+                    + type_ref
+                      - id (List)
+              + initexpr
+        + oftype
+          + type
+            + type_one/1
+              + type_ref
+                - id (U32)
+        + constraints
+      + block
+        + seq
+          + assign
+            + let
+              - local (sum)
+              + oftype
+                + type
+                  + type_one/1
+                    + type_ref
+                      - id (U32)
+            - int (0)
+          + assign
+            + let
+              - local (iter$0)
+              + oftype
+            + invoke
+              + member
+                - localref (x)
+                - lookup (values)
+              + typeargs
+              + args
+          + while
+            + cond
+              + seq
+                + invoke
+                  + member
+                    - localref (iter$0)
+                    - lookup (has_value)
+                  + typeargs
+                  + args
+            + block
+              + seq
+                + assign
+                  + let
+                    - local (a)
+                    + oftype
+                  + invoke
+                    + member
+                      - localref (iter$0)
+                      - lookup (apply)
+                    + typeargs
+                    + args
+                + invoke
+                  + member
+                    - localref (iter$0)
+                    - lookup (next)
+                  + typeargs
+                  + args
+                + assign
+                  - localref (sum)
+                  + call
+                    - function (+)
+                    + typeargs
+                    - localref (sum)
+                    + args
+                      - localref (a)
+          + assign
+            + let
+              - local (iter$1)
+              + oftype
+            + invoke
+              + member
+                - localref (x)
+                - lookup (values)
+              + typeargs
+              + args
+          + while
+            + cond
+              + seq
+                + invoke
+                  + member
+                    - localref (iter$1)
+                    - lookup (has_value)
+                  + typeargs
+                  + args
+            + block
+              + seq
+                + assign
+                  + let
+                    - local (a)
+                    + oftype
+                  + invoke
+                    + member
+                      - localref (iter$1)
+                      - lookup (apply)
+                    + typeargs
+                    + args
+                + invoke
+                  + member
+                    - localref (iter$1)
+                    - lookup (next)
+                  + typeargs
+                  + args
+                + assign
+                  - localref (sum)
+                  + call
+                    - function (+)
+                    + typeargs
+                    - localref (sum)
+                    + args
+                      - localref (a)
+                + assign
+                  + let
+                    - local (iter$2)
+                    + oftype
+                  + invoke
+                    + member
+                      - localref (x)
+                      - lookup (values)
+                    + typeargs
+                    + args
+                + while
+                  + cond
+                    + seq
+                      + invoke
+                        + member
+                          - localref (iter$2)
+                          - lookup (has_value)
+                        + typeargs
+                        + args
+                  + block
+                    + seq
+                      + assign
+                        + let
+                          - local (a)
+                          + oftype
+                        + invoke
+                          + member
+                            - localref (iter$2)
+                            - lookup (apply)
+                          + typeargs
+                          + args
+                      + invoke
+                        + member
+                          - localref (iter$2)
+                          - lookup (next)
+                        + typeargs
+                        + args
+                      + assign
+                        - localref (sum)
+                        + call
+                          - function (+)
+                          + typeargs
+                          - localref (sum)
+                          + args
+                            - localref (a)
+          + if
+            + cond
+              + seq
+                + invoke
+                  + member
+                    - localref (x)
+                    - lookup (has_values)
+                  + typeargs
+                  + args
+            + block
+              + seq
+                + assign
+                  + let
+                    - local (iter$3)
+                    + oftype
+                  + invoke
+                    + member
+                      - localref (x)
+                      - lookup (values)
+                    + typeargs
+                    + args
+                + while
+                  + cond
+                    + seq
+                      + invoke
+                        + member
+                          - localref (iter$3)
+                          - lookup (has_value)
+                        + typeargs
+                        + args
+                  + block
+                    + seq
+                      + assign
+                        + let
+                          - local (a)
+                          + oftype
+                        + invoke
+                          + member
+                            - localref (iter$3)
+                            - lookup (apply)
+                          + typeargs
+                          + args
+                      + invoke
+                        + member
+                          - localref (iter$3)
+                          - lookup (next)
+                        + typeargs
+                        + args
+                      + assign
+                        - localref (sum)
+                        + call
+                          - function (+)
+                          + typeargs
+                          - localref (sum)
+                          + args
+                            - localref (a)
+            + else
+              + block
+                + seq
+                  + assign
+                    + let
+                      - local (iter$4)
+                      + oftype
+                    + invoke
+                      + member
+                        - localref (x)
+                        - lookup (values)
+                      + typeargs
+                      + args
+                  + while
+                    + cond
+                      + seq
+                        + invoke
+                          + member
+                            - localref (iter$4)
+                            - lookup (has_value)
+                          + typeargs
+                          + args
+                    + block
+                      + seq
+                        + assign
+                          + let
+                            - local (a)
+                            + oftype
+                          + invoke
+                            + member
+                              - localref (iter$4)
+                              - lookup (apply)
+                            + typeargs
+                            + args
+                        + invoke
+                          + member
+                            - localref (iter$4)
+                            - lookup (next)
+                          + typeargs
+                          + args
+                        + assign
+                          - localref (sum)
+                          + call
+                            - function (+)
+                            + typeargs
+                            - localref (sum)
+                            + args
+                              - localref (a)
+          + return
+            - localref (sum)

--- a/testsuite/parse/ast-parse/loop/ast.txt
+++ b/testsuite/parse/ast-parse/loop/ast.txt
@@ -60,12 +60,36 @@
                     + block
                       + seq
                         - break (break)
-          + for
-            - localref (a)
-            + seq
-              - localref (x)
+          + assign
+            + let
+              - local (iter$0)
+              + oftype
+            - localref (x)
+          + while
+            + cond
+              + seq
+                + invoke
+                  + member
+                    - localref (iter$0)
+                    - lookup (has_value)
+                  + typeargs
+                  + args
             + block
               + seq
+                + assign
+                  - localref (a)
+                  + invoke
+                    + member
+                      - localref (iter$0)
+                      - lookup (apply)
+                    + typeargs
+                    + args
+                + invoke
+                  + member
+                    - localref (iter$0)
+                    - lookup (next)
+                  + typeargs
+                  + args
                 + call
                   - function (foo)
                   + typeargs


### PR DESCRIPTION
Adding desugar ast pass with one transformation for replacing `for`
loops as `while` loops with the appropriate API calls. The types used in
the `for` loop are supposed to implement the iterator interfaces that
have methods: has_value, apply and next.

Some helper functions are added to sugar.cc, as it's not clear they will
be useful outside the de-sugaring context, but others were added to
ast.cc, which are available to all passes.

Those are:
 * insert_before(child, before): insert `child` into `before`'s parent,
   before that node.
 * move(ast, child): move `child` to its new parent, `ast`.
 * move_before(child, before): same as insert_before, but move.
 * move_children(ast, old): move all children from `old` into `ast` and
   clear `old` children.

Also, added a hygienic ID per class scope, auto incrementing a number
and allowing a prefix to help read the ast tree. The counter should be
module-wide, but given that the module is a class, and it's stil unclear
how we'll handle it, I'm just finding the nearest `classdef`. This could
be improved later.

Removing MLIR's `parseForLoop` since the ast now de-sugars all for loops into
while loops. Adding test with rough equivalent to make sure the lowered
IR is identical.

Fixes #321