### PR TITLE
Fix false leak detection of muted cowns

### DIFF
--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -897,9 +897,12 @@ namespace verona::rt
       auto bp = bp_state.load(std::memory_order_relaxed);
       yield();
       auto p = (Priority)(bp & (uintptr_t)PriorityMask::All);
-      bp_state.compare_exchange_strong(bp, b | p, std::memory_order_acq_rel);
+      const auto success =
+        bp_state.compare_exchange_strong(bp, b | p, std::memory_order_acq_rel);
       yield();
       p = (Priority)(bp & (uintptr_t)PriorityMask::All);
+      assert(success || (p & PriorityMask::High));
+      UNUSED(success);
       return (p & PriorityMask::High);
     }
 

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -223,9 +223,9 @@ namespace verona::rt
         assert(p != Priority::Low);
 
         if (
-          (p & PriorityMask::High) || (state == ThreadState::PreScan) ||
-          (state == ThreadState::Scan) || (state == ThreadState::AllInScan))
-        { // Messages in this cown's queue must be scanned.
+          (p & PriorityMask::High) ||
+          (cown->get_epoch_mark() == EpochMark::SCANNED))
+        {
           cown->schedule();
           continue;
         }


### PR DESCRIPTION
This PR changes the condition to delay a muted cown. Previously, a cown would not be muted on a thread in the `Prescan`, `Scan`, or `AllInScan`. Now we only delay muting cowns that have the `SCANNED` epoch mark.

This PR also makes a change to rescan the mute map so long as a key in the map has been unmuted as a member of an invalid mute set. This is necessary to ensure that deadlock detection avoids false positives after an incremental scan.