### PR TITLE
Change the grammar of when to not use a tuple.

### DIFF
--- a/src/ast/grammar.peg
+++ b/src/ast/grammar.peg
@@ -50,7 +50,8 @@ expr <- blockexpr / atom+ blockexpr?
 
 blockexpr <- block / when / while / match / if / for / classdef / typedef
 block <- '{' seq '}'
-when <- 'when' tuple block
+when <- 'when' whenargs block
+whenargs <- '(' list(expr) ')'
 while <- 'while' cond block
 match <- 'match' cond '{' case* '}'
 if <- 'if' cond block else

--- a/testsuite/parse/ast-parse/when/ast.txt
+++ b/testsuite/parse/ast-parse/when/ast.txt
@@ -46,21 +46,23 @@
       + block
         + seq
           + when
-            - localref (a)
+            + whenargs
+              - localref (a)
             + block
               + seq
           + when
-            + tuple
+            + whenargs
               - localref (a)
               - localref (b)
             + block
               + seq
                 + when
-                  + call
-                    - function (bar)
-                    + typeargs
-                    + tuple
-                    + args
+                  + whenargs
+                    + call
+                      - function (bar)
+                      + typeargs
+                      + tuple
+                      + args
                   + block
                     + seq
                 + return


### PR DESCRIPTION
Using a tuple to store the list of arguments to a when block makes
handling it in the rest of the compiler a bit awkward. Singleton
tuples are elided, therefore when blocks with 1 arguments had a
different representation compared to those with more.

It may also help us in the future, when we want to expand the syntax
allowed in when blocks to allow binding the cown to a new name
(eg. `when (x <- E)`). Using a tuple here wouldn't make sense.