### PR TITLE
Remove unused assignment operator

### DIFF
--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -57,12 +57,6 @@ namespace mlir::verona
     {
       values.insert(values.begin(), range.begin(), range.end());
     }
-    /// Assignment operator for ReturnValue.
-    ReturnValue& operator=(ReturnValue& other)
-    {
-      values = other.values;
-      return *this;
-    }
     /// Assignment operator for mlir::Value.
     ReturnValue& operator=(mlir::Value& value)
     {


### PR DESCRIPTION
This is the last warning in the Verona code:
 * warning: definition of implicit copy constructor for 'ReturnValue'
   is deprecated because it has a user-declared copy assignment operator

All other warnings in the build are in external components.