### PR TITLE
Move from alloca/load/store to block arguments

### DIFF
--- a/src/mlir/ast-utils.h
+++ b/src/mlir/ast-utils.h
@@ -386,7 +386,7 @@ namespace mlir::verona
       return getTokenValue(findNode(ast, NodeKind::Localref));
     }
 
-    /// Return true if node is a variable definition
+    /// Get the assignment variable name (new local or localref)
     static llvm::StringRef getLocalName(::ast::Ast ast)
     {
       // Local variables can be new 'local' or existing 'localref'
@@ -398,13 +398,15 @@ namespace mlir::verona
       return getTokenValue(findNode(ast, NodeKind::Local));
     }
 
-    /// Return true if node is an ID (func, var, type names)
+    /// Get the token value of the ID (func, var, type names, localref, etc.)
     static llvm::StringRef getID(::ast::Ast ast)
     {
       if (isAny(ast, {NodeKind::Call, NodeKind::StaticCall}))
         return getTokenValue(findNode(ast, NodeKind::Function));
       if (isMember(ast))
         return getTokenValue(findNode(ast, NodeKind::Lookup));
+      if (isLet(ast))
+        return getTokenValue(findNode(ast, NodeKind::Local));
       if (isQualType(ast))
         return getTokenValue(findNode(ast, NodeKind::Typeref));
       if (isInvoke(ast))

--- a/src/mlir/ast-utils.h
+++ b/src/mlir/ast-utils.h
@@ -357,6 +357,16 @@ namespace mlir::verona
       nodes.insert(nodes.end(), ast->nodes.begin(), ast->nodes.end());
     }
 
+    /// Return the sequence of a block ast, in case we don't want to
+    /// push to the variable scope (when it needs to exist for longer).
+    /// If not a block, just return the ast.
+    static ::ast::Ast skipBlock(::ast::Ast ast)
+    {
+      if (isBlock(ast))
+        return findNode(ast, NodeKind::Seq);
+      return ast;
+    }
+
     // ================================================= Value Helpers
     /// Get the string value of a token
     static llvm::StringRef getTokenValue(::ast::Ast ast)
@@ -662,7 +672,7 @@ namespace mlir::verona
     }
 
     // ================================================= Condition Helpers
-    /// Return the condition from an if statement
+    /// Return true if the 'if' node has an else block
     static bool hasElse(::ast::Ast ast)
     {
       // Else nodes always exist inside `if` nodes, but if there was no `else`
@@ -671,7 +681,7 @@ namespace mlir::verona
         hasSubs(findNode(ast, NodeKind::Else));
     }
 
-    /// Return the block from an if statement
+    /// Return the condition from an if statement
     static ::ast::Ast getCond(::ast::Ast ast)
     {
       // These are the nodes that could have conditions as subnodes
@@ -681,7 +691,7 @@ namespace mlir::verona
       return findNode(cond, NodeKind::Seq);
     }
 
-    /// Return true if the 'if' node has an else block
+    /// Return the if block from an if statement
     static ::ast::Ast getIfBlock(::ast::Ast ast)
     {
       assert(isIf(ast) && "Bad node");

--- a/src/mlir/ast-utils.h
+++ b/src/mlir/ast-utils.h
@@ -91,7 +91,6 @@ namespace mlir::verona
       If = peg::str2tag("if"), // = 3567
       Else = peg::str2tag("else"), // = 3742303
       While = peg::str2tag("while"), // = 140358143
-      For = peg::str2tag("for"), // = 112155
       Continue = peg::str2tag("continue"), // = 2929012833
       Break = peg::str2tag("break"), // = 117842911
       New = peg::str2tag("new"), // = 120796
@@ -293,22 +292,10 @@ namespace mlir::verona
       return isA(ast, NodeKind::Else);
     }
 
-    /// Return true if node is a while loop
-    static bool isWhile(::ast::Ast ast)
-    {
-      return isA(ast, NodeKind::While);
-    }
-
-    /// Return true if node is a for loop
-    static bool isFor(::ast::Ast ast)
-    {
-      return isA(ast, NodeKind::For);
-    }
-
     /// Return true if node is any kind of loop
     static bool isLoop(::ast::Ast ast)
     {
-      return isWhile(ast) || isFor(ast);
+      return isA(ast, NodeKind::While);
     }
 
     /// Return true if node is a loop continue
@@ -716,20 +703,6 @@ namespace mlir::verona
     {
       assert(isLoop(ast) && "Bad node");
       return findNode(ast, NodeKind::Block);
-    }
-
-    /// Return the sequence generator from a `for` loop
-    static ::ast::Ast getLoopSeq(::ast::Ast ast)
-    {
-      assert(isFor(ast) && "Bad node");
-      return findNode(findNode(ast, NodeKind::Seq), NodeKind::Localref);
-    }
-
-    /// Return the induction variable from a `for` loop
-    static ::ast::Ast getLoopInd(::ast::Ast ast)
-    {
-      assert(isFor(ast) && "Bad node");
-      return findNode(ast, NodeKind::Localref);
     }
   };
 }

--- a/src/mlir/dialect/VeronaTypes.cc
+++ b/src/mlir/dialect/VeronaTypes.cc
@@ -397,7 +397,11 @@ namespace mlir::verona
 
   std::pair<Type, Type> lookupFieldType(Type origin, StringRef name)
   {
+    MLIRContext* ctx = origin.getContext();
     return TypeSwitch<Type, std::pair<Type, Type>>(origin)
+      .Case<UnknownType>([&ctx](Type origin) -> std::pair<Type, Type> {
+        return {UnknownType::get(ctx), UnknownType::get(ctx)};
+      })
       .Case<MeetType>(
         [&](MeetType origin) { return lookupMeetFieldType(origin, name); })
       .Case<JoinType>(

--- a/src/mlir/free-vars.h
+++ b/src/mlir/free-vars.h
@@ -1,0 +1,206 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "ast-utils.h"
+#include "ast/cli.h"
+#include "ast/files.h"
+#include "ast/parser.h"
+#include "ast/path.h"
+#include "ast/sym.h"
+#include "error.h"
+
+#include <map>
+#include <set>
+#include <string>
+
+// Only for debug, remove later
+#include <iostream>
+
+namespace mlir::verona
+{
+  /**
+   * Free Variable Analysis: scans nodes for new definitions, reads and writes
+   * to variables to identify which blocks or regions will need for return
+   * values and arguments.
+   *
+   * The algorithm is recursive, using an intermediate block information to
+   * allow collection of read/write/def variables (by name) and annotate the
+   * nodes that define new basic blocks or regions to help the generator
+   * define arguments and return values without having to back-track.
+   *
+   * Those names will only be associated with SSA values once lowering start,
+   * and can be used directly to associate the arguments in each block.
+   */
+
+  class FreeVariableAnalysis
+  {
+    using Vars = std::set<llvm::StringRef>;
+
+    /// Simple struct with reads, writes and defs.
+    struct BlockInfo
+    {
+      Vars read;
+      Vars write;
+      Vars def;
+    };
+
+    /// Simple struct to hold args and rets for each region.
+    struct ArgRet
+    {
+      Vars args; // read minus def
+      Vars rets; // write minus def
+    };
+
+  private:
+    /// The map that will contain all arguments and returns, by name.
+    /// Verona forbids shadowing, and the context of this analysis is within
+    /// a function, so there is no context to worry about and no risk of
+    /// having two different variables with the same name.
+    std::map<::ast::Ast, ArgRet> freeVars;
+
+    /// Cache of the function being evaluated (for dumping purposes)
+    ::ast::Ast function;
+
+    /// Merge variables from one block onto another.
+    void mergeInfo(BlockInfo& base, BlockInfo&& sub)
+    {
+      base.read.insert(sub.read.begin(), sub.read.end());
+      base.write.insert(sub.write.begin(), sub.write.end());
+      base.def.insert(sub.def.begin(), sub.def.end());
+    }
+
+    /// Get arguments and return values from read/write/def.
+    ArgRet getArgsRets(BlockInfo& block)
+    {
+      ArgRet ar;
+      ar.args = block.read;
+      ar.rets = block.write;
+      // TODO: this is inefficient but will do for now
+      for (auto def : block.def)
+      {
+        ar.args.erase(def);
+        ar.rets.erase(def);
+      }
+      return ar;
+    }
+
+    /// Return true if the node is a block (and needs arguments, rets).
+    bool isBlockNode(::ast::Ast node)
+    {
+      switch (node->tag)
+      {
+        case AST::NodeKind::If:
+        case AST::NodeKind::While:
+        case AST::NodeKind::For:
+          return true;
+      }
+      return false;
+    }
+
+    /// Recursively run on a node (and its sub-nodes).
+    BlockInfo runOnNode(::ast::Ast node)
+    {
+      BlockInfo info;
+
+      // First, descend into all sub-nodes and take their info
+      std::vector<::ast::Ast> nodes;
+      AST::getSubNodes(nodes, node);
+      for (auto sub : nodes)
+      {
+        mergeInfo(info, runOnNode(sub));
+      }
+
+      // Then see if there's any info this node can give
+      // TODO: This may be incomplete.
+      switch (node->tag)
+      {
+        // Nodes that define new variables
+        case AST::NodeKind::NamedParam:
+        case AST::NodeKind::Let:
+        {
+          // Defines a variable with the name in the ID node.
+          // Reads from sub-expressions have already been added to the
+          // list by recursion and merge above.
+          info.def.insert(AST::getID(node));
+          break;
+        }
+        // Nodes that assign to variables
+        case AST::NodeKind::Assign:
+        {
+          // Writes to the variable in the first node.
+          // Reads from sub-expressions have already been added to the
+          // list by recursion and merge above.
+          info.write.insert(AST::getLocalName(node->nodes[0]));
+          break;
+        }
+        // Nodes that access existing variables.
+        case AST::NodeKind::Localref:
+        {
+          // All reads are localref at some (nested) level, and since we're
+          // recursing earlier (and merging the data) we don't need to search
+          // for them here.
+          info.read.insert(AST::getLocalName(node));
+          break;
+        }
+      }
+
+      // Finally, update the map if need args/rets.
+      if (isBlockNode(node))
+        freeVars.insert({node, getArgsRets(info)});
+
+      return info;
+    }
+
+    /// Dump an ArgRet structure.
+    void dump(ArgRet& ar)
+    {
+      std::cerr << "    Args:";
+      for (auto var : ar.args)
+        std::cerr << "  " << var.str();
+      std::cerr << std::endl;
+      std::cerr << "    Rets:";
+      for (auto var : ar.rets)
+        std::cerr << "  " << var.str();
+      std::cerr << std::endl;
+    }
+
+  public:
+    /// Run the analysis on a function, returns a map with all the nodes that
+    /// create, use or consume values.
+    void runOnFunction(::ast::Ast func)
+    {
+      assert(AST::isFunction(func) && "Bad node");
+      // Cache for debug purposes, get rid once we're happy with the impl.
+      function = func;
+      // Clear any previous data and scan the whole function.
+      freeVars.clear();
+      runOnNode(func);
+    }
+
+    /// Return the ArgsRet information from an Ast node
+    const ArgRet& getArgRet(::ast::Ast node)
+    {
+      assert(!freeVars.empty() && "Not in a function");
+      auto argRet = freeVars.find(node);
+      assert(argRet != freeVars.end() && "Node doesn't have associated ArgRet");
+      return argRet->second;
+    }
+
+    /// Dumps the whole map, per function.
+    void dump()
+    {
+      auto funcName = AST::getFunctionName(function);
+      std::cerr << "Free Var Map: " << funcName.str() << std::endl;
+      for (auto pair : freeVars)
+      {
+        auto node = pair.first;
+        std::cerr << "Node: " << node->name << std::endl;
+        auto ar = pair.second;
+        dump(ar);
+      }
+      std::cerr << std::endl;
+    }
+  };
+}

--- a/src/mlir/free-vars.h
+++ b/src/mlir/free-vars.h
@@ -187,6 +187,19 @@ namespace mlir::verona
       return argRet->second;
     }
 
+    /// Append returns to a list, for building basic-block arguments.
+    /// TODO: This may be all we need from this entire class, so maybe we
+    /// could ignore reads and the sets above.
+    /// T must be a list<StringRef> type with push_back.
+    template <class T>
+    void appendReturnsTo(::ast::Ast node, T& list)
+    {
+      auto argRet = freeVars.find(node);
+      assert(argRet != freeVars.end() && "Node doesn't have associated ArgRet");
+      for (auto ret : argRet->second.rets)
+        list.push_back(ret);
+    }
+
     /// Dumps the whole map, per function.
     void dump()
     {

--- a/src/mlir/free-vars.h
+++ b/src/mlir/free-vars.h
@@ -93,7 +93,6 @@ namespace mlir::verona
       {
         case AST::NodeKind::If:
         case AST::NodeKind::While:
-        case AST::NodeKind::For:
           return true;
       }
       return false;

--- a/src/mlir/free-vars.h
+++ b/src/mlir/free-vars.h
@@ -11,9 +11,9 @@
 #include "ast/sym.h"
 #include "error.h"
 
-#include <map>
 #include <set>
 #include <string>
+#include <vector>
 
 // Only for debug, remove later
 #include <iostream>
@@ -41,8 +41,10 @@ namespace mlir::verona
 
   class FreeVariableAnalysis
   {
-    /// Simple struct with writes and defs.
     using Vars = std::set<llvm::StringRef>;
+    using Args = std::vector<llvm::StringRef>;
+
+    /// Simple struct with writes and defs.
     struct BlockInfo
     {
       Vars write;
@@ -141,15 +143,13 @@ namespace mlir::verona
       runOnNode(func);
     }
 
-    /// Append returns to a list, for building basic-block arguments.
-    /// T must be a list<StringRef> type with push_back.
-    template <class T>
-    void appendArguments(::ast::Ast node, T& list)
+    /// Returns the arguments list of (cond/loop) nodes.
+    Args getArguments(::ast::Ast node)
     {
-      auto args = freeVars.find(node);
-      assert(args != freeVars.end() && "Node doesn't have associated Vars");
-      for (auto ret : args->second)
-        list.push_back(ret);
+      auto vars = freeVars.find(node);
+      assert(vars != freeVars.end() && "Node doesn't have associated Vars");
+      Args args(vars->second.begin(), vars->second.end());
+      return args;
     }
   };
 }

--- a/src/mlir/generator.cc
+++ b/src/mlir/generator.cc
@@ -638,7 +638,7 @@ namespace mlir::verona
 
   llvm::Expected<ReturnValue> Generator::parseWhileLoop(const ::ast::Ast& ast)
   {
-    assert(AST::isWhile(ast) && "Bad node");
+    assert(AST::isLoop(ast) && "Bad node");
 
     // Create the head basic-block, which will check the condition
     // and dispatch the loop to the body block or exit.

--- a/src/mlir/generator.cc
+++ b/src/mlir/generator.cc
@@ -661,10 +661,7 @@ namespace mlir::verona
     // Pop the variable scope, to update the values from the exit block's
     // arguments (PHI nodes)
     symbolTable.popScope();
-    for (auto ret_val : llvm::zip(args, exitBB->getArguments()))
-    {
-      symbolTable.update(std::get<0>(ret_val), std::get<1>(ret_val));
-    }
+    updateSymbolTable(args, exitBB->getArguments());
 
     // No values to return from lexical blocks.
     return ReturnValue();
@@ -703,8 +700,7 @@ namespace mlir::verona
 
     // Update symbol table with basic block argument
     builder.setInsertionPointToEnd(headBB);
-    for (auto ret_val : llvm::zip(args, headBB->getArguments()))
-      symbolTable.update(std::get<0>(ret_val), std::get<1>(ret_val));
+    updateSymbolTable(args, headBB->getArguments());
 
     // First node is a sequence of conditions
     // lower in the head basic block, with the conditional branch.
@@ -728,8 +724,7 @@ namespace mlir::verona
 
     // Update symbol table with basic block argument
     builder.setInsertionPointToEnd(bodyBB);
-    for (auto ret_val : llvm::zip(args, bodyBB->getArguments()))
-      symbolTable.update(std::get<0>(ret_val), std::get<1>(ret_val));
+    updateSymbolTable(args, bodyBB->getArguments());
 
     // Loop body, branch back to head node which will decide exit criteria
     auto bodyNode = AST::getLoopBlock(ast);
@@ -754,8 +749,7 @@ namespace mlir::verona
     // Move to exit block, where the remaining instructions will be lowered
     // and rerurn the updated values from the exitBB's arguments.
     builder.setInsertionPointToEnd(exitBB);
-    for (auto ret_val : llvm::zip(args, exitBB->getArguments()))
-      symbolTable.update(std::get<0>(ret_val), std::get<1>(ret_val));
+    updateSymbolTable(args, exitBB->getArguments());
 
     // No values to return from lexical blocks.
     return ReturnValue();
@@ -943,7 +937,8 @@ namespace mlir::verona
   }
 
   void Generator::updateSymbolTable(
-    llvm::ArrayRef<llvm::StringRef> vars, llvm::ArrayRef<mlir::Value> vals)
+    llvm::ArrayRef<llvm::StringRef> vars,
+    llvm::ArrayRef<mlir::BlockArgument> vals)
   {
     for (auto ret_val : llvm::zip(vars, vals))
       symbolTable.update(std::get<0>(ret_val), std::get<1>(ret_val));

--- a/src/mlir/generator.cc
+++ b/src/mlir/generator.cc
@@ -5,6 +5,7 @@
 
 #include "ast-utils.h"
 #include "dialect/VeronaDialect.h"
+#include "free-vars.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Dialect.h"
@@ -152,6 +153,12 @@ namespace mlir::verona
   llvm::Expected<mlir::FuncOp> Generator::parseFunction(const ::ast::Ast& ast)
   {
     assert(AST::isFunction(ast) && "Bad node");
+
+    // Runs the free variable analysis on the function to help build all
+    // arguments and return values of each basic block inside it
+    freeVars.runOnFunction(ast);
+    // TODO: This is temporary!
+    freeVars.dump();
 
     // Parse 'where' clause
     TypeScopeT alias_scope(typeTable);

--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -119,7 +119,6 @@ namespace mlir::verona
     mlir::Block* tail;
     std::vector<llvm::StringRef> args;
   };
-  using LoopFCStack = std::stack<LoopFlowControl>;
 
   /**
    * MLIR Generator.
@@ -170,7 +169,7 @@ namespace mlir::verona
     /// Symbol tables for classes.
     TypeTableT typeTable;
     /// Nested reference for head/exit blocks and args in loops.
-    LoopFCStack loopScope;
+    std::stack<LoopFlowControl> loopScope;
 
     /// Unknown types, will be defined during type inference.
     mlir::Type unkTy;
@@ -215,11 +214,9 @@ namespace mlir::verona
     /// Parses function calls and native operations.
     llvm::Expected<ReturnValue> parseCall(const ::ast::Ast& ast);
     /// Parses an if/else block.
-    llvm::Expected<ReturnValue>
-    parseCondition(const ::ast::Ast& ast, llvm::ArrayRef<llvm::StringRef> args);
+    llvm::Expected<ReturnValue> parseCondition(const ::ast::Ast& ast);
     /// Parses a 'while' loop block.
-    llvm::Expected<ReturnValue>
-    parseWhileLoop(const ::ast::Ast& ast, llvm::ArrayRef<llvm::StringRef> args);
+    llvm::Expected<ReturnValue> parseWhileLoop(const ::ast::Ast& ast);
     /// Parses a 'for' loop block.
     llvm::Expected<ReturnValue> parseForLoop(const ::ast::Ast& ast);
     /// Parses a 'continue' statement.
@@ -258,7 +255,8 @@ namespace mlir::verona
     /// Update symbol table with new values (to build PHI nodes)
     void updateSymbolTable(
       llvm::ArrayRef<llvm::StringRef> vars, llvm::ArrayRef<mlir::Value> vals);
-    /// Create a basic-block argument list from a variable name list
+    /// Create a basic-block argument list from a variable name list,
+    /// clearing the list before inserting the values.
     template<class T>
     void generateBBArgList(
       mlir::Location loc, llvm::ArrayRef<llvm::StringRef> names, T& vars);

--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -254,7 +254,8 @@ namespace mlir::verona
       llvm::ArrayRef<mlir::Type> retTy);
     /// Update symbol table with new values (to build PHI nodes)
     void updateSymbolTable(
-      llvm::ArrayRef<llvm::StringRef> vars, llvm::ArrayRef<mlir::Value> vals);
+      llvm::ArrayRef<llvm::StringRef> vars,
+      llvm::ArrayRef<mlir::BlockArgument> vals);
     /// Create a basic-block argument list from a variable name list,
     /// clearing the list before inserting the values.
     template<class T>

--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -7,6 +7,7 @@
 #include "dialect/VeronaOps.h"
 #include "dialect/VeronaTypes.h"
 #include "error.h"
+#include "free-vars.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Function.h"
 #include "mlir/IR/MLIRContext.h"
@@ -130,6 +131,9 @@ namespace mlir::verona
 
     /// MLIR context. This is owned by the caller of Generator::lower.
     mlir::MLIRContext* context;
+
+    /// Free variable analysis
+    FreeVariableAnalysis freeVars;
 
     /// MLIR builder.
     mlir::OpBuilder builder;

--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -205,8 +205,10 @@ namespace mlir::verona
     /// individual type.
     llvm::Expected<ReturnValue> parseNode(const ::ast::Ast& ast);
 
-    /// Parses a block (multiple statements), return last value.
+    /// Parses a block (multiple statements), return last value, add scope.
     llvm::Expected<ReturnValue> parseBlock(const ::ast::Ast& ast);
+    /// Parses a seq (multiple statements), return last value.
+    llvm::Expected<ReturnValue> parseSeq(const ::ast::Ast& ast);
     /// Parses a value (constants, variables).
     llvm::Expected<ReturnValue> parseValue(const ::ast::Ast& ast);
     /// Parses an assign statement.

--- a/testsuite/mlir/mlir-parse/block-args.verona
+++ b/testsuite/mlir/mlir-parse/block-args.verona
@@ -1,0 +1,72 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+foo(a: U64 & iso, b: U64 & imm): U64
+{
+  // Variables so far: a,b,c
+  let c = a + b;
+
+  // New region will consume a,b,c and return a,c
+  while (c < 100)
+  {
+    // New variables: d,e using a,b
+    let d = a - b;
+    let e = c;
+
+    // New block will consume a,b,d,e and return a,e
+    if (a > b)
+    {
+      // New variable: f using b,d
+      let f = b + d;
+
+      // New region will consume e,f and return e
+      while (f < 10)
+      {
+        // Consume f and return e
+        e = e + f;
+      }
+
+      // Consume e and return a
+      a = a + e;
+    }
+
+    // New block will consume c and return c
+    else
+    {
+      c = 42;
+    }
+  }
+
+  // Test loop break, reads x, a; may write to x;
+  let x = 21;
+  // Condition that doesn't depend on x, so this block shouldn't have it as arg
+  while (a > 0)
+  {
+    // Consumes a, b and return x
+    if (a == b)
+    {
+      x = 20;
+      break;
+    }
+    // Consumes x from either while or if, no return
+    let innerX = x;
+  }
+
+  // Test loop continue, reads y, a; may write to y;
+  let y = 30;
+  while (y > 0)
+  {
+    if (a == b)
+    {
+      y = 40;
+      continue;
+    }
+    let innerY = y;
+  }
+
+  // Return a,b,c,x,y using the new values (from the while region)
+  a = a + x;
+  b = b + y;
+  let ret = a + b;
+  return ret + c;
+}

--- a/testsuite/mlir/mlir-parse/block-args/mlir.txt
+++ b/testsuite/mlir/mlir-parse/block-args/mlir.txt
@@ -22,60 +22,61 @@ module @"$module" {
     br ^bb7(%8 : !verona.unknown)
   ^bb5:  // pred: ^bb2
     %17 = "verona.constant(42)"() : () -> !verona.class<"int">
-    br ^bb6(%7, %8, %8 : !verona.unknown, !verona.unknown, !verona.unknown)
-  ^bb6(%18: !verona.unknown, %19: !verona.unknown, %20: !verona.unknown):  // 2 preds: ^bb5, ^bb9
-    br ^bb1(%7, %8 : !verona.unknown, !verona.unknown)
-  ^bb7(%21: !verona.unknown):  // 2 preds: ^bb4, ^bb8
-    %22 = "verona.constant(10)"() : () -> !verona.class<"int">
-    %23 = verona.call "<"[%16 : !verona.unknown] (%22 : !verona.class<"int">) : !verona.unknown
-    %24 = "verona.cast"(%23) : (!verona.unknown) -> i1
-    cond_br %24, ^bb8(%21 : !verona.unknown), ^bb9(%21 : !verona.unknown)
-  ^bb8(%25: !verona.unknown):  // pred: ^bb7
-    %26 = verona.call "+"[%25 : !verona.unknown] (%16 : !verona.unknown) : !verona.unknown
-    br ^bb7(%25 : !verona.unknown)
-  ^bb9(%27: !verona.unknown):  // pred: ^bb7
-    %28 = verona.call "+"[%7 : !verona.unknown] (%27 : !verona.unknown) : !verona.unknown
-    br ^bb6(%7, %8, %8 : !verona.unknown, !verona.unknown, !verona.unknown)
-  ^bb10(%29: !verona.unknown):  // 2 preds: ^bb3, ^bb14
-    %30 = "verona.constant(0)"() : () -> !verona.class<"int">
-    %31 = verona.call ">"[%12 : !verona.unknown] (%30 : !verona.class<"int">) : !verona.unknown
-    %32 = "verona.cast"(%31) : (!verona.unknown) -> i1
-    cond_br %32, ^bb11(%29 : !verona.unknown), ^bb12(%29 : !verona.unknown)
-  ^bb11(%33: !verona.unknown):  // pred: ^bb10
-    %34 = verona.call "=="[%12 : !verona.unknown] (%arg1 : !verona.meet<class<"U64">, imm>) : !verona.unknown
-    %35 = "verona.cast"(%34) : (!verona.unknown) -> i1
-    cond_br %35, ^bb13, ^bb14(%33 : !verona.unknown)
-  ^bb12(%36: !verona.unknown):  // 2 preds: ^bb10, ^bb13
-    %37 = "verona.constant(30)"() : () -> !verona.class<"int">
-    %38 = "verona.cast"(%37) : (!verona.class<"int">) -> !verona.unknown
-    br ^bb15(%38 : !verona.unknown)
+    %18 = "verona.cast"(%17) : (!verona.class<"int">) -> !verona.unknown
+    br ^bb6(%7, %18, %8 : !verona.unknown, !verona.unknown, !verona.unknown)
+  ^bb6(%19: !verona.unknown, %20: !verona.unknown, %21: !verona.unknown):  // 2 preds: ^bb5, ^bb9
+    br ^bb1(%19, %20 : !verona.unknown, !verona.unknown)
+  ^bb7(%22: !verona.unknown):  // 2 preds: ^bb4, ^bb8
+    %23 = "verona.constant(10)"() : () -> !verona.class<"int">
+    %24 = verona.call "<"[%16 : !verona.unknown] (%23 : !verona.class<"int">) : !verona.unknown
+    %25 = "verona.cast"(%24) : (!verona.unknown) -> i1
+    cond_br %25, ^bb8(%22 : !verona.unknown), ^bb9(%22 : !verona.unknown)
+  ^bb8(%26: !verona.unknown):  // pred: ^bb7
+    %27 = verona.call "+"[%26 : !verona.unknown] (%16 : !verona.unknown) : !verona.unknown
+    br ^bb7(%27 : !verona.unknown)
+  ^bb9(%28: !verona.unknown):  // pred: ^bb7
+    %29 = verona.call "+"[%7 : !verona.unknown] (%28 : !verona.unknown) : !verona.unknown
+    br ^bb6(%29, %8, %28 : !verona.unknown, !verona.unknown, !verona.unknown)
+  ^bb10(%30: !verona.unknown):  // 2 preds: ^bb3, ^bb14
+    %31 = "verona.constant(0)"() : () -> !verona.class<"int">
+    %32 = verona.call ">"[%12 : !verona.unknown] (%31 : !verona.class<"int">) : !verona.unknown
+    %33 = "verona.cast"(%32) : (!verona.unknown) -> i1
+    cond_br %33, ^bb11(%30 : !verona.unknown), ^bb12(%30 : !verona.unknown)
+  ^bb11(%34: !verona.unknown):  // pred: ^bb10
+    %35 = verona.call "=="[%12 : !verona.unknown] (%arg1 : !verona.meet<class<"U64">, imm>) : !verona.unknown
+    %36 = "verona.cast"(%35) : (!verona.unknown) -> i1
+    cond_br %36, ^bb13, ^bb14(%34 : !verona.unknown)
+  ^bb12(%37: !verona.unknown):  // 2 preds: ^bb10, ^bb13
+    %38 = "verona.constant(30)"() : () -> !verona.class<"int">
+    %39 = "verona.cast"(%38) : (!verona.class<"int">) -> !verona.unknown
+    br ^bb15(%39 : !verona.unknown)
   ^bb13:  // pred: ^bb11
-    %39 = "verona.constant(20)"() : () -> !verona.class<"int">
-    %40 = "verona.cast"(%39) : (!verona.class<"int">) -> !verona.unknown
-    br ^bb12(%40 : !verona.unknown)
-  ^bb14(%41: !verona.unknown):  // pred: ^bb11
-    br ^bb10(%33 : !verona.unknown)
-  ^bb15(%42: !verona.unknown):  // 3 preds: ^bb12, ^bb18, ^bb19
-    %43 = "verona.constant(0)"() : () -> !verona.class<"int">
-    %44 = verona.call ">"[%42 : !verona.unknown] (%43 : !verona.class<"int">) : !verona.unknown
-    %45 = "verona.cast"(%44) : (!verona.unknown) -> i1
-    cond_br %45, ^bb16(%42 : !verona.unknown), ^bb17(%42 : !verona.unknown)
-  ^bb16(%46: !verona.unknown):  // pred: ^bb15
-    %47 = verona.call "=="[%12 : !verona.unknown] (%arg1 : !verona.meet<class<"U64">, imm>) : !verona.unknown
-    %48 = "verona.cast"(%47) : (!verona.unknown) -> i1
-    cond_br %48, ^bb18, ^bb19(%46 : !verona.unknown)
-  ^bb17(%49: !verona.unknown):  // pred: ^bb15
-    %50 = verona.call "+"[%12 : !verona.unknown] (%36 : !verona.unknown) : !verona.unknown
-    %51 = verona.call "+"[%arg1 : !verona.meet<class<"U64">, imm>] (%49 : !verona.unknown) : !verona.unknown
-    %52 = verona.call "+"[%50 : !verona.unknown] (%51 : !verona.unknown) : !verona.unknown
-    %53 = verona.call "+"[%52 : !verona.unknown] (%13 : !verona.unknown) : !verona.unknown
-    %54 = "verona.cast"(%53) : (!verona.unknown) -> !verona.class<"U64">
-    return %54 : !verona.class<"U64">
+    %40 = "verona.constant(20)"() : () -> !verona.class<"int">
+    %41 = "verona.cast"(%40) : (!verona.class<"int">) -> !verona.unknown
+    br ^bb12(%41 : !verona.unknown)
+  ^bb14(%42: !verona.unknown):  // pred: ^bb11
+    br ^bb10(%42 : !verona.unknown)
+  ^bb15(%43: !verona.unknown):  // 3 preds: ^bb12, ^bb18, ^bb19
+    %44 = "verona.constant(0)"() : () -> !verona.class<"int">
+    %45 = verona.call ">"[%43 : !verona.unknown] (%44 : !verona.class<"int">) : !verona.unknown
+    %46 = "verona.cast"(%45) : (!verona.unknown) -> i1
+    cond_br %46, ^bb16(%43 : !verona.unknown), ^bb17(%43 : !verona.unknown)
+  ^bb16(%47: !verona.unknown):  // pred: ^bb15
+    %48 = verona.call "=="[%12 : !verona.unknown] (%arg1 : !verona.meet<class<"U64">, imm>) : !verona.unknown
+    %49 = "verona.cast"(%48) : (!verona.unknown) -> i1
+    cond_br %49, ^bb18, ^bb19(%47 : !verona.unknown)
+  ^bb17(%50: !verona.unknown):  // pred: ^bb15
+    %51 = verona.call "+"[%12 : !verona.unknown] (%37 : !verona.unknown) : !verona.unknown
+    %52 = verona.call "+"[%arg1 : !verona.meet<class<"U64">, imm>] (%50 : !verona.unknown) : !verona.unknown
+    %53 = verona.call "+"[%51 : !verona.unknown] (%52 : !verona.unknown) : !verona.unknown
+    %54 = verona.call "+"[%53 : !verona.unknown] (%13 : !verona.unknown) : !verona.unknown
+    %55 = "verona.cast"(%54) : (!verona.unknown) -> !verona.class<"U64">
+    return %55 : !verona.class<"U64">
   ^bb18:  // pred: ^bb16
-    %55 = "verona.constant(40)"() : () -> !verona.class<"int">
-    %56 = "verona.cast"(%55) : (!verona.class<"int">) -> !verona.unknown
-    br ^bb15(%56 : !verona.unknown)
-  ^bb19(%57: !verona.unknown):  // pred: ^bb16
-    br ^bb15(%46 : !verona.unknown)
+    %56 = "verona.constant(40)"() : () -> !verona.class<"int">
+    %57 = "verona.cast"(%56) : (!verona.class<"int">) -> !verona.unknown
+    br ^bb15(%57 : !verona.unknown)
+  ^bb19(%58: !verona.unknown):  // pred: ^bb16
+    br ^bb15(%58 : !verona.unknown)
   }
 }

--- a/testsuite/mlir/mlir-parse/block-args/mlir.txt
+++ b/testsuite/mlir/mlir-parse/block-args/mlir.txt
@@ -1,0 +1,136 @@
+module @"$module" {
+  func @foo(%arg0: !verona.meet<class<"U64">, iso>, %arg1: !verona.meet<class<"U64">, imm>) -> !verona.class<"U64"> attributes {class = !verona.class<"$module">} {
+    %0 = "verona.alloca"() : () -> !verona.meet<class<"U64">, iso>
+    %1 = "verona.store"(%arg0, %0) : (!verona.meet<class<"U64">, iso>, !verona.meet<class<"U64">, iso>) -> !verona.unknown
+    %2 = "verona.alloca"() : () -> !verona.meet<class<"U64">, imm>
+    %3 = "verona.store"(%arg1, %2) : (!verona.meet<class<"U64">, imm>, !verona.meet<class<"U64">, imm>) -> !verona.unknown
+    %4 = "verona.load"(%0) : (!verona.meet<class<"U64">, iso>) -> !verona.unknown
+    %5 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
+    %6 = verona.call "+"[%4 : !verona.unknown] (%5 : !verona.unknown) : !verona.unknown
+    %7 = "verona.alloca"() : () -> !verona.unknown
+    %8 = "verona.store"(%6, %7) : (!verona.unknown, !verona.unknown) -> !verona.unknown
+    br ^bb1
+  ^bb1:  // 2 preds: ^bb0, ^bb6
+    %9 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
+    %10 = "verona.constant(100)"() : () -> !verona.class<"int">
+    %11 = verona.call "<"[%9 : !verona.unknown] (%10 : !verona.class<"int">) : !verona.unknown
+    %12 = "verona.cast"(%11) : (!verona.unknown) -> i1
+    cond_br %12, ^bb2, ^bb3
+  ^bb2:  // pred: ^bb1
+    %13 = "verona.load"(%0) : (!verona.meet<class<"U64">, iso>) -> !verona.unknown
+    %14 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
+    %15 = verona.call "-"[%13 : !verona.unknown] (%14 : !verona.unknown) : !verona.unknown
+    %16 = "verona.alloca"() : () -> !verona.unknown
+    %17 = "verona.store"(%15, %16) : (!verona.unknown, !verona.unknown) -> !verona.unknown
+    %18 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
+    %19 = "verona.alloca"() : () -> !verona.unknown
+    %20 = "verona.store"(%18, %19) : (!verona.unknown, !verona.unknown) -> !verona.unknown
+    %21 = "verona.load"(%0) : (!verona.meet<class<"U64">, iso>) -> !verona.unknown
+    %22 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
+    %23 = verona.call ">"[%21 : !verona.unknown] (%22 : !verona.unknown) : !verona.unknown
+    %24 = "verona.cast"(%23) : (!verona.unknown) -> i1
+    cond_br %24, ^bb4, ^bb5
+  ^bb3:  // pred: ^bb1
+    %25 = "verona.constant(21)"() : () -> !verona.class<"int">
+    %26 = "verona.alloca"() : () -> !verona.unknown
+    %27 = "verona.store"(%25, %26) : (!verona.class<"int">, !verona.unknown) -> !verona.unknown
+    br ^bb10
+  ^bb4:  // pred: ^bb2
+    %28 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
+    %29 = "verona.load"(%16) : (!verona.unknown) -> !verona.unknown
+    %30 = verona.call "+"[%28 : !verona.unknown] (%29 : !verona.unknown) : !verona.unknown
+    %31 = "verona.alloca"() : () -> !verona.unknown
+    %32 = "verona.store"(%30, %31) : (!verona.unknown, !verona.unknown) -> !verona.unknown
+    br ^bb7
+  ^bb5:  // pred: ^bb2
+    %33 = "verona.constant(42)"() : () -> !verona.class<"int">
+    %34 = "verona.store"(%33, %7) : (!verona.class<"int">, !verona.unknown) -> !verona.unknown
+    br ^bb6
+  ^bb6:  // 2 preds: ^bb5, ^bb9
+    br ^bb1
+  ^bb7:  // 2 preds: ^bb4, ^bb8
+    %35 = "verona.load"(%31) : (!verona.unknown) -> !verona.unknown
+    %36 = "verona.constant(10)"() : () -> !verona.class<"int">
+    %37 = verona.call "<"[%35 : !verona.unknown] (%36 : !verona.class<"int">) : !verona.unknown
+    %38 = "verona.cast"(%37) : (!verona.unknown) -> i1
+    cond_br %38, ^bb8, ^bb9
+  ^bb8:  // pred: ^bb7
+    %39 = "verona.load"(%19) : (!verona.unknown) -> !verona.unknown
+    %40 = "verona.load"(%31) : (!verona.unknown) -> !verona.unknown
+    %41 = verona.call "+"[%39 : !verona.unknown] (%40 : !verona.unknown) : !verona.unknown
+    %42 = "verona.store"(%41, %19) : (!verona.unknown, !verona.unknown) -> !verona.unknown
+    br ^bb7
+  ^bb9:  // pred: ^bb7
+    %43 = "verona.load"(%0) : (!verona.meet<class<"U64">, iso>) -> !verona.unknown
+    %44 = "verona.load"(%19) : (!verona.unknown) -> !verona.unknown
+    %45 = verona.call "+"[%43 : !verona.unknown] (%44 : !verona.unknown) : !verona.unknown
+    %46 = "verona.store"(%45, %0) : (!verona.unknown, !verona.meet<class<"U64">, iso>) -> !verona.unknown
+    br ^bb6
+  ^bb10:  // 2 preds: ^bb3, ^bb14
+    %47 = "verona.load"(%0) : (!verona.meet<class<"U64">, iso>) -> !verona.unknown
+    %48 = "verona.constant(0)"() : () -> !verona.class<"int">
+    %49 = verona.call ">"[%47 : !verona.unknown] (%48 : !verona.class<"int">) : !verona.unknown
+    %50 = "verona.cast"(%49) : (!verona.unknown) -> i1
+    cond_br %50, ^bb11, ^bb12
+  ^bb11:  // pred: ^bb10
+    %51 = "verona.load"(%0) : (!verona.meet<class<"U64">, iso>) -> !verona.unknown
+    %52 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
+    %53 = verona.call "=="[%51 : !verona.unknown] (%52 : !verona.unknown) : !verona.unknown
+    %54 = "verona.cast"(%53) : (!verona.unknown) -> i1
+    cond_br %54, ^bb13, ^bb14
+  ^bb12:  // 2 preds: ^bb10, ^bb13
+    %55 = "verona.constant(30)"() : () -> !verona.class<"int">
+    %56 = "verona.alloca"() : () -> !verona.unknown
+    %57 = "verona.store"(%55, %56) : (!verona.class<"int">, !verona.unknown) -> !verona.unknown
+    br ^bb15
+  ^bb13:  // pred: ^bb11
+    %58 = "verona.constant(20)"() : () -> !verona.class<"int">
+    %59 = "verona.store"(%58, %26) : (!verona.class<"int">, !verona.unknown) -> !verona.unknown
+    br ^bb12
+  ^bb14:  // pred: ^bb11
+    %60 = "verona.load"(%26) : (!verona.unknown) -> !verona.unknown
+    %61 = "verona.alloca"() : () -> !verona.unknown
+    %62 = "verona.store"(%60, %61) : (!verona.unknown, !verona.unknown) -> !verona.unknown
+    br ^bb10
+  ^bb15:  // 3 preds: ^bb12, ^bb18, ^bb19
+    %63 = "verona.load"(%56) : (!verona.unknown) -> !verona.unknown
+    %64 = "verona.constant(0)"() : () -> !verona.class<"int">
+    %65 = verona.call ">"[%63 : !verona.unknown] (%64 : !verona.class<"int">) : !verona.unknown
+    %66 = "verona.cast"(%65) : (!verona.unknown) -> i1
+    cond_br %66, ^bb16, ^bb17
+  ^bb16:  // pred: ^bb15
+    %67 = "verona.load"(%0) : (!verona.meet<class<"U64">, iso>) -> !verona.unknown
+    %68 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
+    %69 = verona.call "=="[%67 : !verona.unknown] (%68 : !verona.unknown) : !verona.unknown
+    %70 = "verona.cast"(%69) : (!verona.unknown) -> i1
+    cond_br %70, ^bb18, ^bb19
+  ^bb17:  // pred: ^bb15
+    %71 = "verona.load"(%0) : (!verona.meet<class<"U64">, iso>) -> !verona.unknown
+    %72 = "verona.load"(%26) : (!verona.unknown) -> !verona.unknown
+    %73 = verona.call "+"[%71 : !verona.unknown] (%72 : !verona.unknown) : !verona.unknown
+    %74 = "verona.store"(%73, %0) : (!verona.unknown, !verona.meet<class<"U64">, iso>) -> !verona.unknown
+    %75 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
+    %76 = "verona.load"(%56) : (!verona.unknown) -> !verona.unknown
+    %77 = verona.call "+"[%75 : !verona.unknown] (%76 : !verona.unknown) : !verona.unknown
+    %78 = "verona.store"(%77, %2) : (!verona.unknown, !verona.meet<class<"U64">, imm>) -> !verona.unknown
+    %79 = "verona.load"(%0) : (!verona.meet<class<"U64">, iso>) -> !verona.unknown
+    %80 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
+    %81 = verona.call "+"[%79 : !verona.unknown] (%80 : !verona.unknown) : !verona.unknown
+    %82 = "verona.alloca"() : () -> !verona.unknown
+    %83 = "verona.store"(%81, %82) : (!verona.unknown, !verona.unknown) -> !verona.unknown
+    %84 = "verona.load"(%82) : (!verona.unknown) -> !verona.unknown
+    %85 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
+    %86 = verona.call "+"[%84 : !verona.unknown] (%85 : !verona.unknown) : !verona.unknown
+    %87 = "verona.cast"(%86) : (!verona.unknown) -> !verona.class<"U64">
+    return %87 : !verona.class<"U64">
+  ^bb18:  // pred: ^bb16
+    %88 = "verona.constant(40)"() : () -> !verona.class<"int">
+    %89 = "verona.store"(%88, %56) : (!verona.class<"int">, !verona.unknown) -> !verona.unknown
+    br ^bb15
+  ^bb19:  // pred: ^bb16
+    %90 = "verona.load"(%56) : (!verona.unknown) -> !verona.unknown
+    %91 = "verona.alloca"() : () -> !verona.unknown
+    %92 = "verona.store"(%90, %91) : (!verona.unknown, !verona.unknown) -> !verona.unknown
+    br ^bb15
+  }
+}

--- a/testsuite/mlir/mlir-parse/block-args/mlir.txt
+++ b/testsuite/mlir/mlir-parse/block-args/mlir.txt
@@ -1,136 +1,81 @@
 module @"$module" {
   func @foo(%arg0: !verona.meet<class<"U64">, iso>, %arg1: !verona.meet<class<"U64">, imm>) -> !verona.class<"U64"> attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !verona.meet<class<"U64">, iso>
-    %1 = "verona.store"(%arg0, %0) : (!verona.meet<class<"U64">, iso>, !verona.meet<class<"U64">, iso>) -> !verona.unknown
-    %2 = "verona.alloca"() : () -> !verona.meet<class<"U64">, imm>
-    %3 = "verona.store"(%arg1, %2) : (!verona.meet<class<"U64">, imm>, !verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %4 = "verona.load"(%0) : (!verona.meet<class<"U64">, iso>) -> !verona.unknown
-    %5 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %6 = verona.call "+"[%4 : !verona.unknown] (%5 : !verona.unknown) : !verona.unknown
-    %7 = "verona.alloca"() : () -> !verona.unknown
-    %8 = "verona.store"(%6, %7) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    br ^bb1
-  ^bb1:  // 2 preds: ^bb0, ^bb6
-    %9 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
-    %10 = "verona.constant(100)"() : () -> !verona.class<"int">
-    %11 = verona.call "<"[%9 : !verona.unknown] (%10 : !verona.class<"int">) : !verona.unknown
-    %12 = "verona.cast"(%11) : (!verona.unknown) -> i1
-    cond_br %12, ^bb2, ^bb3
-  ^bb2:  // pred: ^bb1
-    %13 = "verona.load"(%0) : (!verona.meet<class<"U64">, iso>) -> !verona.unknown
-    %14 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %15 = verona.call "-"[%13 : !verona.unknown] (%14 : !verona.unknown) : !verona.unknown
-    %16 = "verona.alloca"() : () -> !verona.unknown
-    %17 = "verona.store"(%15, %16) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    %18 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
-    %19 = "verona.alloca"() : () -> !verona.unknown
-    %20 = "verona.store"(%18, %19) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    %21 = "verona.load"(%0) : (!verona.meet<class<"U64">, iso>) -> !verona.unknown
-    %22 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %23 = verona.call ">"[%21 : !verona.unknown] (%22 : !verona.unknown) : !verona.unknown
-    %24 = "verona.cast"(%23) : (!verona.unknown) -> i1
-    cond_br %24, ^bb4, ^bb5
-  ^bb3:  // pred: ^bb1
-    %25 = "verona.constant(21)"() : () -> !verona.class<"int">
-    %26 = "verona.alloca"() : () -> !verona.unknown
-    %27 = "verona.store"(%25, %26) : (!verona.class<"int">, !verona.unknown) -> !verona.unknown
-    br ^bb10
+    %0 = verona.call "+"[%arg0 : !verona.meet<class<"U64">, iso>] (%arg1 : !verona.meet<class<"U64">, imm>) : !verona.unknown
+    %1 = "verona.cast"(%arg0) : (!verona.meet<class<"U64">, iso>) -> !verona.unknown
+    br ^bb1(%1, %0 : !verona.unknown, !verona.unknown)
+  ^bb1(%2: !verona.unknown, %3: !verona.unknown):  // 2 preds: ^bb0, ^bb6
+    %4 = "verona.constant(100)"() : () -> !verona.class<"int">
+    %5 = verona.call "<"[%3 : !verona.unknown] (%4 : !verona.class<"int">) : !verona.unknown
+    %6 = "verona.cast"(%5) : (!verona.unknown) -> i1
+    cond_br %6, ^bb2(%2, %3 : !verona.unknown, !verona.unknown), ^bb3(%2, %3 : !verona.unknown, !verona.unknown)
+  ^bb2(%7: !verona.unknown, %8: !verona.unknown):  // pred: ^bb1
+    %9 = verona.call "-"[%7 : !verona.unknown] (%arg1 : !verona.meet<class<"U64">, imm>) : !verona.unknown
+    %10 = verona.call ">"[%7 : !verona.unknown] (%arg1 : !verona.meet<class<"U64">, imm>) : !verona.unknown
+    %11 = "verona.cast"(%10) : (!verona.unknown) -> i1
+    cond_br %11, ^bb4, ^bb5
+  ^bb3(%12: !verona.unknown, %13: !verona.unknown):  // pred: ^bb1
+    %14 = "verona.constant(21)"() : () -> !verona.class<"int">
+    %15 = "verona.cast"(%14) : (!verona.class<"int">) -> !verona.unknown
+    br ^bb10(%15 : !verona.unknown)
   ^bb4:  // pred: ^bb2
-    %28 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %29 = "verona.load"(%16) : (!verona.unknown) -> !verona.unknown
-    %30 = verona.call "+"[%28 : !verona.unknown] (%29 : !verona.unknown) : !verona.unknown
-    %31 = "verona.alloca"() : () -> !verona.unknown
-    %32 = "verona.store"(%30, %31) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    br ^bb7
+    %16 = verona.call "+"[%arg1 : !verona.meet<class<"U64">, imm>] (%9 : !verona.unknown) : !verona.unknown
+    br ^bb7(%8 : !verona.unknown)
   ^bb5:  // pred: ^bb2
-    %33 = "verona.constant(42)"() : () -> !verona.class<"int">
-    %34 = "verona.store"(%33, %7) : (!verona.class<"int">, !verona.unknown) -> !verona.unknown
-    br ^bb6
-  ^bb6:  // 2 preds: ^bb5, ^bb9
-    br ^bb1
-  ^bb7:  // 2 preds: ^bb4, ^bb8
-    %35 = "verona.load"(%31) : (!verona.unknown) -> !verona.unknown
-    %36 = "verona.constant(10)"() : () -> !verona.class<"int">
-    %37 = verona.call "<"[%35 : !verona.unknown] (%36 : !verona.class<"int">) : !verona.unknown
-    %38 = "verona.cast"(%37) : (!verona.unknown) -> i1
-    cond_br %38, ^bb8, ^bb9
-  ^bb8:  // pred: ^bb7
-    %39 = "verona.load"(%19) : (!verona.unknown) -> !verona.unknown
-    %40 = "verona.load"(%31) : (!verona.unknown) -> !verona.unknown
-    %41 = verona.call "+"[%39 : !verona.unknown] (%40 : !verona.unknown) : !verona.unknown
-    %42 = "verona.store"(%41, %19) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    br ^bb7
-  ^bb9:  // pred: ^bb7
-    %43 = "verona.load"(%0) : (!verona.meet<class<"U64">, iso>) -> !verona.unknown
-    %44 = "verona.load"(%19) : (!verona.unknown) -> !verona.unknown
-    %45 = verona.call "+"[%43 : !verona.unknown] (%44 : !verona.unknown) : !verona.unknown
-    %46 = "verona.store"(%45, %0) : (!verona.unknown, !verona.meet<class<"U64">, iso>) -> !verona.unknown
-    br ^bb6
-  ^bb10:  // 2 preds: ^bb3, ^bb14
-    %47 = "verona.load"(%0) : (!verona.meet<class<"U64">, iso>) -> !verona.unknown
-    %48 = "verona.constant(0)"() : () -> !verona.class<"int">
-    %49 = verona.call ">"[%47 : !verona.unknown] (%48 : !verona.class<"int">) : !verona.unknown
-    %50 = "verona.cast"(%49) : (!verona.unknown) -> i1
-    cond_br %50, ^bb11, ^bb12
-  ^bb11:  // pred: ^bb10
-    %51 = "verona.load"(%0) : (!verona.meet<class<"U64">, iso>) -> !verona.unknown
-    %52 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %53 = verona.call "=="[%51 : !verona.unknown] (%52 : !verona.unknown) : !verona.unknown
-    %54 = "verona.cast"(%53) : (!verona.unknown) -> i1
-    cond_br %54, ^bb13, ^bb14
-  ^bb12:  // 2 preds: ^bb10, ^bb13
-    %55 = "verona.constant(30)"() : () -> !verona.class<"int">
-    %56 = "verona.alloca"() : () -> !verona.unknown
-    %57 = "verona.store"(%55, %56) : (!verona.class<"int">, !verona.unknown) -> !verona.unknown
-    br ^bb15
+    %17 = "verona.constant(42)"() : () -> !verona.class<"int">
+    br ^bb6(%7, %8, %8 : !verona.unknown, !verona.unknown, !verona.unknown)
+  ^bb6(%18: !verona.unknown, %19: !verona.unknown, %20: !verona.unknown):  // 2 preds: ^bb5, ^bb9
+    br ^bb1(%7, %8 : !verona.unknown, !verona.unknown)
+  ^bb7(%21: !verona.unknown):  // 2 preds: ^bb4, ^bb8
+    %22 = "verona.constant(10)"() : () -> !verona.class<"int">
+    %23 = verona.call "<"[%16 : !verona.unknown] (%22 : !verona.class<"int">) : !verona.unknown
+    %24 = "verona.cast"(%23) : (!verona.unknown) -> i1
+    cond_br %24, ^bb8(%21 : !verona.unknown), ^bb9(%21 : !verona.unknown)
+  ^bb8(%25: !verona.unknown):  // pred: ^bb7
+    %26 = verona.call "+"[%25 : !verona.unknown] (%16 : !verona.unknown) : !verona.unknown
+    br ^bb7(%25 : !verona.unknown)
+  ^bb9(%27: !verona.unknown):  // pred: ^bb7
+    %28 = verona.call "+"[%7 : !verona.unknown] (%27 : !verona.unknown) : !verona.unknown
+    br ^bb6(%7, %8, %8 : !verona.unknown, !verona.unknown, !verona.unknown)
+  ^bb10(%29: !verona.unknown):  // 2 preds: ^bb3, ^bb14
+    %30 = "verona.constant(0)"() : () -> !verona.class<"int">
+    %31 = verona.call ">"[%12 : !verona.unknown] (%30 : !verona.class<"int">) : !verona.unknown
+    %32 = "verona.cast"(%31) : (!verona.unknown) -> i1
+    cond_br %32, ^bb11(%29 : !verona.unknown), ^bb12(%29 : !verona.unknown)
+  ^bb11(%33: !verona.unknown):  // pred: ^bb10
+    %34 = verona.call "=="[%12 : !verona.unknown] (%arg1 : !verona.meet<class<"U64">, imm>) : !verona.unknown
+    %35 = "verona.cast"(%34) : (!verona.unknown) -> i1
+    cond_br %35, ^bb13, ^bb14(%33 : !verona.unknown)
+  ^bb12(%36: !verona.unknown):  // 2 preds: ^bb10, ^bb13
+    %37 = "verona.constant(30)"() : () -> !verona.class<"int">
+    %38 = "verona.cast"(%37) : (!verona.class<"int">) -> !verona.unknown
+    br ^bb15(%38 : !verona.unknown)
   ^bb13:  // pred: ^bb11
-    %58 = "verona.constant(20)"() : () -> !verona.class<"int">
-    %59 = "verona.store"(%58, %26) : (!verona.class<"int">, !verona.unknown) -> !verona.unknown
-    br ^bb12
-  ^bb14:  // pred: ^bb11
-    %60 = "verona.load"(%26) : (!verona.unknown) -> !verona.unknown
-    %61 = "verona.alloca"() : () -> !verona.unknown
-    %62 = "verona.store"(%60, %61) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    br ^bb10
-  ^bb15:  // 3 preds: ^bb12, ^bb18, ^bb19
-    %63 = "verona.load"(%56) : (!verona.unknown) -> !verona.unknown
-    %64 = "verona.constant(0)"() : () -> !verona.class<"int">
-    %65 = verona.call ">"[%63 : !verona.unknown] (%64 : !verona.class<"int">) : !verona.unknown
-    %66 = "verona.cast"(%65) : (!verona.unknown) -> i1
-    cond_br %66, ^bb16, ^bb17
-  ^bb16:  // pred: ^bb15
-    %67 = "verona.load"(%0) : (!verona.meet<class<"U64">, iso>) -> !verona.unknown
-    %68 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %69 = verona.call "=="[%67 : !verona.unknown] (%68 : !verona.unknown) : !verona.unknown
-    %70 = "verona.cast"(%69) : (!verona.unknown) -> i1
-    cond_br %70, ^bb18, ^bb19
-  ^bb17:  // pred: ^bb15
-    %71 = "verona.load"(%0) : (!verona.meet<class<"U64">, iso>) -> !verona.unknown
-    %72 = "verona.load"(%26) : (!verona.unknown) -> !verona.unknown
-    %73 = verona.call "+"[%71 : !verona.unknown] (%72 : !verona.unknown) : !verona.unknown
-    %74 = "verona.store"(%73, %0) : (!verona.unknown, !verona.meet<class<"U64">, iso>) -> !verona.unknown
-    %75 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %76 = "verona.load"(%56) : (!verona.unknown) -> !verona.unknown
-    %77 = verona.call "+"[%75 : !verona.unknown] (%76 : !verona.unknown) : !verona.unknown
-    %78 = "verona.store"(%77, %2) : (!verona.unknown, !verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %79 = "verona.load"(%0) : (!verona.meet<class<"U64">, iso>) -> !verona.unknown
-    %80 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %81 = verona.call "+"[%79 : !verona.unknown] (%80 : !verona.unknown) : !verona.unknown
-    %82 = "verona.alloca"() : () -> !verona.unknown
-    %83 = "verona.store"(%81, %82) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    %84 = "verona.load"(%82) : (!verona.unknown) -> !verona.unknown
-    %85 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
-    %86 = verona.call "+"[%84 : !verona.unknown] (%85 : !verona.unknown) : !verona.unknown
-    %87 = "verona.cast"(%86) : (!verona.unknown) -> !verona.class<"U64">
-    return %87 : !verona.class<"U64">
+    %39 = "verona.constant(20)"() : () -> !verona.class<"int">
+    %40 = "verona.cast"(%39) : (!verona.class<"int">) -> !verona.unknown
+    br ^bb12(%40 : !verona.unknown)
+  ^bb14(%41: !verona.unknown):  // pred: ^bb11
+    br ^bb10(%33 : !verona.unknown)
+  ^bb15(%42: !verona.unknown):  // 3 preds: ^bb12, ^bb18, ^bb19
+    %43 = "verona.constant(0)"() : () -> !verona.class<"int">
+    %44 = verona.call ">"[%42 : !verona.unknown] (%43 : !verona.class<"int">) : !verona.unknown
+    %45 = "verona.cast"(%44) : (!verona.unknown) -> i1
+    cond_br %45, ^bb16(%42 : !verona.unknown), ^bb17(%42 : !verona.unknown)
+  ^bb16(%46: !verona.unknown):  // pred: ^bb15
+    %47 = verona.call "=="[%12 : !verona.unknown] (%arg1 : !verona.meet<class<"U64">, imm>) : !verona.unknown
+    %48 = "verona.cast"(%47) : (!verona.unknown) -> i1
+    cond_br %48, ^bb18, ^bb19(%46 : !verona.unknown)
+  ^bb17(%49: !verona.unknown):  // pred: ^bb15
+    %50 = verona.call "+"[%12 : !verona.unknown] (%36 : !verona.unknown) : !verona.unknown
+    %51 = verona.call "+"[%arg1 : !verona.meet<class<"U64">, imm>] (%49 : !verona.unknown) : !verona.unknown
+    %52 = verona.call "+"[%50 : !verona.unknown] (%51 : !verona.unknown) : !verona.unknown
+    %53 = verona.call "+"[%52 : !verona.unknown] (%13 : !verona.unknown) : !verona.unknown
+    %54 = "verona.cast"(%53) : (!verona.unknown) -> !verona.class<"U64">
+    return %54 : !verona.class<"U64">
   ^bb18:  // pred: ^bb16
-    %88 = "verona.constant(40)"() : () -> !verona.class<"int">
-    %89 = "verona.store"(%88, %56) : (!verona.class<"int">, !verona.unknown) -> !verona.unknown
-    br ^bb15
-  ^bb19:  // pred: ^bb16
-    %90 = "verona.load"(%56) : (!verona.unknown) -> !verona.unknown
-    %91 = "verona.alloca"() : () -> !verona.unknown
-    %92 = "verona.store"(%90, %91) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    br ^bb15
+    %55 = "verona.constant(40)"() : () -> !verona.class<"int">
+    %56 = "verona.cast"(%55) : (!verona.class<"int">) -> !verona.unknown
+    br ^bb15(%56 : !verona.unknown)
+  ^bb19(%57: !verona.unknown):  // pred: ^bb16
+    br ^bb15(%46 : !verona.unknown)
   }
 }

--- a/testsuite/mlir/mlir-parse/call/mlir.txt
+++ b/testsuite/mlir/mlir-parse/call/mlir.txt
@@ -1,61 +1,37 @@
 module @"$module" {
   func @foo(%arg0: !verona.imm, %arg1: !verona.meet<class<"U64">, imm>) -> !verona.meet<class<"U64">, imm> attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !verona.imm
-    %1 = "verona.store"(%arg0, %0) : (!verona.imm, !verona.imm) -> !verona.unknown
-    %2 = "verona.alloca"() : () -> !verona.meet<class<"U64">, imm>
-    %3 = "verona.store"(%arg1, %2) : (!verona.meet<class<"U64">, imm>, !verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %4 = "verona.load"(%0) : (!verona.imm) -> !verona.unknown
-    %5 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %6 = verona.call "+"[%4 : !verona.unknown] (%5 : !verona.unknown) : !verona.unknown
-    %7 = "verona.alloca"() : () -> !verona.unknown
-    %8 = "verona.store"(%6, %7) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    %9 = "verona.load"(%0) : (!verona.imm) -> !verona.unknown
-    %10 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %11 = verona.call "-"[%9 : !verona.unknown] (%10 : !verona.unknown) : !verona.unknown
-    %12 = "verona.alloca"() : () -> !verona.unknown
-    %13 = "verona.store"(%11, %12) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    %14 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
-    %15 = "verona.constant(100)"() : () -> !verona.class<"int">
-    %16 = verona.call "<"[%14 : !verona.unknown] (%15 : !verona.class<"int">) : !verona.unknown
-    %17 = "verona.cast"(%16) : (!verona.unknown) -> i1
-    cond_br %17, ^bb1, ^bb2
+    %0 = verona.call "+"[%arg0 : !verona.imm] (%arg1 : !verona.meet<class<"U64">, imm>) : !verona.unknown
+    %1 = verona.call "-"[%arg0 : !verona.imm] (%arg1 : !verona.meet<class<"U64">, imm>) : !verona.unknown
+    %2 = "verona.constant(100)"() : () -> !verona.class<"int">
+    %3 = verona.call "<"[%0 : !verona.unknown] (%2 : !verona.class<"int">) : !verona.unknown
+    %4 = "verona.cast"(%3) : (!verona.unknown) -> i1
+    cond_br %4, ^bb1, ^bb2
   ^bb1:  // pred: ^bb0
-    %18 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
-    %19 = "verona.load"(%12) : (!verona.unknown) -> !verona.unknown
-    %20 = verona.call "foo"[%18 : !verona.unknown] (%19 : !verona.unknown) : !verona.unknown
-    %21 = "verona.cast"(%20) : (!verona.unknown) -> !verona.meet<class<"U64">, imm>
-    return %21 : !verona.meet<class<"U64">, imm>
+    %5 = verona.call "foo"[%0 : !verona.unknown] (%1 : !verona.unknown) : !verona.unknown
+    %6 = "verona.cast"(%5) : (!verona.unknown) -> !verona.meet<class<"U64">, imm>
+    return %6 : !verona.meet<class<"U64">, imm>
   ^bb2:  // pred: ^bb0
-    %22 = "verona.load"(%0) : (!verona.imm) -> !verona.unknown
-    %23 = "verona.constant(0)"() : () -> !verona.class<"int">
-    %24 = verona.call "!="[%22 : !verona.unknown] (%23 : !verona.class<"int">) : !verona.unknown
-    %25 = "verona.cast"(%24) : (!verona.unknown) -> i1
-    cond_br %25, ^bb4, ^bb5
+    %7 = "verona.constant(0)"() : () -> !verona.class<"int">
+    %8 = verona.call "!="[%arg0 : !verona.imm] (%7 : !verona.class<"int">) : !verona.unknown
+    %9 = "verona.cast"(%8) : (!verona.unknown) -> i1
+    cond_br %9, ^bb4, ^bb5
   ^bb3:  // pred: ^bb5
-    %26 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
-    %27 = "verona.load"(%12) : (!verona.unknown) -> !verona.unknown
-    %28 = verona.call "+"[%26 : !verona.unknown] (%27 : !verona.unknown) : !verona.unknown
-    %29 = "verona.cast"(%28) : (!verona.unknown) -> !verona.meet<class<"U64">, imm>
-    return %29 : !verona.meet<class<"U64">, imm>
+    %10 = verona.call "+"[%0 : !verona.unknown] (%1 : !verona.unknown) : !verona.unknown
+    %11 = "verona.cast"(%10) : (!verona.unknown) -> !verona.meet<class<"U64">, imm>
+    return %11 : !verona.meet<class<"U64">, imm>
   ^bb4:  // pred: ^bb2
-    %30 = "verona.load"(%0) : (!verona.imm) -> !verona.unknown
-    %31 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %32 = verona.call "method"[%30 : !verona.unknown] (%31 : !verona.unknown) : !verona.unknown
-    %33 = "verona.cast"(%32) : (!verona.unknown) -> !verona.meet<class<"U64">, imm>
-    return %33 : !verona.meet<class<"U64">, imm>
+    %12 = verona.call "method"[%arg0 : !verona.imm] (%arg1 : !verona.meet<class<"U64">, imm>) : !verona.unknown
+    %13 = "verona.cast"(%12) : (!verona.unknown) -> !verona.meet<class<"U64">, imm>
+    return %13 : !verona.meet<class<"U64">, imm>
   ^bb5:  // pred: ^bb2
     br ^bb3
   }
   func @apply() attributes {class = !verona.class<"$module">} {
     %0 = "verona.constant(10)"() : () -> !verona.class<"int">
-    %1 = "verona.alloca"() : () -> !verona.imm
-    %2 = "verona.store"(%0, %1) : (!verona.class<"int">, !verona.imm) -> !verona.unknown
-    %3 = "verona.constant(20)"() : () -> !verona.class<"int">
-    %4 = "verona.alloca"() : () -> !verona.meet<class<"U64">, imm>
-    %5 = "verona.store"(%3, %4) : (!verona.class<"int">, !verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %6 = "verona.load"(%1) : (!verona.imm) -> !verona.unknown
-    %7 = "verona.load"(%4) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %8 = verona.call "foo"[%6 : !verona.unknown] (%7 : !verona.unknown) : !verona.unknown
+    %1 = "verona.cast"(%0) : (!verona.class<"int">) -> !verona.imm
+    %2 = "verona.constant(20)"() : () -> !verona.class<"int">
+    %3 = "verona.cast"(%2) : (!verona.class<"int">) -> !verona.meet<class<"U64">, imm>
+    %4 = verona.call "foo"[%1 : !verona.imm] (%3 : !verona.meet<class<"U64">, imm>) : !verona.unknown
     return
   }
 }

--- a/testsuite/mlir/mlir-parse/class/mlir.txt
+++ b/testsuite/mlir/mlir-parse/class/mlir.txt
@@ -11,87 +11,55 @@ module @"$module" {
   }
   module @G {
     func @foo(%arg0: !verona.class<"U32">) -> !verona.class<"F32"> attributes {class = !verona.class<"G", "$parent" : class<"$module">>, qualifiers = ["static"]} {
-      %0 = "verona.alloca"() : () -> !verona.class<"U32">
-      %1 = "verona.store"(%arg0, %0) : (!verona.class<"U32">, !verona.class<"U32">) -> !verona.unknown
-      %2 = "verona.constant(3.14)"() : () -> !verona.class<"float">
-      %3 = "verona.cast"(%2) : (!verona.class<"float">) -> !verona.class<"F32">
-      return %3 : !verona.class<"F32">
+      %0 = "verona.constant(3.14)"() : () -> !verona.class<"float">
+      %1 = "verona.cast"(%0) : (!verona.class<"float">) -> !verona.class<"F32">
+      return %1 : !verona.class<"F32">
     }
     func @baz(%arg0: !verona.class<"F32">) -> !verona.class<"F32"> attributes {class = !verona.class<"G", "$parent" : class<"$module">>, qualifiers = ["static"]} {
-      %0 = "verona.alloca"() : () -> !verona.class<"F32">
-      %1 = "verona.store"(%arg0, %0) : (!verona.class<"F32">, !verona.class<"F32">) -> !verona.unknown
-      %2 = "verona.load"(%0) : (!verona.class<"F32">) -> !verona.unknown
-      %3 = "verona.constant(42)"() : () -> !verona.class<"int">
-      %4 = verona.static !verona.class<"G", "$parent" : class<"$module">> : !verona<"">
-      %5 = verona.call "foo"[%4 : !verona<"">] (%3 : !verona.class<"int">) : !verona.unknown
-      %6 = verona.call "+"[%2 : !verona.unknown] (%5 : !verona.unknown) : !verona.unknown
-      %7 = "verona.cast"(%6) : (!verona.unknown) -> !verona.class<"F32">
-      return %7 : !verona.class<"F32">
+      %0 = "verona.constant(42)"() : () -> !verona.class<"int">
+      %1 = verona.static !verona.class<"G", "$parent" : class<"$module">> : !verona<"">
+      %2 = verona.call "foo"[%1 : !verona<"">] (%0 : !verona.class<"int">) : !verona.unknown
+      %3 = verona.call "+"[%arg0 : !verona.class<"F32">] (%2 : !verona.unknown) : !verona.unknown
+      %4 = "verona.cast"(%3) : (!verona.unknown) -> !verona.class<"F32">
+      return %4 : !verona.class<"F32">
     }
   }
   module @POD {
   }
   func @bar(%arg0: !verona.class<"C", "$parent" : class<"$module">>, %arg1: !verona.class<"D", "$parent" : class<"$module">, "f" : meet<class<"U64">, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : class<"F32">, "i" : class<"F64">, "j" : class<"bool">>, %arg2: !verona.class<"E", "$parent" : class<"$module">, "a" : class<"D", "$parent" : class<"$module">, "f" : meet<class<"U64">, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : class<"F32">, "i" : class<"F64">, "j" : class<"bool">>, "b" : class<"E">, "c" : class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, "d" : class<"G", "$parent" : class<"$module">>>, %arg3: !verona.class<"NestE", "$parent" : class<"E", "$parent" : class<"$module">, "a" : class<"D", "$parent" : class<"$module">, "f" : meet<class<"U64">, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : class<"F32">, "i" : class<"F64">, "j" : class<"bool">>, "b" : class<"E">, "c" : class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, "d" : class<"G", "$parent" : class<"$module">>>, "x" : class<"G", "$parent" : class<"$module">>>, %arg4: !verona.class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, %arg5: !verona.class<"G", "$parent" : class<"$module">>) attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !verona.class<"C", "$parent" : class<"$module">>
-    %1 = "verona.store"(%arg0, %0) : (!verona.class<"C", "$parent" : class<"$module">>, !verona.class<"C", "$parent" : class<"$module">>) -> !verona.unknown
-    %2 = "verona.alloca"() : () -> !verona.class<"D", "$parent" : class<"$module">, "f" : meet<class<"U64">, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : class<"F32">, "i" : class<"F64">, "j" : class<"bool">>
-    %3 = "verona.store"(%arg1, %2) : (!verona.class<"D", "$parent" : class<"$module">, "f" : meet<class<"U64">, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : class<"F32">, "i" : class<"F64">, "j" : class<"bool">>, !verona.class<"D", "$parent" : class<"$module">, "f" : meet<class<"U64">, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : class<"F32">, "i" : class<"F64">, "j" : class<"bool">>) -> !verona.unknown
-    %4 = "verona.alloca"() : () -> !verona.class<"E", "$parent" : class<"$module">, "a" : class<"D", "$parent" : class<"$module">, "f" : meet<class<"U64">, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : class<"F32">, "i" : class<"F64">, "j" : class<"bool">>, "b" : class<"E">, "c" : class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, "d" : class<"G", "$parent" : class<"$module">>>
-    %5 = "verona.store"(%arg2, %4) : (!verona.class<"E", "$parent" : class<"$module">, "a" : class<"D", "$parent" : class<"$module">, "f" : meet<class<"U64">, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : class<"F32">, "i" : class<"F64">, "j" : class<"bool">>, "b" : class<"E">, "c" : class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, "d" : class<"G", "$parent" : class<"$module">>>, !verona.class<"E", "$parent" : class<"$module">, "a" : class<"D", "$parent" : class<"$module">, "f" : meet<class<"U64">, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : class<"F32">, "i" : class<"F64">, "j" : class<"bool">>, "b" : class<"E">, "c" : class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, "d" : class<"G", "$parent" : class<"$module">>>) -> !verona.unknown
-    %6 = "verona.alloca"() : () -> !verona.class<"NestE", "$parent" : class<"E", "$parent" : class<"$module">, "a" : class<"D", "$parent" : class<"$module">, "f" : meet<class<"U64">, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : class<"F32">, "i" : class<"F64">, "j" : class<"bool">>, "b" : class<"E">, "c" : class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, "d" : class<"G", "$parent" : class<"$module">>>, "x" : class<"G", "$parent" : class<"$module">>>
-    %7 = "verona.store"(%arg3, %6) : (!verona.class<"NestE", "$parent" : class<"E", "$parent" : class<"$module">, "a" : class<"D", "$parent" : class<"$module">, "f" : meet<class<"U64">, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : class<"F32">, "i" : class<"F64">, "j" : class<"bool">>, "b" : class<"E">, "c" : class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, "d" : class<"G", "$parent" : class<"$module">>>, "x" : class<"G", "$parent" : class<"$module">>>, !verona.class<"NestE", "$parent" : class<"E", "$parent" : class<"$module">, "a" : class<"D", "$parent" : class<"$module">, "f" : meet<class<"U64">, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : class<"F32">, "i" : class<"F64">, "j" : class<"bool">>, "b" : class<"E">, "c" : class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, "d" : class<"G", "$parent" : class<"$module">>>, "x" : class<"G", "$parent" : class<"$module">>>) -> !verona.unknown
-    %8 = "verona.alloca"() : () -> !verona.class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>
-    %9 = "verona.store"(%arg4, %8) : (!verona.class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, !verona.class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>) -> !verona.unknown
-    %10 = "verona.alloca"() : () -> !verona.class<"G", "$parent" : class<"$module">>
-    %11 = "verona.store"(%arg5, %10) : (!verona.class<"G", "$parent" : class<"$module">>, !verona.class<"G", "$parent" : class<"$module">>) -> !verona.unknown
-    %12 = verona.new_region @C [] : !verona.class<"C", "$parent" : class<"$module">>
-    %13 = "verona.alloca"() : () -> !verona.meet<class<"C", "$parent" : class<"$module">>, iso>
-    %14 = "verona.store"(%12, %13) : (!verona.class<"C", "$parent" : class<"$module">>, !verona.meet<class<"C", "$parent" : class<"$module">>, iso>) -> !verona.unknown
-    %15 = "verona.load"(%13) : (!verona.meet<class<"C", "$parent" : class<"$module">>, iso>) -> !verona.unknown
-    %16 = verona.new_object @C [] in(%15 : !verona.unknown) : !verona.class<"C", "$parent" : class<"$module">>
-    %17 = "verona.alloca"() : () -> !verona.meet<class<"C", "$parent" : class<"$module">>, iso>
-    %18 = "verona.store"(%16, %17) : (!verona.class<"C", "$parent" : class<"$module">>, !verona.meet<class<"C", "$parent" : class<"$module">>, iso>) -> !verona.unknown
-    %19 = "verona.constant(42)"() : () -> !verona.class<"int">
-    %20 = "verona.constant(3.14)"() : () -> !verona.class<"float">
-    %21 = verona.new_region @POD ["a", "b"](%19, %20 : !verona.class<"int">, !verona.class<"float">) : !verona.class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>
-    %22 = "verona.alloca"() : () -> !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso>
-    %23 = "verona.store"(%21, %22) : (!verona.class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso>) -> !verona.unknown
-    %24 = "verona.constant(21)"() : () -> !verona.class<"int">
-    %25 = "verona.constant(2.72)"() : () -> !verona.class<"float">
-    %26 = "verona.load"(%22) : (!verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso>) -> !verona.unknown
-    %27 = verona.new_object @POD ["a", "b"](%24, %25 : !verona.class<"int">, !verona.class<"float">) in(%26 : !verona.unknown) : !verona.class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>
-    %28 = "verona.alloca"() : () -> !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso>
-    %29 = "verona.store"(%27, %28) : (!verona.class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso>) -> !verona.unknown
-    %30 = verona.field_read %22["a"] : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown
-    %31 = "verona.alloca"() : () -> !verona.meet<class<"U32">, mut>
-    %32 = "verona.store"(%30, %31) : (!verona.unknown, !verona.meet<class<"U32">, mut>) -> !verona.unknown
-    %33 = verona.field_read %28["a"] : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown
-    %34 = "verona.alloca"() : () -> !verona.meet<class<"U32">, mut>
-    %35 = "verona.store"(%33, %34) : (!verona.unknown, !verona.meet<class<"U32">, mut>) -> !verona.unknown
-    %36 = "verona.load"(%31) : (!verona.meet<class<"U32">, mut>) -> !verona.unknown
-    %37 = "verona.load"(%34) : (!verona.meet<class<"U32">, mut>) -> !verona.unknown
-    %38 = verona.call "+"[%36 : !verona.unknown] (%37 : !verona.unknown) : !verona.unknown
-    %39 = verona.field_write %28["a"], %38 : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown -> !verona.unknown
-    %40 = verona.field_read %28["a"] : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown
-    %41 = verona.field_write %22["a"], %40 : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown -> !verona.unknown
-    %42 = "verona.constant(1337)"() : () -> !verona.class<"int">
-    %43 = "verona.cast"(%42) : (!verona.class<"int">) -> !verona.unknown
-    %44 = verona.field_write %22["a"], %43 : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown -> !verona.unknown
-    %45 = verona.field_write %28["a"], %44 : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown -> !verona.unknown
-    %46 = "verona.constant(13)"() : () -> !verona.class<"int">
-    %47 = verona.static !verona.class<"G", "$parent" : class<"$module">> : !verona<"">
-    %48 = verona.call "foo"[%47 : !verona<"">] (%46 : !verona.class<"int">) : !verona.unknown
-    %49 = "verona.alloca"() : () -> !verona.class<"F32">
-    %50 = "verona.store"(%48, %49) : (!verona.unknown, !verona.class<"F32">) -> !verona.unknown
-    %51 = "verona.load"(%49) : (!verona.class<"F32">) -> !verona.unknown
-    %52 = verona.static !verona.class<"G", "$parent" : class<"$module">> : !verona<"">
-    %53 = verona.call "baz"[%52 : !verona<"">] (%51 : !verona.unknown) : !verona.unknown
-    %54 = "verona.alloca"() : () -> !verona.class<"F32">
-    %55 = "verona.store"(%53, %54) : (!verona.unknown, !verona.class<"F32">) -> !verona.unknown
-    %56 = "verona.load"(%0) : (!verona.class<"C", "$parent" : class<"$module">>) -> !verona.unknown
-    verona.tidy %56 : !verona.unknown
-    %57 = "verona.load"(%2) : (!verona.class<"D", "$parent" : class<"$module">, "f" : meet<class<"U64">, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : class<"F32">, "i" : class<"F64">, "j" : class<"bool">>) -> !verona.unknown
-    verona.drop %57 : !verona.unknown
+    %0 = verona.new_region @C [] : !verona.class<"C", "$parent" : class<"$module">>
+    %1 = "verona.cast"(%0) : (!verona.class<"C", "$parent" : class<"$module">>) -> !verona.meet<class<"C", "$parent" : class<"$module">>, iso>
+    %2 = verona.new_object @C [] in(%1 : !verona.meet<class<"C", "$parent" : class<"$module">>, iso>) : !verona.class<"C", "$parent" : class<"$module">>
+    %3 = "verona.cast"(%2) : (!verona.class<"C", "$parent" : class<"$module">>) -> !verona.meet<class<"C", "$parent" : class<"$module">>, iso>
+    %4 = "verona.constant(42)"() : () -> !verona.class<"int">
+    %5 = "verona.constant(3.14)"() : () -> !verona.class<"float">
+    %6 = verona.new_region @POD ["a", "b"](%4, %5 : !verona.class<"int">, !verona.class<"float">) : !verona.class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>
+    %7 = "verona.cast"(%6) : (!verona.class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>) -> !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso>
+    %8 = "verona.constant(21)"() : () -> !verona.class<"int">
+    %9 = "verona.constant(2.72)"() : () -> !verona.class<"float">
+    %10 = verona.new_object @POD ["a", "b"](%8, %9 : !verona.class<"int">, !verona.class<"float">) in(%7 : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso>) : !verona.class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>
+    %11 = "verona.cast"(%10) : (!verona.class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>) -> !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso>
+    %12 = verona.field_read %7["a"] : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown
+    %13 = "verona.cast"(%12) : (!verona.unknown) -> !verona.meet<class<"U32">, mut>
+    %14 = verona.field_read %11["a"] : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown
+    %15 = "verona.cast"(%14) : (!verona.unknown) -> !verona.meet<class<"U32">, mut>
+    %16 = verona.call "+"[%13 : !verona.meet<class<"U32">, mut>] (%15 : !verona.meet<class<"U32">, mut>) : !verona.unknown
+    %17 = verona.field_write %11["a"], %16 : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown -> !verona.unknown
+    %18 = verona.field_read %11["a"] : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown
+    %19 = verona.field_write %7["a"], %18 : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown -> !verona.unknown
+    %20 = "verona.constant(1337)"() : () -> !verona.class<"int">
+    %21 = "verona.cast"(%20) : (!verona.class<"int">) -> !verona.unknown
+    %22 = verona.field_write %7["a"], %21 : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown -> !verona.unknown
+    %23 = verona.field_write %11["a"], %22 : !verona.meet<class<"POD", "$parent" : class<"$module">, "a" : class<"U32">, "b" : class<"F64">>, iso> -> !verona.unknown -> !verona.unknown
+    %24 = "verona.constant(13)"() : () -> !verona.class<"int">
+    %25 = verona.static !verona.class<"G", "$parent" : class<"$module">> : !verona<"">
+    %26 = verona.call "foo"[%25 : !verona<"">] (%24 : !verona.class<"int">) : !verona.unknown
+    %27 = "verona.cast"(%26) : (!verona.unknown) -> !verona.class<"F32">
+    %28 = verona.static !verona.class<"G", "$parent" : class<"$module">> : !verona<"">
+    %29 = verona.call "baz"[%28 : !verona<"">] (%27 : !verona.class<"F32">) : !verona.unknown
+    %30 = "verona.cast"(%29) : (!verona.unknown) -> !verona.class<"F32">
+    verona.tidy %arg0 : !verona.class<"C", "$parent" : class<"$module">>
+    verona.drop %arg1 : !verona.class<"D", "$parent" : class<"$module">, "f" : meet<class<"U64">, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : class<"F32">, "i" : class<"F64">, "j" : class<"bool">>
     return
   }
 }

--- a/testsuite/mlir/mlir-parse/conditional.verona
+++ b/testsuite/mlir/mlir-parse/conditional.verona
@@ -125,3 +125,19 @@ double_diamond(flag : bool, a : U16, b : U16, x : U16, y : U16) : S16
   // y(3) = PHI(y, y(2))
   x + y;
 }
+
+// Testing calls and field access, to make sure the right value is propagated.
+
+class A
+{
+  x : U32;
+  m() : A;
+}
+
+method_test(a : A & mut) : U32
+{
+  if (true) {
+    a = a.m();
+  }
+  a.x;
+}

--- a/testsuite/mlir/mlir-parse/conditional.verona
+++ b/testsuite/mlir/mlir-parse/conditional.verona
@@ -1,19 +1,127 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
 
-f(x : U16) : S16
+// Simple if updating a variable inside and a variable bypass
+// to show the basic block arguments are correctly chosen
+// for the update and not for the bypass
+
+simple_with_bypass(a : U16, x : U16) : S16
 {
+  // Args:  a  x
+  // Rets:  x
+  if (a == x)
+  {
+    // x(1)
+    x = 42;
+  }
+  // x(2) = PHI(x, x(1))
+  // a(1) = a
+  a + x;
+}
+
+// Checks a simple if/else/if chain
+// Only x propagates through the chain
+// No need for arguments, only in the last two
+// merging basic blocks, which need one argument,
+// the local updated valus of x.
+
+chain(x : U16) : S16
+{
+  // Args:  x
+  // Rets:  x
   if (x < 2)
   {
+    // x(1)
     x = x + 1;
   }
+  // Args:  x
+  // Rets:  x
   else if (true)
   {
+    // x(2)
     x = x - 1;
   }
   else
   {
+    // x(3)
     x = 0;
   }
+  // x(4) = PHI(x(2), x(3))
+  // x(5) = PHI(x(1), x(4))
   x;
+}
+
+// Checks that two values (x, y) are carried correctly
+// through the diamond CFG, with each side modifying a
+// different variable, and the final block with an
+// argument for both. In each side, the values used are
+// the original plus the modified one.
+
+diamond(x : U16, y : U16) : S16
+{
+  // Args:  x  y
+  // Rets:  x  y
+  if (x > y)
+  {
+    // x(1), y
+    x = 10;
+  }
+  else
+  {
+    // x, y(1)
+    y = 20;
+  }
+  // x(2) = PHI(x(1), x)
+  // y(2) = PHI(y, y(1))
+  x + y;
+}
+
+// Double diamond, to make sure the PHI nodes that are created in
+// the inner diamonds are correctly connected to the final PHI nodes
+// in the last block, which should have all four variables.
+
+double_diamond(flag : bool, a : U16, b : U16, x : U16, y : U16) : S16
+{
+  // Args:  a  b  flag  x  y
+  // Rets:  a  b  x  y
+  if (flag)
+  {
+    // Args:  a  b
+    // Rets:  a  b
+    if (a == b)
+    {
+      // a(1)
+      a = 1;
+    }
+    else
+    {
+      // b(1)
+      b = 2;
+    }
+    // a(2) = PHI(a(1), a)
+    // b(2) = PHI(b, b(1))
+  }
+  else
+  {
+    // Args:  x  y
+    // Rets:  x  y
+    if (x == y)
+    {
+      // x(1)
+      x = 3;
+    }
+    else
+    {
+      // y(1)
+      y = 4;
+    }
+    // x(2) = PHI(x(1), x)
+    // y(2) = PHI(y, y(1))
+  }
+  // a(3) = PHI(a(2), a)
+  // b(3) = PHI(b(2), b)
+  a + b;
+  // x(3) = PHI(x, x(2))
+  // y(3) = PHI(y, y(2))
+  x + y;
 }

--- a/testsuite/mlir/mlir-parse/conditional/mlir.txt
+++ b/testsuite/mlir/mlir-parse/conditional/mlir.txt
@@ -1,37 +1,125 @@
 module @"$module" {
-  func @f(%arg0: !verona.class<"U16">) -> !verona.class<"S16"> attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !verona.class<"U16">
-    %1 = "verona.store"(%arg0, %0) : (!verona.class<"U16">, !verona.class<"U16">) -> !verona.unknown
-    %2 = "verona.load"(%0) : (!verona.class<"U16">) -> !verona.unknown
-    %3 = "verona.constant(2)"() : () -> !verona.class<"int">
-    %4 = verona.call "<"[%2 : !verona.unknown] (%3 : !verona.class<"int">) : !verona.unknown
-    %5 = "verona.cast"(%4) : (!verona.unknown) -> i1
-    cond_br %5, ^bb1, ^bb2
+  func @simple_with_bypass(%arg0: !verona.class<"U16">, %arg1: !verona.class<"U16">) -> !verona.class<"S16"> attributes {class = !verona.class<"$module">} {
+    %0 = verona.call "=="[%arg0 : !verona.class<"U16">] (%arg1 : !verona.class<"U16">) : !verona.unknown
+    %1 = "verona.cast"(%0) : (!verona.unknown) -> i1
+    %2 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
+    cond_br %1, ^bb1, ^bb2(%2 : !verona.unknown)
   ^bb1:  // pred: ^bb0
-    %6 = "verona.load"(%0) : (!verona.class<"U16">) -> !verona.unknown
-    %7 = "verona.constant(1)"() : () -> !verona.class<"int">
-    %8 = verona.call "+"[%6 : !verona.unknown] (%7 : !verona.class<"int">) : !verona.unknown
-    %9 = "verona.store"(%8, %0) : (!verona.unknown, !verona.class<"U16">) -> !verona.unknown
-    br ^bb3
+    %3 = "verona.constant(42)"() : () -> !verona.class<"int">
+    %4 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
+    br ^bb2(%4 : !verona.unknown)
+  ^bb2(%5: !verona.unknown):  // 2 preds: ^bb0, ^bb1
+    %6 = verona.call "+"[%arg0 : !verona.class<"U16">] (%5 : !verona.unknown) : !verona.unknown
+    %7 = "verona.cast"(%6) : (!verona.unknown) -> !verona.class<"S16">
+    return %7 : !verona.class<"S16">
+  }
+  func @chain(%arg0: !verona.class<"U16">) -> !verona.class<"S16"> attributes {class = !verona.class<"$module">} {
+    %0 = "verona.constant(2)"() : () -> !verona.class<"int">
+    %1 = verona.call "<"[%arg0 : !verona.class<"U16">] (%0 : !verona.class<"int">) : !verona.unknown
+    %2 = "verona.cast"(%1) : (!verona.unknown) -> i1
+    %3 = "verona.cast"(%arg0) : (!verona.class<"U16">) -> !verona.unknown
+    cond_br %2, ^bb1, ^bb2
+  ^bb1:  // pred: ^bb0
+    %4 = "verona.constant(1)"() : () -> !verona.class<"int">
+    %5 = verona.call "+"[%arg0 : !verona.class<"U16">] (%4 : !verona.class<"int">) : !verona.unknown
+    %6 = "verona.cast"(%arg0) : (!verona.class<"U16">) -> !verona.unknown
+    br ^bb3(%6 : !verona.unknown)
   ^bb2:  // pred: ^bb0
-    %10 = "verona.constant(true)"() : () -> !verona.class<"bool">
-    %11 = "verona.cast"(%10) : (!verona.class<"bool">) -> i1
-    cond_br %11, ^bb4, ^bb5
-  ^bb3:  // 2 preds: ^bb1, ^bb6
-    %12 = "verona.load"(%0) : (!verona.class<"U16">) -> !verona.unknown
+    %7 = "verona.constant(true)"() : () -> !verona.class<"bool">
+    %8 = "verona.cast"(%7) : (!verona.class<"bool">) -> i1
+    %9 = "verona.cast"(%arg0) : (!verona.class<"U16">) -> !verona.unknown
+    cond_br %8, ^bb4, ^bb5
+  ^bb3(%10: !verona.unknown):  // 2 preds: ^bb1, ^bb6
+    %11 = "verona.cast"(%10) : (!verona.unknown) -> !verona.class<"S16">
+    return %11 : !verona.class<"S16">
+  ^bb4:  // pred: ^bb2
+    %12 = "verona.constant(1)"() : () -> !verona.class<"int">
+    %13 = verona.call "-"[%arg0 : !verona.class<"U16">] (%12 : !verona.class<"int">) : !verona.unknown
+    %14 = "verona.cast"(%arg0) : (!verona.class<"U16">) -> !verona.unknown
+    br ^bb6(%14 : !verona.unknown)
+  ^bb5:  // pred: ^bb2
+    %15 = "verona.constant(0)"() : () -> !verona.class<"int">
+    %16 = "verona.cast"(%arg0) : (!verona.class<"U16">) -> !verona.unknown
+    br ^bb6(%16 : !verona.unknown)
+  ^bb6(%17: !verona.unknown):  // 2 preds: ^bb4, ^bb5
+    br ^bb3(%17 : !verona.unknown)
+  }
+  func @diamond(%arg0: !verona.class<"U16">, %arg1: !verona.class<"U16">) -> !verona.class<"S16"> attributes {class = !verona.class<"$module">} {
+    %0 = verona.call ">"[%arg0 : !verona.class<"U16">] (%arg1 : !verona.class<"U16">) : !verona.unknown
+    %1 = "verona.cast"(%0) : (!verona.unknown) -> i1
+    %2 = "verona.cast"(%arg0) : (!verona.class<"U16">) -> !verona.unknown
+    %3 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
+    cond_br %1, ^bb1, ^bb2
+  ^bb1:  // pred: ^bb0
+    %4 = "verona.constant(10)"() : () -> !verona.class<"int">
+    %5 = "verona.cast"(%arg0) : (!verona.class<"U16">) -> !verona.unknown
+    %6 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
+    br ^bb3(%5, %6 : !verona.unknown, !verona.unknown)
+  ^bb2:  // pred: ^bb0
+    %7 = "verona.constant(20)"() : () -> !verona.class<"int">
+    %8 = "verona.cast"(%arg0) : (!verona.class<"U16">) -> !verona.unknown
+    %9 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
+    br ^bb3(%8, %9 : !verona.unknown, !verona.unknown)
+  ^bb3(%10: !verona.unknown, %11: !verona.unknown):  // 2 preds: ^bb1, ^bb2
+    %12 = verona.call "+"[%10 : !verona.unknown] (%11 : !verona.unknown) : !verona.unknown
     %13 = "verona.cast"(%12) : (!verona.unknown) -> !verona.class<"S16">
     return %13 : !verona.class<"S16">
-  ^bb4:  // pred: ^bb2
-    %14 = "verona.load"(%0) : (!verona.class<"U16">) -> !verona.unknown
-    %15 = "verona.constant(1)"() : () -> !verona.class<"int">
-    %16 = verona.call "-"[%14 : !verona.unknown] (%15 : !verona.class<"int">) : !verona.unknown
-    %17 = "verona.store"(%16, %0) : (!verona.unknown, !verona.class<"U16">) -> !verona.unknown
-    br ^bb6
-  ^bb5:  // pred: ^bb2
-    %18 = "verona.constant(0)"() : () -> !verona.class<"int">
-    %19 = "verona.store"(%18, %0) : (!verona.class<"int">, !verona.class<"U16">) -> !verona.unknown
-    br ^bb6
-  ^bb6:  // 2 preds: ^bb4, ^bb5
-    br ^bb3
+  }
+  func @double_diamond(%arg0: !verona.class<"bool">, %arg1: !verona.class<"U16">, %arg2: !verona.class<"U16">, %arg3: !verona.class<"U16">, %arg4: !verona.class<"U16">) -> !verona.class<"S16"> attributes {class = !verona.class<"$module">} {
+    %0 = "verona.cast"(%arg0) : (!verona.class<"bool">) -> i1
+    %1 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
+    %2 = "verona.cast"(%arg2) : (!verona.class<"U16">) -> !verona.unknown
+    %3 = "verona.cast"(%arg3) : (!verona.class<"U16">) -> !verona.unknown
+    %4 = "verona.cast"(%arg4) : (!verona.class<"U16">) -> !verona.unknown
+    cond_br %0, ^bb1, ^bb2
+  ^bb1:  // pred: ^bb0
+    %5 = verona.call "=="[%arg1 : !verona.class<"U16">] (%arg2 : !verona.class<"U16">) : !verona.unknown
+    %6 = "verona.cast"(%5) : (!verona.unknown) -> i1
+    %7 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
+    %8 = "verona.cast"(%arg2) : (!verona.class<"U16">) -> !verona.unknown
+    cond_br %6, ^bb4, ^bb5
+  ^bb2:  // pred: ^bb0
+    %9 = verona.call "=="[%arg3 : !verona.class<"U16">] (%arg4 : !verona.class<"U16">) : !verona.unknown
+    %10 = "verona.cast"(%9) : (!verona.unknown) -> i1
+    %11 = "verona.cast"(%arg3) : (!verona.class<"U16">) -> !verona.unknown
+    %12 = "verona.cast"(%arg4) : (!verona.class<"U16">) -> !verona.unknown
+    cond_br %10, ^bb7, ^bb8
+  ^bb3(%13: !verona.unknown, %14: !verona.unknown, %15: !verona.unknown, %16: !verona.unknown):  // 2 preds: ^bb6, ^bb9
+    %17 = verona.call "+"[%13 : !verona.unknown] (%14 : !verona.unknown) : !verona.unknown
+    %18 = verona.call "+"[%15 : !verona.unknown] (%16 : !verona.unknown) : !verona.unknown
+    %19 = "verona.cast"(%18) : (!verona.unknown) -> !verona.class<"S16">
+    return %19 : !verona.class<"S16">
+  ^bb4:  // pred: ^bb1
+    %20 = "verona.constant(1)"() : () -> !verona.class<"int">
+    %21 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
+    %22 = "verona.cast"(%arg2) : (!verona.class<"U16">) -> !verona.unknown
+    br ^bb6(%21, %22 : !verona.unknown, !verona.unknown)
+  ^bb5:  // pred: ^bb1
+    %23 = "verona.constant(2)"() : () -> !verona.class<"int">
+    %24 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
+    %25 = "verona.cast"(%arg2) : (!verona.class<"U16">) -> !verona.unknown
+    br ^bb6(%24, %25 : !verona.unknown, !verona.unknown)
+  ^bb6(%26: !verona.unknown, %27: !verona.unknown):  // 2 preds: ^bb4, ^bb5
+    %28 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
+    %29 = "verona.cast"(%arg2) : (!verona.class<"U16">) -> !verona.unknown
+    %30 = "verona.cast"(%arg3) : (!verona.class<"U16">) -> !verona.unknown
+    %31 = "verona.cast"(%arg4) : (!verona.class<"U16">) -> !verona.unknown
+    br ^bb3(%28, %29, %30, %31 : !verona.unknown, !verona.unknown, !verona.unknown, !verona.unknown)
+  ^bb7:  // pred: ^bb2
+    %32 = "verona.constant(3)"() : () -> !verona.class<"int">
+    %33 = "verona.cast"(%arg3) : (!verona.class<"U16">) -> !verona.unknown
+    %34 = "verona.cast"(%arg4) : (!verona.class<"U16">) -> !verona.unknown
+    br ^bb9(%33, %34 : !verona.unknown, !verona.unknown)
+  ^bb8:  // pred: ^bb2
+    %35 = "verona.constant(4)"() : () -> !verona.class<"int">
+    %36 = "verona.cast"(%arg3) : (!verona.class<"U16">) -> !verona.unknown
+    %37 = "verona.cast"(%arg4) : (!verona.class<"U16">) -> !verona.unknown
+    br ^bb9(%36, %37 : !verona.unknown, !verona.unknown)
+  ^bb9(%38: !verona.unknown, %39: !verona.unknown):  // 2 preds: ^bb7, ^bb8
+    %40 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
+    %41 = "verona.cast"(%arg2) : (!verona.class<"U16">) -> !verona.unknown
+    %42 = "verona.cast"(%arg3) : (!verona.class<"U16">) -> !verona.unknown
+    %43 = "verona.cast"(%arg4) : (!verona.class<"U16">) -> !verona.unknown
+    br ^bb3(%40, %41, %42, %43 : !verona.unknown, !verona.unknown, !verona.unknown, !verona.unknown)
   }
 }

--- a/testsuite/mlir/mlir-parse/conditional/mlir.txt
+++ b/testsuite/mlir/mlir-parse/conditional/mlir.txt
@@ -17,109 +17,97 @@ module @"$module" {
     %0 = "verona.constant(2)"() : () -> !verona.class<"int">
     %1 = verona.call "<"[%arg0 : !verona.class<"U16">] (%0 : !verona.class<"int">) : !verona.unknown
     %2 = "verona.cast"(%1) : (!verona.unknown) -> i1
-    %3 = "verona.cast"(%arg0) : (!verona.class<"U16">) -> !verona.unknown
     cond_br %2, ^bb1, ^bb2
   ^bb1:  // pred: ^bb0
-    %4 = "verona.constant(1)"() : () -> !verona.class<"int">
-    %5 = verona.call "+"[%arg0 : !verona.class<"U16">] (%4 : !verona.class<"int">) : !verona.unknown
-    %6 = "verona.cast"(%arg0) : (!verona.class<"U16">) -> !verona.unknown
-    br ^bb3(%6 : !verona.unknown)
+    %3 = "verona.constant(1)"() : () -> !verona.class<"int">
+    %4 = verona.call "+"[%arg0 : !verona.class<"U16">] (%3 : !verona.class<"int">) : !verona.unknown
+    %5 = "verona.cast"(%arg0) : (!verona.class<"U16">) -> !verona.unknown
+    br ^bb3(%5 : !verona.unknown)
   ^bb2:  // pred: ^bb0
-    %7 = "verona.constant(true)"() : () -> !verona.class<"bool">
-    %8 = "verona.cast"(%7) : (!verona.class<"bool">) -> i1
-    %9 = "verona.cast"(%arg0) : (!verona.class<"U16">) -> !verona.unknown
-    cond_br %8, ^bb4, ^bb5
-  ^bb3(%10: !verona.unknown):  // 2 preds: ^bb1, ^bb6
-    %11 = "verona.cast"(%10) : (!verona.unknown) -> !verona.class<"S16">
-    return %11 : !verona.class<"S16">
+    %6 = "verona.constant(true)"() : () -> !verona.class<"bool">
+    %7 = "verona.cast"(%6) : (!verona.class<"bool">) -> i1
+    cond_br %7, ^bb4, ^bb5
+  ^bb3(%8: !verona.unknown):  // 2 preds: ^bb1, ^bb6
+    %9 = "verona.cast"(%8) : (!verona.unknown) -> !verona.class<"S16">
+    return %9 : !verona.class<"S16">
   ^bb4:  // pred: ^bb2
-    %12 = "verona.constant(1)"() : () -> !verona.class<"int">
-    %13 = verona.call "-"[%arg0 : !verona.class<"U16">] (%12 : !verona.class<"int">) : !verona.unknown
+    %10 = "verona.constant(1)"() : () -> !verona.class<"int">
+    %11 = verona.call "-"[%arg0 : !verona.class<"U16">] (%10 : !verona.class<"int">) : !verona.unknown
+    %12 = "verona.cast"(%arg0) : (!verona.class<"U16">) -> !verona.unknown
+    br ^bb6(%12 : !verona.unknown)
+  ^bb5:  // pred: ^bb2
+    %13 = "verona.constant(0)"() : () -> !verona.class<"int">
     %14 = "verona.cast"(%arg0) : (!verona.class<"U16">) -> !verona.unknown
     br ^bb6(%14 : !verona.unknown)
-  ^bb5:  // pred: ^bb2
-    %15 = "verona.constant(0)"() : () -> !verona.class<"int">
-    %16 = "verona.cast"(%arg0) : (!verona.class<"U16">) -> !verona.unknown
-    br ^bb6(%16 : !verona.unknown)
-  ^bb6(%17: !verona.unknown):  // 2 preds: ^bb4, ^bb5
-    br ^bb3(%17 : !verona.unknown)
+  ^bb6(%15: !verona.unknown):  // 2 preds: ^bb4, ^bb5
+    br ^bb3(%15 : !verona.unknown)
   }
   func @diamond(%arg0: !verona.class<"U16">, %arg1: !verona.class<"U16">) -> !verona.class<"S16"> attributes {class = !verona.class<"$module">} {
     %0 = verona.call ">"[%arg0 : !verona.class<"U16">] (%arg1 : !verona.class<"U16">) : !verona.unknown
     %1 = "verona.cast"(%0) : (!verona.unknown) -> i1
-    %2 = "verona.cast"(%arg0) : (!verona.class<"U16">) -> !verona.unknown
-    %3 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
     cond_br %1, ^bb1, ^bb2
   ^bb1:  // pred: ^bb0
-    %4 = "verona.constant(10)"() : () -> !verona.class<"int">
-    %5 = "verona.cast"(%arg0) : (!verona.class<"U16">) -> !verona.unknown
-    %6 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
-    br ^bb3(%5, %6 : !verona.unknown, !verona.unknown)
+    %2 = "verona.constant(10)"() : () -> !verona.class<"int">
+    %3 = "verona.cast"(%arg0) : (!verona.class<"U16">) -> !verona.unknown
+    %4 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
+    br ^bb3(%3, %4 : !verona.unknown, !verona.unknown)
   ^bb2:  // pred: ^bb0
-    %7 = "verona.constant(20)"() : () -> !verona.class<"int">
-    %8 = "verona.cast"(%arg0) : (!verona.class<"U16">) -> !verona.unknown
-    %9 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
-    br ^bb3(%8, %9 : !verona.unknown, !verona.unknown)
-  ^bb3(%10: !verona.unknown, %11: !verona.unknown):  // 2 preds: ^bb1, ^bb2
-    %12 = verona.call "+"[%10 : !verona.unknown] (%11 : !verona.unknown) : !verona.unknown
-    %13 = "verona.cast"(%12) : (!verona.unknown) -> !verona.class<"S16">
-    return %13 : !verona.class<"S16">
+    %5 = "verona.constant(20)"() : () -> !verona.class<"int">
+    %6 = "verona.cast"(%arg0) : (!verona.class<"U16">) -> !verona.unknown
+    %7 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
+    br ^bb3(%6, %7 : !verona.unknown, !verona.unknown)
+  ^bb3(%8: !verona.unknown, %9: !verona.unknown):  // 2 preds: ^bb1, ^bb2
+    %10 = verona.call "+"[%8 : !verona.unknown] (%9 : !verona.unknown) : !verona.unknown
+    %11 = "verona.cast"(%10) : (!verona.unknown) -> !verona.class<"S16">
+    return %11 : !verona.class<"S16">
   }
   func @double_diamond(%arg0: !verona.class<"bool">, %arg1: !verona.class<"U16">, %arg2: !verona.class<"U16">, %arg3: !verona.class<"U16">, %arg4: !verona.class<"U16">) -> !verona.class<"S16"> attributes {class = !verona.class<"$module">} {
     %0 = "verona.cast"(%arg0) : (!verona.class<"bool">) -> i1
-    %1 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
-    %2 = "verona.cast"(%arg2) : (!verona.class<"U16">) -> !verona.unknown
-    %3 = "verona.cast"(%arg3) : (!verona.class<"U16">) -> !verona.unknown
-    %4 = "verona.cast"(%arg4) : (!verona.class<"U16">) -> !verona.unknown
     cond_br %0, ^bb1, ^bb2
   ^bb1:  // pred: ^bb0
-    %5 = verona.call "=="[%arg1 : !verona.class<"U16">] (%arg2 : !verona.class<"U16">) : !verona.unknown
-    %6 = "verona.cast"(%5) : (!verona.unknown) -> i1
-    %7 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
-    %8 = "verona.cast"(%arg2) : (!verona.class<"U16">) -> !verona.unknown
-    cond_br %6, ^bb4, ^bb5
+    %1 = verona.call "=="[%arg1 : !verona.class<"U16">] (%arg2 : !verona.class<"U16">) : !verona.unknown
+    %2 = "verona.cast"(%1) : (!verona.unknown) -> i1
+    cond_br %2, ^bb4, ^bb5
   ^bb2:  // pred: ^bb0
-    %9 = verona.call "=="[%arg3 : !verona.class<"U16">] (%arg4 : !verona.class<"U16">) : !verona.unknown
-    %10 = "verona.cast"(%9) : (!verona.unknown) -> i1
-    %11 = "verona.cast"(%arg3) : (!verona.class<"U16">) -> !verona.unknown
-    %12 = "verona.cast"(%arg4) : (!verona.class<"U16">) -> !verona.unknown
-    cond_br %10, ^bb7, ^bb8
-  ^bb3(%13: !verona.unknown, %14: !verona.unknown, %15: !verona.unknown, %16: !verona.unknown):  // 2 preds: ^bb6, ^bb9
-    %17 = verona.call "+"[%13 : !verona.unknown] (%14 : !verona.unknown) : !verona.unknown
-    %18 = verona.call "+"[%15 : !verona.unknown] (%16 : !verona.unknown) : !verona.unknown
-    %19 = "verona.cast"(%18) : (!verona.unknown) -> !verona.class<"S16">
-    return %19 : !verona.class<"S16">
+    %3 = verona.call "=="[%arg3 : !verona.class<"U16">] (%arg4 : !verona.class<"U16">) : !verona.unknown
+    %4 = "verona.cast"(%3) : (!verona.unknown) -> i1
+    cond_br %4, ^bb7, ^bb8
+  ^bb3(%5: !verona.unknown, %6: !verona.unknown, %7: !verona.unknown, %8: !verona.unknown):  // 2 preds: ^bb6, ^bb9
+    %9 = verona.call "+"[%5 : !verona.unknown] (%6 : !verona.unknown) : !verona.unknown
+    %10 = verona.call "+"[%7 : !verona.unknown] (%8 : !verona.unknown) : !verona.unknown
+    %11 = "verona.cast"(%10) : (!verona.unknown) -> !verona.class<"S16">
+    return %11 : !verona.class<"S16">
   ^bb4:  // pred: ^bb1
-    %20 = "verona.constant(1)"() : () -> !verona.class<"int">
-    %21 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
-    %22 = "verona.cast"(%arg2) : (!verona.class<"U16">) -> !verona.unknown
-    br ^bb6(%21, %22 : !verona.unknown, !verona.unknown)
+    %12 = "verona.constant(1)"() : () -> !verona.class<"int">
+    %13 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
+    %14 = "verona.cast"(%arg2) : (!verona.class<"U16">) -> !verona.unknown
+    br ^bb6(%13, %14 : !verona.unknown, !verona.unknown)
   ^bb5:  // pred: ^bb1
-    %23 = "verona.constant(2)"() : () -> !verona.class<"int">
-    %24 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
-    %25 = "verona.cast"(%arg2) : (!verona.class<"U16">) -> !verona.unknown
-    br ^bb6(%24, %25 : !verona.unknown, !verona.unknown)
-  ^bb6(%26: !verona.unknown, %27: !verona.unknown):  // 2 preds: ^bb4, ^bb5
-    %28 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
-    %29 = "verona.cast"(%arg2) : (!verona.class<"U16">) -> !verona.unknown
-    %30 = "verona.cast"(%arg3) : (!verona.class<"U16">) -> !verona.unknown
-    %31 = "verona.cast"(%arg4) : (!verona.class<"U16">) -> !verona.unknown
-    br ^bb3(%28, %29, %30, %31 : !verona.unknown, !verona.unknown, !verona.unknown, !verona.unknown)
+    %15 = "verona.constant(2)"() : () -> !verona.class<"int">
+    %16 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
+    %17 = "verona.cast"(%arg2) : (!verona.class<"U16">) -> !verona.unknown
+    br ^bb6(%16, %17 : !verona.unknown, !verona.unknown)
+  ^bb6(%18: !verona.unknown, %19: !verona.unknown):  // 2 preds: ^bb4, ^bb5
+    %20 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
+    %21 = "verona.cast"(%arg2) : (!verona.class<"U16">) -> !verona.unknown
+    %22 = "verona.cast"(%arg3) : (!verona.class<"U16">) -> !verona.unknown
+    %23 = "verona.cast"(%arg4) : (!verona.class<"U16">) -> !verona.unknown
+    br ^bb3(%20, %21, %22, %23 : !verona.unknown, !verona.unknown, !verona.unknown, !verona.unknown)
   ^bb7:  // pred: ^bb2
-    %32 = "verona.constant(3)"() : () -> !verona.class<"int">
-    %33 = "verona.cast"(%arg3) : (!verona.class<"U16">) -> !verona.unknown
-    %34 = "verona.cast"(%arg4) : (!verona.class<"U16">) -> !verona.unknown
-    br ^bb9(%33, %34 : !verona.unknown, !verona.unknown)
+    %24 = "verona.constant(3)"() : () -> !verona.class<"int">
+    %25 = "verona.cast"(%arg3) : (!verona.class<"U16">) -> !verona.unknown
+    %26 = "verona.cast"(%arg4) : (!verona.class<"U16">) -> !verona.unknown
+    br ^bb9(%25, %26 : !verona.unknown, !verona.unknown)
   ^bb8:  // pred: ^bb2
-    %35 = "verona.constant(4)"() : () -> !verona.class<"int">
-    %36 = "verona.cast"(%arg3) : (!verona.class<"U16">) -> !verona.unknown
-    %37 = "verona.cast"(%arg4) : (!verona.class<"U16">) -> !verona.unknown
-    br ^bb9(%36, %37 : !verona.unknown, !verona.unknown)
-  ^bb9(%38: !verona.unknown, %39: !verona.unknown):  // 2 preds: ^bb7, ^bb8
-    %40 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
-    %41 = "verona.cast"(%arg2) : (!verona.class<"U16">) -> !verona.unknown
-    %42 = "verona.cast"(%arg3) : (!verona.class<"U16">) -> !verona.unknown
-    %43 = "verona.cast"(%arg4) : (!verona.class<"U16">) -> !verona.unknown
-    br ^bb3(%40, %41, %42, %43 : !verona.unknown, !verona.unknown, !verona.unknown, !verona.unknown)
+    %27 = "verona.constant(4)"() : () -> !verona.class<"int">
+    %28 = "verona.cast"(%arg3) : (!verona.class<"U16">) -> !verona.unknown
+    %29 = "verona.cast"(%arg4) : (!verona.class<"U16">) -> !verona.unknown
+    br ^bb9(%28, %29 : !verona.unknown, !verona.unknown)
+  ^bb9(%30: !verona.unknown, %31: !verona.unknown):  // 2 preds: ^bb7, ^bb8
+    %32 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
+    %33 = "verona.cast"(%arg2) : (!verona.class<"U16">) -> !verona.unknown
+    %34 = "verona.cast"(%arg3) : (!verona.class<"U16">) -> !verona.unknown
+    %35 = "verona.cast"(%arg4) : (!verona.class<"U16">) -> !verona.unknown
+    br ^bb3(%32, %33, %34, %35 : !verona.unknown, !verona.unknown, !verona.unknown, !verona.unknown)
   }
 }

--- a/testsuite/mlir/mlir-parse/conditional/mlir.txt
+++ b/testsuite/mlir/mlir-parse/conditional/mlir.txt
@@ -6,7 +6,7 @@ module @"$module" {
     cond_br %1, ^bb1, ^bb2(%2 : !verona.unknown)
   ^bb1:  // pred: ^bb0
     %3 = "verona.constant(42)"() : () -> !verona.class<"int">
-    %4 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
+    %4 = "verona.cast"(%3) : (!verona.class<"int">) -> !verona.unknown
     br ^bb2(%4 : !verona.unknown)
   ^bb2(%5: !verona.unknown):  // 2 preds: ^bb0, ^bb1
     %6 = verona.call "+"[%arg0 : !verona.class<"U16">] (%5 : !verona.unknown) : !verona.unknown
@@ -21,26 +21,24 @@ module @"$module" {
   ^bb1:  // pred: ^bb0
     %3 = "verona.constant(1)"() : () -> !verona.class<"int">
     %4 = verona.call "+"[%arg0 : !verona.class<"U16">] (%3 : !verona.class<"int">) : !verona.unknown
-    %5 = "verona.cast"(%arg0) : (!verona.class<"U16">) -> !verona.unknown
-    br ^bb3(%5 : !verona.unknown)
+    br ^bb3(%4 : !verona.unknown)
   ^bb2:  // pred: ^bb0
-    %6 = "verona.constant(true)"() : () -> !verona.class<"bool">
-    %7 = "verona.cast"(%6) : (!verona.class<"bool">) -> i1
-    cond_br %7, ^bb4, ^bb5
-  ^bb3(%8: !verona.unknown):  // 2 preds: ^bb1, ^bb6
-    %9 = "verona.cast"(%8) : (!verona.unknown) -> !verona.class<"S16">
-    return %9 : !verona.class<"S16">
+    %5 = "verona.constant(true)"() : () -> !verona.class<"bool">
+    %6 = "verona.cast"(%5) : (!verona.class<"bool">) -> i1
+    cond_br %6, ^bb4, ^bb5
+  ^bb3(%7: !verona.unknown):  // 2 preds: ^bb1, ^bb6
+    %8 = "verona.cast"(%7) : (!verona.unknown) -> !verona.class<"S16">
+    return %8 : !verona.class<"S16">
   ^bb4:  // pred: ^bb2
-    %10 = "verona.constant(1)"() : () -> !verona.class<"int">
-    %11 = verona.call "-"[%arg0 : !verona.class<"U16">] (%10 : !verona.class<"int">) : !verona.unknown
-    %12 = "verona.cast"(%arg0) : (!verona.class<"U16">) -> !verona.unknown
-    br ^bb6(%12 : !verona.unknown)
+    %9 = "verona.constant(1)"() : () -> !verona.class<"int">
+    %10 = verona.call "-"[%arg0 : !verona.class<"U16">] (%9 : !verona.class<"int">) : !verona.unknown
+    br ^bb6(%10 : !verona.unknown)
   ^bb5:  // pred: ^bb2
-    %13 = "verona.constant(0)"() : () -> !verona.class<"int">
-    %14 = "verona.cast"(%arg0) : (!verona.class<"U16">) -> !verona.unknown
-    br ^bb6(%14 : !verona.unknown)
-  ^bb6(%15: !verona.unknown):  // 2 preds: ^bb4, ^bb5
-    br ^bb3(%15 : !verona.unknown)
+    %11 = "verona.constant(0)"() : () -> !verona.class<"int">
+    %12 = "verona.cast"(%11) : (!verona.class<"int">) -> !verona.unknown
+    br ^bb6(%12 : !verona.unknown)
+  ^bb6(%13: !verona.unknown):  // 2 preds: ^bb4, ^bb5
+    br ^bb3(%13 : !verona.unknown)
   }
   func @diamond(%arg0: !verona.class<"U16">, %arg1: !verona.class<"U16">) -> !verona.class<"S16"> attributes {class = !verona.class<"$module">} {
     %0 = verona.call ">"[%arg0 : !verona.class<"U16">] (%arg1 : !verona.class<"U16">) : !verona.unknown
@@ -48,13 +46,13 @@ module @"$module" {
     cond_br %1, ^bb1, ^bb2
   ^bb1:  // pred: ^bb0
     %2 = "verona.constant(10)"() : () -> !verona.class<"int">
-    %3 = "verona.cast"(%arg0) : (!verona.class<"U16">) -> !verona.unknown
+    %3 = "verona.cast"(%2) : (!verona.class<"int">) -> !verona.unknown
     %4 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
     br ^bb3(%3, %4 : !verona.unknown, !verona.unknown)
   ^bb2:  // pred: ^bb0
     %5 = "verona.constant(20)"() : () -> !verona.class<"int">
     %6 = "verona.cast"(%arg0) : (!verona.class<"U16">) -> !verona.unknown
-    %7 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
+    %7 = "verona.cast"(%5) : (!verona.class<"int">) -> !verona.unknown
     br ^bb3(%6, %7 : !verona.unknown, !verona.unknown)
   ^bb3(%8: !verona.unknown, %9: !verona.unknown):  // 2 preds: ^bb1, ^bb2
     %10 = verona.call "+"[%8 : !verona.unknown] (%9 : !verona.unknown) : !verona.unknown
@@ -79,35 +77,47 @@ module @"$module" {
     return %11 : !verona.class<"S16">
   ^bb4:  // pred: ^bb1
     %12 = "verona.constant(1)"() : () -> !verona.class<"int">
-    %13 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
+    %13 = "verona.cast"(%12) : (!verona.class<"int">) -> !verona.unknown
     %14 = "verona.cast"(%arg2) : (!verona.class<"U16">) -> !verona.unknown
     br ^bb6(%13, %14 : !verona.unknown, !verona.unknown)
   ^bb5:  // pred: ^bb1
     %15 = "verona.constant(2)"() : () -> !verona.class<"int">
     %16 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
-    %17 = "verona.cast"(%arg2) : (!verona.class<"U16">) -> !verona.unknown
+    %17 = "verona.cast"(%15) : (!verona.class<"int">) -> !verona.unknown
     br ^bb6(%16, %17 : !verona.unknown, !verona.unknown)
   ^bb6(%18: !verona.unknown, %19: !verona.unknown):  // 2 preds: ^bb4, ^bb5
-    %20 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
-    %21 = "verona.cast"(%arg2) : (!verona.class<"U16">) -> !verona.unknown
-    %22 = "verona.cast"(%arg3) : (!verona.class<"U16">) -> !verona.unknown
-    %23 = "verona.cast"(%arg4) : (!verona.class<"U16">) -> !verona.unknown
-    br ^bb3(%20, %21, %22, %23 : !verona.unknown, !verona.unknown, !verona.unknown, !verona.unknown)
+    %20 = "verona.cast"(%arg3) : (!verona.class<"U16">) -> !verona.unknown
+    %21 = "verona.cast"(%arg4) : (!verona.class<"U16">) -> !verona.unknown
+    br ^bb3(%18, %19, %20, %21 : !verona.unknown, !verona.unknown, !verona.unknown, !verona.unknown)
   ^bb7:  // pred: ^bb2
-    %24 = "verona.constant(3)"() : () -> !verona.class<"int">
-    %25 = "verona.cast"(%arg3) : (!verona.class<"U16">) -> !verona.unknown
-    %26 = "verona.cast"(%arg4) : (!verona.class<"U16">) -> !verona.unknown
-    br ^bb9(%25, %26 : !verona.unknown, !verona.unknown)
+    %22 = "verona.constant(3)"() : () -> !verona.class<"int">
+    %23 = "verona.cast"(%22) : (!verona.class<"int">) -> !verona.unknown
+    %24 = "verona.cast"(%arg4) : (!verona.class<"U16">) -> !verona.unknown
+    br ^bb9(%23, %24 : !verona.unknown, !verona.unknown)
   ^bb8:  // pred: ^bb2
-    %27 = "verona.constant(4)"() : () -> !verona.class<"int">
-    %28 = "verona.cast"(%arg3) : (!verona.class<"U16">) -> !verona.unknown
-    %29 = "verona.cast"(%arg4) : (!verona.class<"U16">) -> !verona.unknown
-    br ^bb9(%28, %29 : !verona.unknown, !verona.unknown)
-  ^bb9(%30: !verona.unknown, %31: !verona.unknown):  // 2 preds: ^bb7, ^bb8
-    %32 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
-    %33 = "verona.cast"(%arg2) : (!verona.class<"U16">) -> !verona.unknown
-    %34 = "verona.cast"(%arg3) : (!verona.class<"U16">) -> !verona.unknown
-    %35 = "verona.cast"(%arg4) : (!verona.class<"U16">) -> !verona.unknown
-    br ^bb3(%32, %33, %34, %35 : !verona.unknown, !verona.unknown, !verona.unknown, !verona.unknown)
+    %25 = "verona.constant(4)"() : () -> !verona.class<"int">
+    %26 = "verona.cast"(%arg3) : (!verona.class<"U16">) -> !verona.unknown
+    %27 = "verona.cast"(%25) : (!verona.class<"int">) -> !verona.unknown
+    br ^bb9(%26, %27 : !verona.unknown, !verona.unknown)
+  ^bb9(%28: !verona.unknown, %29: !verona.unknown):  // 2 preds: ^bb7, ^bb8
+    %30 = "verona.cast"(%arg1) : (!verona.class<"U16">) -> !verona.unknown
+    %31 = "verona.cast"(%arg2) : (!verona.class<"U16">) -> !verona.unknown
+    br ^bb3(%30, %31, %28, %29 : !verona.unknown, !verona.unknown, !verona.unknown, !verona.unknown)
+  }
+  module @A {
+    func @m() -> !verona.class<"A", "$parent" : class<"$module">, "x" : class<"U32">> attributes {class = !verona.class<"A", "$parent" : class<"$module">, "x" : class<"U32">>}
+  }
+  func @method_test(%arg0: !verona.meet<class<"A", "$parent" : class<"$module">, "x" : class<"U32">>, mut>) -> !verona.class<"U32"> attributes {class = !verona.class<"$module">} {
+    %0 = "verona.constant(true)"() : () -> !verona.class<"bool">
+    %1 = "verona.cast"(%0) : (!verona.class<"bool">) -> i1
+    %2 = "verona.cast"(%arg0) : (!verona.meet<class<"A", "$parent" : class<"$module">, "x" : class<"U32">>, mut>) -> !verona.unknown
+    cond_br %1, ^bb1, ^bb2(%2 : !verona.unknown)
+  ^bb1:  // pred: ^bb0
+    %3 = verona.call "m"[%arg0 : !verona.meet<class<"A", "$parent" : class<"$module">, "x" : class<"U32">>, mut>] ( : ) : !verona.unknown
+    br ^bb2(%3 : !verona.unknown)
+  ^bb2(%4: !verona.unknown):  // 2 preds: ^bb0, ^bb1
+    %5 = verona.field_read %4["x"] : !verona.unknown -> !verona.unknown
+    %6 = "verona.cast"(%5) : (!verona.unknown) -> !verona.class<"U32">
+    return %6 : !verona.class<"U32">
   }
 }

--- a/testsuite/mlir/mlir-parse/constant/mlir.txt
+++ b/testsuite/mlir/mlir-parse/constant/mlir.txt
@@ -1,35 +1,19 @@
 module @"$module" {
   func @f() attributes {class = !verona.class<"$module">} {
     %0 = "verona.constant(42)"() : () -> !verona.class<"int">
-    %1 = "verona.alloca"() : () -> !verona.unknown
-    %2 = "verona.store"(%0, %1) : (!verona.class<"int">, !verona.unknown) -> !verona.unknown
-    %3 = "verona.constant(3.1415)"() : () -> !verona.class<"float">
-    %4 = "verona.alloca"() : () -> !verona.unknown
-    %5 = "verona.store"(%3, %4) : (!verona.class<"float">, !verona.unknown) -> !verona.unknown
-    %6 = "verona.constant(true)"() : () -> !verona.class<"bool">
-    %7 = "verona.alloca"() : () -> !verona.unknown
-    %8 = "verona.store"(%6, %7) : (!verona.class<"bool">, !verona.unknown) -> !verona.unknown
-    %9 = "verona.constant(0xAE)"() : () -> !verona.class<"hex">
-    %10 = "verona.alloca"() : () -> !verona.unknown
-    %11 = "verona.store"(%9, %10) : (!verona.class<"hex">, !verona.unknown) -> !verona.unknown
-    %12 = "verona.constant(0b11011)"() : () -> !verona.class<"binary">
-    %13 = "verona.alloca"() : () -> !verona.unknown
-    %14 = "verona.store"(%12, %13) : (!verona.class<"binary">, !verona.unknown) -> !verona.unknown
-    %15 = "verona.constant(42)"() : () -> !verona.class<"int">
-    %16 = "verona.alloca"() : () -> !verona.class<"S32">
-    %17 = "verona.store"(%15, %16) : (!verona.class<"int">, !verona.class<"S32">) -> !verona.unknown
-    %18 = "verona.constant(3.1415)"() : () -> !verona.class<"float">
-    %19 = "verona.alloca"() : () -> !verona.class<"F32">
-    %20 = "verona.store"(%18, %19) : (!verona.class<"float">, !verona.class<"F32">) -> !verona.unknown
-    %21 = "verona.constant(false)"() : () -> !verona.class<"bool">
-    %22 = "verona.alloca"() : () -> !verona.class<"bool">
-    %23 = "verona.store"(%21, %22) : (!verona.class<"bool">, !verona.class<"bool">) -> !verona.unknown
-    %24 = "verona.constant(0xDEADBEEF)"() : () -> !verona.class<"hex">
-    %25 = "verona.alloca"() : () -> !verona.class<"U32">
-    %26 = "verona.store"(%24, %25) : (!verona.class<"hex">, !verona.class<"U32">) -> !verona.unknown
-    %27 = "verona.constant(0b1)"() : () -> !verona.class<"binary">
-    %28 = "verona.alloca"() : () -> !verona.class<"bool">
-    %29 = "verona.store"(%27, %28) : (!verona.class<"binary">, !verona.class<"bool">) -> !verona.unknown
+    %1 = "verona.constant(3.1415)"() : () -> !verona.class<"float">
+    %2 = "verona.constant(true)"() : () -> !verona.class<"bool">
+    %3 = "verona.constant(0xAE)"() : () -> !verona.class<"hex">
+    %4 = "verona.constant(0b11011)"() : () -> !verona.class<"binary">
+    %5 = "verona.constant(42)"() : () -> !verona.class<"int">
+    %6 = "verona.cast"(%5) : (!verona.class<"int">) -> !verona.class<"S32">
+    %7 = "verona.constant(3.1415)"() : () -> !verona.class<"float">
+    %8 = "verona.cast"(%7) : (!verona.class<"float">) -> !verona.class<"F32">
+    %9 = "verona.constant(false)"() : () -> !verona.class<"bool">
+    %10 = "verona.constant(0xDEADBEEF)"() : () -> !verona.class<"hex">
+    %11 = "verona.cast"(%10) : (!verona.class<"hex">) -> !verona.class<"U32">
+    %12 = "verona.constant(0b1)"() : () -> !verona.class<"binary">
+    %13 = "verona.cast"(%12) : (!verona.class<"binary">) -> !verona.class<"bool">
     return
   }
 }

--- a/testsuite/mlir/mlir-parse/for-sugar/mlir.txt
+++ b/testsuite/mlir/mlir-parse/for-sugar/mlir.txt
@@ -13,7 +13,7 @@ module @"$module" {
     %8 = verona.call "apply"[%2 : !verona.unknown] ( : ) : !verona.unknown
     %9 = verona.call "next"[%2 : !verona.unknown] ( : ) : !verona.unknown
     %10 = verona.call "+"[%7 : !verona.unknown] (%8 : !verona.unknown) : !verona.unknown
-    br ^bb1(%7 : !verona.unknown)
+    br ^bb1(%10 : !verona.unknown)
   ^bb3(%11: !verona.unknown):  // pred: ^bb1
     %12 = "verona.cast"(%11) : (!verona.unknown) -> !verona.class<"U32">
     return %12 : !verona.class<"U32">
@@ -32,7 +32,7 @@ module @"$module" {
     %8 = verona.call "apply"[%2 : !verona.unknown] ( : ) : !verona.unknown
     %9 = verona.call "next"[%2 : !verona.unknown] ( : ) : !verona.unknown
     %10 = verona.call "+"[%7 : !verona.unknown] (%8 : !verona.unknown) : !verona.unknown
-    br ^bb1(%7 : !verona.unknown)
+    br ^bb1(%10 : !verona.unknown)
   ^bb3(%11: !verona.unknown):  // pred: ^bb1
     %12 = "verona.cast"(%11) : (!verona.unknown) -> !verona.class<"U32">
     return %12 : !verona.class<"U32">

--- a/testsuite/mlir/mlir-parse/for-sugar/mlir.txt
+++ b/testsuite/mlir/mlir-parse/for-sugar/mlir.txt
@@ -1,68 +1,40 @@
 module @"$module" {
   func @for_sum(%arg0: !verona.class<"List">) -> !verona.class<"U32"> attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !verona.class<"List">
-    %1 = "verona.store"(%arg0, %0) : (!verona.class<"List">, !verona.class<"List">) -> !verona.unknown
-    %2 = "verona.constant(0)"() : () -> !verona.class<"int">
-    %3 = "verona.alloca"() : () -> !verona.class<"U32">
-    %4 = "verona.store"(%2, %3) : (!verona.class<"int">, !verona.class<"U32">) -> !verona.unknown
-    %5 = "verona.load"(%0) : (!verona.class<"List">) -> !verona.unknown
-    %6 = verona.call "values"[%5 : !verona.unknown] ( : ) : !verona.unknown
-    %7 = "verona.alloca"() : () -> !verona.unknown
-    %8 = "verona.store"(%6, %7) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    br ^bb1
-  ^bb1:  // 2 preds: ^bb0, ^bb2
-    %9 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
-    %10 = verona.call "has_value"[%9 : !verona.unknown] ( : ) : !verona.unknown
-    %11 = "verona.cast"(%10) : (!verona.unknown) -> i1
-    cond_br %11, ^bb2, ^bb3
-  ^bb2:  // pred: ^bb1
-    %12 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
-    %13 = verona.call "apply"[%12 : !verona.unknown] ( : ) : !verona.unknown
-    %14 = "verona.alloca"() : () -> !verona.unknown
-    %15 = "verona.store"(%13, %14) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    %16 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
-    %17 = verona.call "next"[%16 : !verona.unknown] ( : ) : !verona.unknown
-    %18 = "verona.load"(%3) : (!verona.class<"U32">) -> !verona.unknown
-    %19 = "verona.load"(%14) : (!verona.unknown) -> !verona.unknown
-    %20 = verona.call "+"[%18 : !verona.unknown] (%19 : !verona.unknown) : !verona.unknown
-    %21 = "verona.store"(%20, %3) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
-    br ^bb1
-  ^bb3:  // pred: ^bb1
-    %22 = "verona.load"(%3) : (!verona.class<"U32">) -> !verona.unknown
-    %23 = "verona.cast"(%22) : (!verona.unknown) -> !verona.class<"U32">
-    return %23 : !verona.class<"U32">
+    %0 = "verona.constant(0)"() : () -> !verona.class<"int">
+    %1 = "verona.cast"(%0) : (!verona.class<"int">) -> !verona.class<"U32">
+    %2 = verona.call "values"[%arg0 : !verona.class<"List">] ( : ) : !verona.unknown
+    %3 = "verona.cast"(%1) : (!verona.class<"U32">) -> !verona.unknown
+    br ^bb1(%3 : !verona.unknown)
+  ^bb1(%4: !verona.unknown):  // 2 preds: ^bb0, ^bb2
+    %5 = verona.call "has_value"[%2 : !verona.unknown] ( : ) : !verona.unknown
+    %6 = "verona.cast"(%5) : (!verona.unknown) -> i1
+    cond_br %6, ^bb2(%4 : !verona.unknown), ^bb3(%4 : !verona.unknown)
+  ^bb2(%7: !verona.unknown):  // pred: ^bb1
+    %8 = verona.call "apply"[%2 : !verona.unknown] ( : ) : !verona.unknown
+    %9 = verona.call "next"[%2 : !verona.unknown] ( : ) : !verona.unknown
+    %10 = verona.call "+"[%7 : !verona.unknown] (%8 : !verona.unknown) : !verona.unknown
+    br ^bb1(%7 : !verona.unknown)
+  ^bb3(%11: !verona.unknown):  // pred: ^bb1
+    %12 = "verona.cast"(%11) : (!verona.unknown) -> !verona.class<"U32">
+    return %12 : !verona.class<"U32">
   }
   func @while_sum(%arg0: !verona.class<"List">) -> !verona.class<"U32"> attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !verona.class<"List">
-    %1 = "verona.store"(%arg0, %0) : (!verona.class<"List">, !verona.class<"List">) -> !verona.unknown
-    %2 = "verona.constant(0)"() : () -> !verona.class<"int">
-    %3 = "verona.alloca"() : () -> !verona.class<"U32">
-    %4 = "verona.store"(%2, %3) : (!verona.class<"int">, !verona.class<"U32">) -> !verona.unknown
-    %5 = "verona.load"(%0) : (!verona.class<"List">) -> !verona.unknown
-    %6 = verona.call "values"[%5 : !verona.unknown] ( : ) : !verona.unknown
-    %7 = "verona.alloca"() : () -> !verona.unknown
-    %8 = "verona.store"(%6, %7) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    br ^bb1
-  ^bb1:  // 2 preds: ^bb0, ^bb2
-    %9 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
-    %10 = verona.call "has_value"[%9 : !verona.unknown] ( : ) : !verona.unknown
-    %11 = "verona.cast"(%10) : (!verona.unknown) -> i1
-    cond_br %11, ^bb2, ^bb3
-  ^bb2:  // pred: ^bb1
-    %12 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
-    %13 = verona.call "apply"[%12 : !verona.unknown] ( : ) : !verona.unknown
-    %14 = "verona.alloca"() : () -> !verona.unknown
-    %15 = "verona.store"(%13, %14) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    %16 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
-    %17 = verona.call "next"[%16 : !verona.unknown] ( : ) : !verona.unknown
-    %18 = "verona.load"(%3) : (!verona.class<"U32">) -> !verona.unknown
-    %19 = "verona.load"(%14) : (!verona.unknown) -> !verona.unknown
-    %20 = verona.call "+"[%18 : !verona.unknown] (%19 : !verona.unknown) : !verona.unknown
-    %21 = "verona.store"(%20, %3) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
-    br ^bb1
-  ^bb3:  // pred: ^bb1
-    %22 = "verona.load"(%3) : (!verona.class<"U32">) -> !verona.unknown
-    %23 = "verona.cast"(%22) : (!verona.unknown) -> !verona.class<"U32">
-    return %23 : !verona.class<"U32">
+    %0 = "verona.constant(0)"() : () -> !verona.class<"int">
+    %1 = "verona.cast"(%0) : (!verona.class<"int">) -> !verona.class<"U32">
+    %2 = verona.call "values"[%arg0 : !verona.class<"List">] ( : ) : !verona.unknown
+    %3 = "verona.cast"(%1) : (!verona.class<"U32">) -> !verona.unknown
+    br ^bb1(%3 : !verona.unknown)
+  ^bb1(%4: !verona.unknown):  // 2 preds: ^bb0, ^bb2
+    %5 = verona.call "has_value"[%2 : !verona.unknown] ( : ) : !verona.unknown
+    %6 = "verona.cast"(%5) : (!verona.unknown) -> i1
+    cond_br %6, ^bb2(%4 : !verona.unknown), ^bb3(%4 : !verona.unknown)
+  ^bb2(%7: !verona.unknown):  // pred: ^bb1
+    %8 = verona.call "apply"[%2 : !verona.unknown] ( : ) : !verona.unknown
+    %9 = verona.call "next"[%2 : !verona.unknown] ( : ) : !verona.unknown
+    %10 = verona.call "+"[%7 : !verona.unknown] (%8 : !verona.unknown) : !verona.unknown
+    br ^bb1(%7 : !verona.unknown)
+  ^bb3(%11: !verona.unknown):  // pred: ^bb1
+    %12 = "verona.cast"(%11) : (!verona.unknown) -> !verona.class<"U32">
+    return %12 : !verona.class<"U32">
   }
 }

--- a/testsuite/mlir/mlir-parse/for/mlir.txt
+++ b/testsuite/mlir/mlir-parse/for/mlir.txt
@@ -1,77 +1,54 @@
 module @"$module" {
   func @foo(!verona.class<"S32">) attributes {class = !verona.class<"$module">}
   func @f(%arg0: !verona.class<"U64">) attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !verona.class<"U64">
-    %1 = "verona.store"(%arg0, %0) : (!verona.class<"U64">, !verona.class<"U64">) -> !verona.unknown
-    %2 = "verona.constant(0)"() : () -> !verona.class<"int">
-    %3 = "verona.alloca"() : () -> !verona.class<"S32">
-    %4 = "verona.store"(%2, %3) : (!verona.class<"int">, !verona.class<"S32">) -> !verona.unknown
-    %5 = "verona.load"(%0) : (!verona.class<"U64">) -> !verona.unknown
-    %6 = "verona.alloca"() : () -> !verona.unknown
-    %7 = "verona.store"(%5, %6) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    br ^bb1
-  ^bb1:  // 2 preds: ^bb0, ^bb2
-    %8 = "verona.load"(%6) : (!verona.unknown) -> !verona.unknown
-    %9 = verona.call "has_value"[%8 : !verona.unknown] ( : ) : !verona.unknown
-    %10 = "verona.cast"(%9) : (!verona.unknown) -> i1
-    cond_br %10, ^bb2, ^bb3
-  ^bb2:  // pred: ^bb1
-    %11 = "verona.load"(%6) : (!verona.unknown) -> !verona.unknown
-    %12 = verona.call "apply"[%11 : !verona.unknown] ( : ) : !verona.unknown
-    %13 = "verona.store"(%12, %3) : (!verona.unknown, !verona.class<"S32">) -> !verona.unknown
-    %14 = "verona.load"(%6) : (!verona.unknown) -> !verona.unknown
-    %15 = verona.call "next"[%14 : !verona.unknown] ( : ) : !verona.unknown
-    %16 = "verona.load"(%3) : (!verona.class<"S32">) -> !verona.unknown
-    %17 = verona.call "foo"[%16 : !verona.unknown] ( : ) : !verona.unknown
-    br ^bb1
-  ^bb3:  // pred: ^bb1
+    %0 = "verona.constant(0)"() : () -> !verona.class<"int">
+    %1 = "verona.cast"(%0) : (!verona.class<"int">) -> !verona.class<"S32">
+    %2 = "verona.cast"(%1) : (!verona.class<"S32">) -> !verona.unknown
+    br ^bb1(%2 : !verona.unknown)
+  ^bb1(%3: !verona.unknown):  // 2 preds: ^bb0, ^bb2
+    %4 = verona.call "has_value"[%arg0 : !verona.class<"U64">] ( : ) : !verona.unknown
+    %5 = "verona.cast"(%4) : (!verona.unknown) -> i1
+    cond_br %5, ^bb2(%3 : !verona.unknown), ^bb3(%3 : !verona.unknown)
+  ^bb2(%6: !verona.unknown):  // pred: ^bb1
+    %7 = verona.call "apply"[%arg0 : !verona.class<"U64">] ( : ) : !verona.unknown
+    %8 = verona.call "next"[%arg0 : !verona.class<"U64">] ( : ) : !verona.unknown
+    %9 = verona.call "foo"[%7 : !verona.unknown] ( : ) : !verona.unknown
+    br ^bb1(%6 : !verona.unknown)
+  ^bb3(%10: !verona.unknown):  // pred: ^bb1
     return
   }
   func @f2(%arg0: !verona.class<"U64">) attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !verona.class<"U64">
-    %1 = "verona.store"(%arg0, %0) : (!verona.class<"U64">, !verona.class<"U64">) -> !verona.unknown
-    %2 = "verona.constant(0)"() : () -> !verona.class<"int">
-    %3 = "verona.alloca"() : () -> !verona.class<"S32">
-    %4 = "verona.store"(%2, %3) : (!verona.class<"int">, !verona.class<"S32">) -> !verona.unknown
-    %5 = "verona.load"(%0) : (!verona.class<"U64">) -> !verona.unknown
-    %6 = "verona.alloca"() : () -> !verona.unknown
-    %7 = "verona.store"(%5, %6) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    br ^bb1
-  ^bb1:  // 3 preds: ^bb0, ^bb6, ^bb7
-    %8 = "verona.load"(%6) : (!verona.unknown) -> !verona.unknown
-    %9 = verona.call "has_value"[%8 : !verona.unknown] ( : ) : !verona.unknown
-    %10 = "verona.cast"(%9) : (!verona.unknown) -> i1
-    cond_br %10, ^bb2, ^bb3
-  ^bb2:  // pred: ^bb1
-    %11 = "verona.load"(%6) : (!verona.unknown) -> !verona.unknown
-    %12 = verona.call "apply"[%11 : !verona.unknown] ( : ) : !verona.unknown
-    %13 = "verona.store"(%12, %3) : (!verona.unknown, !verona.class<"S32">) -> !verona.unknown
-    %14 = "verona.load"(%6) : (!verona.unknown) -> !verona.unknown
-    %15 = verona.call "next"[%14 : !verona.unknown] ( : ) : !verona.unknown
-    %16 = "verona.load"(%3) : (!verona.class<"S32">) -> !verona.unknown
-    %17 = verona.call "foo"[%16 : !verona.unknown] ( : ) : !verona.unknown
-    %18 = "verona.load"(%3) : (!verona.class<"S32">) -> !verona.unknown
-    %19 = "verona.constant(5)"() : () -> !verona.class<"int">
-    %20 = verona.call ">"[%18 : !verona.unknown] (%19 : !verona.class<"int">) : !verona.unknown
-    %21 = "verona.cast"(%20) : (!verona.unknown) -> i1
-    cond_br %21, ^bb4, ^bb5
-  ^bb3:  // 2 preds: ^bb1, ^bb4
+    %0 = "verona.constant(0)"() : () -> !verona.class<"int">
+    %1 = "verona.cast"(%0) : (!verona.class<"int">) -> !verona.class<"S32">
+    %2 = "verona.cast"(%1) : (!verona.class<"S32">) -> !verona.unknown
+    br ^bb1(%2 : !verona.unknown)
+  ^bb1(%3: !verona.unknown):  // 3 preds: ^bb0, ^bb6, ^bb7
+    %4 = verona.call "has_value"[%arg0 : !verona.class<"U64">] ( : ) : !verona.unknown
+    %5 = "verona.cast"(%4) : (!verona.unknown) -> i1
+    cond_br %5, ^bb2(%3 : !verona.unknown), ^bb3(%3 : !verona.unknown)
+  ^bb2(%6: !verona.unknown):  // pred: ^bb1
+    %7 = verona.call "apply"[%arg0 : !verona.class<"U64">] ( : ) : !verona.unknown
+    %8 = verona.call "next"[%arg0 : !verona.class<"U64">] ( : ) : !verona.unknown
+    %9 = verona.call "foo"[%7 : !verona.unknown] ( : ) : !verona.unknown
+    %10 = "verona.constant(5)"() : () -> !verona.class<"int">
+    %11 = verona.call ">"[%7 : !verona.unknown] (%10 : !verona.class<"int">) : !verona.unknown
+    %12 = "verona.cast"(%11) : (!verona.unknown) -> i1
+    cond_br %12, ^bb4, ^bb5
+  ^bb3(%13: !verona.unknown):  // 2 preds: ^bb1, ^bb4
     return
   ^bb4:  // pred: ^bb2
-    br ^bb3
+    br ^bb3(%7 : !verona.unknown)
   ^bb5:  // pred: ^bb2
-    %22 = "verona.load"(%3) : (!verona.class<"S32">) -> !verona.unknown
-    %23 = "verona.constant(2)"() : () -> !verona.class<"int">
-    %24 = verona.call "<"[%22 : !verona.unknown] (%23 : !verona.class<"int">) : !verona.unknown
-    %25 = "verona.cast"(%24) : (!verona.unknown) -> i1
-    cond_br %25, ^bb7, ^bb8
+    %14 = "verona.constant(2)"() : () -> !verona.class<"int">
+    %15 = verona.call "<"[%7 : !verona.unknown] (%14 : !verona.class<"int">) : !verona.unknown
+    %16 = "verona.cast"(%15) : (!verona.unknown) -> i1
+    cond_br %16, ^bb7, ^bb8
   ^bb6:  // pred: ^bb9
-    br ^bb1
+    br ^bb1(%6 : !verona.unknown)
   ^bb7:  // pred: ^bb5
-    br ^bb1
+    br ^bb1(%7 : !verona.unknown)
   ^bb8:  // pred: ^bb5
-    %26 = "verona.load"(%3) : (!verona.class<"S32">) -> !verona.unknown
-    %27 = verona.call "foo"[%26 : !verona.unknown] ( : ) : !verona.unknown
+    %17 = verona.call "foo"[%7 : !verona.unknown] ( : ) : !verona.unknown
     br ^bb9
   ^bb9:  // pred: ^bb8
     br ^bb6

--- a/testsuite/mlir/mlir-parse/for/mlir.txt
+++ b/testsuite/mlir/mlir-parse/for/mlir.txt
@@ -13,7 +13,7 @@ module @"$module" {
     %7 = verona.call "apply"[%arg0 : !verona.class<"U64">] ( : ) : !verona.unknown
     %8 = verona.call "next"[%arg0 : !verona.class<"U64">] ( : ) : !verona.unknown
     %9 = verona.call "foo"[%7 : !verona.unknown] ( : ) : !verona.unknown
-    br ^bb1(%6 : !verona.unknown)
+    br ^bb1(%7 : !verona.unknown)
   ^bb3(%10: !verona.unknown):  // pred: ^bb1
     return
   }
@@ -44,7 +44,7 @@ module @"$module" {
     %16 = "verona.cast"(%15) : (!verona.unknown) -> i1
     cond_br %16, ^bb7, ^bb8
   ^bb6:  // pred: ^bb9
-    br ^bb1(%6 : !verona.unknown)
+    br ^bb1(%7 : !verona.unknown)
   ^bb7:  // pred: ^bb5
     br ^bb1(%7 : !verona.unknown)
   ^bb8:  // pred: ^bb5

--- a/testsuite/mlir/mlir-parse/function/mlir.txt
+++ b/testsuite/mlir/mlir-parse/function/mlir.txt
@@ -18,21 +18,10 @@ module @"$module" {
     return
   }
   func @foo(%arg0: !verona.imm, %arg1: !verona.meet<class<"U64">, imm>) -> !verona.meet<class<"U64">, imm> attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !verona.imm
-    %1 = "verona.store"(%arg0, %0) : (!verona.imm, !verona.imm) -> !verona.unknown
-    %2 = "verona.alloca"() : () -> !verona.meet<class<"U64">, imm>
-    %3 = "verona.store"(%arg1, %2) : (!verona.meet<class<"U64">, imm>, !verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %4 = "verona.load"(%0) : (!verona.imm) -> !verona.unknown
-    %5 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %6 = verona.call "+"[%4 : !verona.unknown] (%5 : !verona.unknown) : !verona.unknown
-    %7 = "verona.alloca"() : () -> !verona.unknown
-    %8 = "verona.store"(%6, %7) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    %9 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
-    %10 = "verona.alloca"() : () -> !verona.meet<class<"U64">, imm>
-    %11 = "verona.store"(%9, %10) : (!verona.unknown, !verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %12 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
-    %13 = "verona.cast"(%12) : (!verona.unknown) -> !verona.meet<class<"U64">, imm>
-    return %13 : !verona.meet<class<"U64">, imm>
+    %0 = verona.call "+"[%arg0 : !verona.imm] (%arg1 : !verona.meet<class<"U64">, imm>) : !verona.unknown
+    %1 = "verona.cast"(%0) : (!verona.unknown) -> !verona.meet<class<"U64">, imm>
+    %2 = "verona.cast"(%0) : (!verona.unknown) -> !verona.meet<class<"U64">, imm>
+    return %2 : !verona.meet<class<"U64">, imm>
   }
   func @apply() attributes {class = !verona.class<"$module">} {
     return

--- a/testsuite/mlir/mlir-parse/nested-conditional/mlir.txt
+++ b/testsuite/mlir/mlir-parse/nested-conditional/mlir.txt
@@ -3,82 +3,76 @@ module @"$module" {
     %0 = "verona.constant(2)"() : () -> !verona.class<"int">
     %1 = verona.call "<"[%arg0 : !verona.class<"U32">] (%0 : !verona.class<"int">) : !verona.unknown
     %2 = "verona.cast"(%1) : (!verona.unknown) -> i1
-    %3 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
     cond_br %2, ^bb1, ^bb2
   ^bb1:  // pred: ^bb0
-    %4 = "verona.constant(1)"() : () -> !verona.class<"int">
-    %5 = verona.call "+"[%arg0 : !verona.class<"U32">] (%4 : !verona.class<"int">) : !verona.unknown
-    %6 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
-    br ^bb3(%6 : !verona.unknown)
+    %3 = "verona.constant(1)"() : () -> !verona.class<"int">
+    %4 = verona.call "+"[%arg0 : !verona.class<"U32">] (%3 : !verona.class<"int">) : !verona.unknown
+    %5 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
+    br ^bb3(%5 : !verona.unknown)
   ^bb2:  // pred: ^bb0
-    %7 = "verona.constant(100)"() : () -> !verona.class<"int">
-    %8 = verona.call ">"[%arg0 : !verona.class<"U32">] (%7 : !verona.class<"int">) : !verona.unknown
-    %9 = "verona.cast"(%8) : (!verona.unknown) -> i1
-    %10 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
-    cond_br %9, ^bb4, ^bb5
-  ^bb3(%11: !verona.unknown):  // 2 preds: ^bb1, ^bb6
-    %12 = "verona.cast"(%11) : (!verona.unknown) -> !verona.class<"U32">
-    return %12 : !verona.class<"U32">
+    %6 = "verona.constant(100)"() : () -> !verona.class<"int">
+    %7 = verona.call ">"[%arg0 : !verona.class<"U32">] (%6 : !verona.class<"int">) : !verona.unknown
+    %8 = "verona.cast"(%7) : (!verona.unknown) -> i1
+    cond_br %8, ^bb4, ^bb5
+  ^bb3(%9: !verona.unknown):  // 2 preds: ^bb1, ^bb6
+    %10 = "verona.cast"(%9) : (!verona.unknown) -> !verona.class<"U32">
+    return %10 : !verona.class<"U32">
   ^bb4:  // pred: ^bb2
-    %13 = "verona.constant(1)"() : () -> !verona.class<"int">
-    %14 = verona.call "-"[%arg0 : !verona.class<"U32">] (%13 : !verona.class<"int">) : !verona.unknown
-    %15 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
-    br ^bb6(%15 : !verona.unknown)
+    %11 = "verona.constant(1)"() : () -> !verona.class<"int">
+    %12 = verona.call "-"[%arg0 : !verona.class<"U32">] (%11 : !verona.class<"int">) : !verona.unknown
+    %13 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
+    br ^bb6(%13 : !verona.unknown)
   ^bb5:  // pred: ^bb2
-    %16 = "verona.constant(20)"() : () -> !verona.class<"int">
-    %17 = verona.call "<="[%arg0 : !verona.class<"U32">] (%16 : !verona.class<"int">) : !verona.unknown
-    %18 = "verona.cast"(%17) : (!verona.unknown) -> i1
-    %19 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
-    cond_br %18, ^bb7, ^bb8
-  ^bb6(%20: !verona.unknown):  // 2 preds: ^bb4, ^bb9
-    br ^bb3(%20 : !verona.unknown)
+    %14 = "verona.constant(20)"() : () -> !verona.class<"int">
+    %15 = verona.call "<="[%arg0 : !verona.class<"U32">] (%14 : !verona.class<"int">) : !verona.unknown
+    %16 = "verona.cast"(%15) : (!verona.unknown) -> i1
+    cond_br %16, ^bb7, ^bb8
+  ^bb6(%17: !verona.unknown):  // 2 preds: ^bb4, ^bb9
+    br ^bb3(%17 : !verona.unknown)
   ^bb7:  // pred: ^bb5
-    %21 = "verona.constant(2)"() : () -> !verona.class<"int">
-    %22 = verona.call "*"[%arg0 : !verona.class<"U32">] (%21 : !verona.class<"int">) : !verona.unknown
-    %23 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
-    br ^bb9(%23 : !verona.unknown)
+    %18 = "verona.constant(2)"() : () -> !verona.class<"int">
+    %19 = verona.call "*"[%arg0 : !verona.class<"U32">] (%18 : !verona.class<"int">) : !verona.unknown
+    %20 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
+    br ^bb9(%20 : !verona.unknown)
   ^bb8:  // pred: ^bb5
-    %24 = "verona.constant(50)"() : () -> !verona.class<"int">
-    %25 = verona.call ">="[%arg0 : !verona.class<"U32">] (%24 : !verona.class<"int">) : !verona.unknown
-    %26 = "verona.cast"(%25) : (!verona.unknown) -> i1
-    %27 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
-    cond_br %26, ^bb10, ^bb11
-  ^bb9(%28: !verona.unknown):  // 2 preds: ^bb7, ^bb12
-    br ^bb6(%28 : !verona.unknown)
+    %21 = "verona.constant(50)"() : () -> !verona.class<"int">
+    %22 = verona.call ">="[%arg0 : !verona.class<"U32">] (%21 : !verona.class<"int">) : !verona.unknown
+    %23 = "verona.cast"(%22) : (!verona.unknown) -> i1
+    cond_br %23, ^bb10, ^bb11
+  ^bb9(%24: !verona.unknown):  // 2 preds: ^bb7, ^bb12
+    br ^bb6(%24 : !verona.unknown)
   ^bb10:  // pred: ^bb8
-    %29 = "verona.constant(10)"() : () -> !verona.class<"int">
-    %30 = verona.call "/"[%arg0 : !verona.class<"U32">] (%29 : !verona.class<"int">) : !verona.unknown
-    %31 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
-    br ^bb12(%31 : !verona.unknown)
+    %25 = "verona.constant(10)"() : () -> !verona.class<"int">
+    %26 = verona.call "/"[%arg0 : !verona.class<"U32">] (%25 : !verona.class<"int">) : !verona.unknown
+    %27 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
+    br ^bb12(%27 : !verona.unknown)
   ^bb11:  // pred: ^bb8
-    %32 = "verona.constant(10)"() : () -> !verona.class<"int">
-    %33 = verona.call "=="[%arg0 : !verona.class<"U32">] (%32 : !verona.class<"int">) : !verona.unknown
-    %34 = "verona.cast"(%33) : (!verona.unknown) -> i1
-    %35 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
-    cond_br %34, ^bb13, ^bb14
-  ^bb12(%36: !verona.unknown):  // 2 preds: ^bb10, ^bb15
-    br ^bb9(%36 : !verona.unknown)
+    %28 = "verona.constant(10)"() : () -> !verona.class<"int">
+    %29 = verona.call "=="[%arg0 : !verona.class<"U32">] (%28 : !verona.class<"int">) : !verona.unknown
+    %30 = "verona.cast"(%29) : (!verona.unknown) -> i1
+    cond_br %30, ^bb13, ^bb14
+  ^bb12(%31: !verona.unknown):  // 2 preds: ^bb10, ^bb15
+    br ^bb9(%31 : !verona.unknown)
   ^bb13:  // pred: ^bb11
-    %37 = "verona.constant(10)"() : () -> !verona.class<"int">
-    %38 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
-    br ^bb15(%38 : !verona.unknown)
+    %32 = "verona.constant(10)"() : () -> !verona.class<"int">
+    %33 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
+    br ^bb15(%33 : !verona.unknown)
   ^bb14:  // pred: ^bb11
-    %39 = "verona.constant(20)"() : () -> !verona.class<"int">
-    %40 = verona.call "!="[%arg0 : !verona.class<"U32">] (%39 : !verona.class<"int">) : !verona.unknown
-    %41 = "verona.cast"(%40) : (!verona.unknown) -> i1
-    %42 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
-    cond_br %41, ^bb16, ^bb17
-  ^bb15(%43: !verona.unknown):  // 2 preds: ^bb13, ^bb18
-    br ^bb12(%43 : !verona.unknown)
+    %34 = "verona.constant(20)"() : () -> !verona.class<"int">
+    %35 = verona.call "!="[%arg0 : !verona.class<"U32">] (%34 : !verona.class<"int">) : !verona.unknown
+    %36 = "verona.cast"(%35) : (!verona.unknown) -> i1
+    cond_br %36, ^bb16, ^bb17
+  ^bb15(%37: !verona.unknown):  // 2 preds: ^bb13, ^bb18
+    br ^bb12(%37 : !verona.unknown)
   ^bb16:  // pred: ^bb14
-    %44 = "verona.constant(42)"() : () -> !verona.class<"int">
-    %45 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
-    br ^bb18(%45 : !verona.unknown)
+    %38 = "verona.constant(42)"() : () -> !verona.class<"int">
+    %39 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
+    br ^bb18(%39 : !verona.unknown)
   ^bb17:  // pred: ^bb14
-    %46 = "verona.constant(0)"() : () -> !verona.class<"int">
-    %47 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
-    br ^bb18(%47 : !verona.unknown)
-  ^bb18(%48: !verona.unknown):  // 2 preds: ^bb16, ^bb17
-    br ^bb15(%48 : !verona.unknown)
+    %40 = "verona.constant(0)"() : () -> !verona.class<"int">
+    %41 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
+    br ^bb18(%41 : !verona.unknown)
+  ^bb18(%42: !verona.unknown):  // 2 preds: ^bb16, ^bb17
+    br ^bb15(%42 : !verona.unknown)
   }
 }

--- a/testsuite/mlir/mlir-parse/nested-conditional/mlir.txt
+++ b/testsuite/mlir/mlir-parse/nested-conditional/mlir.txt
@@ -1,91 +1,84 @@
 module @"$module" {
   func @f(%arg0: !verona.class<"U32">) -> !verona.class<"U32"> attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !verona.class<"U32">
-    %1 = "verona.store"(%arg0, %0) : (!verona.class<"U32">, !verona.class<"U32">) -> !verona.unknown
-    %2 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
-    %3 = "verona.constant(2)"() : () -> !verona.class<"int">
-    %4 = verona.call "<"[%2 : !verona.unknown] (%3 : !verona.class<"int">) : !verona.unknown
-    %5 = "verona.cast"(%4) : (!verona.unknown) -> i1
-    cond_br %5, ^bb1, ^bb2
+    %0 = "verona.constant(2)"() : () -> !verona.class<"int">
+    %1 = verona.call "<"[%arg0 : !verona.class<"U32">] (%0 : !verona.class<"int">) : !verona.unknown
+    %2 = "verona.cast"(%1) : (!verona.unknown) -> i1
+    %3 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
+    cond_br %2, ^bb1, ^bb2
   ^bb1:  // pred: ^bb0
-    %6 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
-    %7 = "verona.constant(1)"() : () -> !verona.class<"int">
-    %8 = verona.call "+"[%6 : !verona.unknown] (%7 : !verona.class<"int">) : !verona.unknown
-    %9 = "verona.store"(%8, %0) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
-    br ^bb3
+    %4 = "verona.constant(1)"() : () -> !verona.class<"int">
+    %5 = verona.call "+"[%arg0 : !verona.class<"U32">] (%4 : !verona.class<"int">) : !verona.unknown
+    %6 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
+    br ^bb3(%6 : !verona.unknown)
   ^bb2:  // pred: ^bb0
-    %10 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
-    %11 = "verona.constant(100)"() : () -> !verona.class<"int">
-    %12 = verona.call ">"[%10 : !verona.unknown] (%11 : !verona.class<"int">) : !verona.unknown
-    %13 = "verona.cast"(%12) : (!verona.unknown) -> i1
-    cond_br %13, ^bb4, ^bb5
-  ^bb3:  // 2 preds: ^bb1, ^bb6
-    %14 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
-    %15 = "verona.cast"(%14) : (!verona.unknown) -> !verona.class<"U32">
-    return %15 : !verona.class<"U32">
+    %7 = "verona.constant(100)"() : () -> !verona.class<"int">
+    %8 = verona.call ">"[%arg0 : !verona.class<"U32">] (%7 : !verona.class<"int">) : !verona.unknown
+    %9 = "verona.cast"(%8) : (!verona.unknown) -> i1
+    %10 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
+    cond_br %9, ^bb4, ^bb5
+  ^bb3(%11: !verona.unknown):  // 2 preds: ^bb1, ^bb6
+    %12 = "verona.cast"(%11) : (!verona.unknown) -> !verona.class<"U32">
+    return %12 : !verona.class<"U32">
   ^bb4:  // pred: ^bb2
-    %16 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
-    %17 = "verona.constant(1)"() : () -> !verona.class<"int">
-    %18 = verona.call "-"[%16 : !verona.unknown] (%17 : !verona.class<"int">) : !verona.unknown
-    %19 = "verona.store"(%18, %0) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
-    br ^bb6
+    %13 = "verona.constant(1)"() : () -> !verona.class<"int">
+    %14 = verona.call "-"[%arg0 : !verona.class<"U32">] (%13 : !verona.class<"int">) : !verona.unknown
+    %15 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
+    br ^bb6(%15 : !verona.unknown)
   ^bb5:  // pred: ^bb2
-    %20 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
-    %21 = "verona.constant(20)"() : () -> !verona.class<"int">
-    %22 = verona.call "<="[%20 : !verona.unknown] (%21 : !verona.class<"int">) : !verona.unknown
-    %23 = "verona.cast"(%22) : (!verona.unknown) -> i1
-    cond_br %23, ^bb7, ^bb8
-  ^bb6:  // 2 preds: ^bb4, ^bb9
-    br ^bb3
+    %16 = "verona.constant(20)"() : () -> !verona.class<"int">
+    %17 = verona.call "<="[%arg0 : !verona.class<"U32">] (%16 : !verona.class<"int">) : !verona.unknown
+    %18 = "verona.cast"(%17) : (!verona.unknown) -> i1
+    %19 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
+    cond_br %18, ^bb7, ^bb8
+  ^bb6(%20: !verona.unknown):  // 2 preds: ^bb4, ^bb9
+    br ^bb3(%20 : !verona.unknown)
   ^bb7:  // pred: ^bb5
-    %24 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
-    %25 = "verona.constant(2)"() : () -> !verona.class<"int">
-    %26 = verona.call "*"[%24 : !verona.unknown] (%25 : !verona.class<"int">) : !verona.unknown
-    %27 = "verona.store"(%26, %0) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
-    br ^bb9
+    %21 = "verona.constant(2)"() : () -> !verona.class<"int">
+    %22 = verona.call "*"[%arg0 : !verona.class<"U32">] (%21 : !verona.class<"int">) : !verona.unknown
+    %23 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
+    br ^bb9(%23 : !verona.unknown)
   ^bb8:  // pred: ^bb5
-    %28 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
-    %29 = "verona.constant(50)"() : () -> !verona.class<"int">
-    %30 = verona.call ">="[%28 : !verona.unknown] (%29 : !verona.class<"int">) : !verona.unknown
-    %31 = "verona.cast"(%30) : (!verona.unknown) -> i1
-    cond_br %31, ^bb10, ^bb11
-  ^bb9:  // 2 preds: ^bb7, ^bb12
-    br ^bb6
+    %24 = "verona.constant(50)"() : () -> !verona.class<"int">
+    %25 = verona.call ">="[%arg0 : !verona.class<"U32">] (%24 : !verona.class<"int">) : !verona.unknown
+    %26 = "verona.cast"(%25) : (!verona.unknown) -> i1
+    %27 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
+    cond_br %26, ^bb10, ^bb11
+  ^bb9(%28: !verona.unknown):  // 2 preds: ^bb7, ^bb12
+    br ^bb6(%28 : !verona.unknown)
   ^bb10:  // pred: ^bb8
-    %32 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
-    %33 = "verona.constant(10)"() : () -> !verona.class<"int">
-    %34 = verona.call "/"[%32 : !verona.unknown] (%33 : !verona.class<"int">) : !verona.unknown
-    %35 = "verona.store"(%34, %0) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
-    br ^bb12
+    %29 = "verona.constant(10)"() : () -> !verona.class<"int">
+    %30 = verona.call "/"[%arg0 : !verona.class<"U32">] (%29 : !verona.class<"int">) : !verona.unknown
+    %31 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
+    br ^bb12(%31 : !verona.unknown)
   ^bb11:  // pred: ^bb8
-    %36 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
-    %37 = "verona.constant(10)"() : () -> !verona.class<"int">
-    %38 = verona.call "=="[%36 : !verona.unknown] (%37 : !verona.class<"int">) : !verona.unknown
-    %39 = "verona.cast"(%38) : (!verona.unknown) -> i1
-    cond_br %39, ^bb13, ^bb14
-  ^bb12:  // 2 preds: ^bb10, ^bb15
-    br ^bb9
+    %32 = "verona.constant(10)"() : () -> !verona.class<"int">
+    %33 = verona.call "=="[%arg0 : !verona.class<"U32">] (%32 : !verona.class<"int">) : !verona.unknown
+    %34 = "verona.cast"(%33) : (!verona.unknown) -> i1
+    %35 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
+    cond_br %34, ^bb13, ^bb14
+  ^bb12(%36: !verona.unknown):  // 2 preds: ^bb10, ^bb15
+    br ^bb9(%36 : !verona.unknown)
   ^bb13:  // pred: ^bb11
-    %40 = "verona.constant(10)"() : () -> !verona.class<"int">
-    %41 = "verona.store"(%40, %0) : (!verona.class<"int">, !verona.class<"U32">) -> !verona.unknown
-    br ^bb15
+    %37 = "verona.constant(10)"() : () -> !verona.class<"int">
+    %38 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
+    br ^bb15(%38 : !verona.unknown)
   ^bb14:  // pred: ^bb11
-    %42 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
-    %43 = "verona.constant(20)"() : () -> !verona.class<"int">
-    %44 = verona.call "!="[%42 : !verona.unknown] (%43 : !verona.class<"int">) : !verona.unknown
-    %45 = "verona.cast"(%44) : (!verona.unknown) -> i1
-    cond_br %45, ^bb16, ^bb17
-  ^bb15:  // 2 preds: ^bb13, ^bb18
-    br ^bb12
+    %39 = "verona.constant(20)"() : () -> !verona.class<"int">
+    %40 = verona.call "!="[%arg0 : !verona.class<"U32">] (%39 : !verona.class<"int">) : !verona.unknown
+    %41 = "verona.cast"(%40) : (!verona.unknown) -> i1
+    %42 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
+    cond_br %41, ^bb16, ^bb17
+  ^bb15(%43: !verona.unknown):  // 2 preds: ^bb13, ^bb18
+    br ^bb12(%43 : !verona.unknown)
   ^bb16:  // pred: ^bb14
-    %46 = "verona.constant(42)"() : () -> !verona.class<"int">
-    %47 = "verona.store"(%46, %0) : (!verona.class<"int">, !verona.class<"U32">) -> !verona.unknown
-    br ^bb18
+    %44 = "verona.constant(42)"() : () -> !verona.class<"int">
+    %45 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
+    br ^bb18(%45 : !verona.unknown)
   ^bb17:  // pred: ^bb14
-    %48 = "verona.constant(0)"() : () -> !verona.class<"int">
-    %49 = "verona.store"(%48, %0) : (!verona.class<"int">, !verona.class<"U32">) -> !verona.unknown
-    br ^bb18
-  ^bb18:  // 2 preds: ^bb16, ^bb17
-    br ^bb15
+    %46 = "verona.constant(0)"() : () -> !verona.class<"int">
+    %47 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
+    br ^bb18(%47 : !verona.unknown)
+  ^bb18(%48: !verona.unknown):  // 2 preds: ^bb16, ^bb17
+    br ^bb15(%48 : !verona.unknown)
   }
 }

--- a/testsuite/mlir/mlir-parse/nested-conditional/mlir.txt
+++ b/testsuite/mlir/mlir-parse/nested-conditional/mlir.txt
@@ -7,72 +7,68 @@ module @"$module" {
   ^bb1:  // pred: ^bb0
     %3 = "verona.constant(1)"() : () -> !verona.class<"int">
     %4 = verona.call "+"[%arg0 : !verona.class<"U32">] (%3 : !verona.class<"int">) : !verona.unknown
-    %5 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
-    br ^bb3(%5 : !verona.unknown)
+    br ^bb3(%4 : !verona.unknown)
   ^bb2:  // pred: ^bb0
-    %6 = "verona.constant(100)"() : () -> !verona.class<"int">
-    %7 = verona.call ">"[%arg0 : !verona.class<"U32">] (%6 : !verona.class<"int">) : !verona.unknown
-    %8 = "verona.cast"(%7) : (!verona.unknown) -> i1
-    cond_br %8, ^bb4, ^bb5
-  ^bb3(%9: !verona.unknown):  // 2 preds: ^bb1, ^bb6
-    %10 = "verona.cast"(%9) : (!verona.unknown) -> !verona.class<"U32">
-    return %10 : !verona.class<"U32">
+    %5 = "verona.constant(100)"() : () -> !verona.class<"int">
+    %6 = verona.call ">"[%arg0 : !verona.class<"U32">] (%5 : !verona.class<"int">) : !verona.unknown
+    %7 = "verona.cast"(%6) : (!verona.unknown) -> i1
+    cond_br %7, ^bb4, ^bb5
+  ^bb3(%8: !verona.unknown):  // 2 preds: ^bb1, ^bb6
+    %9 = "verona.cast"(%8) : (!verona.unknown) -> !verona.class<"U32">
+    return %9 : !verona.class<"U32">
   ^bb4:  // pred: ^bb2
-    %11 = "verona.constant(1)"() : () -> !verona.class<"int">
-    %12 = verona.call "-"[%arg0 : !verona.class<"U32">] (%11 : !verona.class<"int">) : !verona.unknown
-    %13 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
-    br ^bb6(%13 : !verona.unknown)
+    %10 = "verona.constant(1)"() : () -> !verona.class<"int">
+    %11 = verona.call "-"[%arg0 : !verona.class<"U32">] (%10 : !verona.class<"int">) : !verona.unknown
+    br ^bb6(%11 : !verona.unknown)
   ^bb5:  // pred: ^bb2
-    %14 = "verona.constant(20)"() : () -> !verona.class<"int">
-    %15 = verona.call "<="[%arg0 : !verona.class<"U32">] (%14 : !verona.class<"int">) : !verona.unknown
-    %16 = "verona.cast"(%15) : (!verona.unknown) -> i1
-    cond_br %16, ^bb7, ^bb8
-  ^bb6(%17: !verona.unknown):  // 2 preds: ^bb4, ^bb9
-    br ^bb3(%17 : !verona.unknown)
+    %12 = "verona.constant(20)"() : () -> !verona.class<"int">
+    %13 = verona.call "<="[%arg0 : !verona.class<"U32">] (%12 : !verona.class<"int">) : !verona.unknown
+    %14 = "verona.cast"(%13) : (!verona.unknown) -> i1
+    cond_br %14, ^bb7, ^bb8
+  ^bb6(%15: !verona.unknown):  // 2 preds: ^bb4, ^bb9
+    br ^bb3(%15 : !verona.unknown)
   ^bb7:  // pred: ^bb5
-    %18 = "verona.constant(2)"() : () -> !verona.class<"int">
-    %19 = verona.call "*"[%arg0 : !verona.class<"U32">] (%18 : !verona.class<"int">) : !verona.unknown
-    %20 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
-    br ^bb9(%20 : !verona.unknown)
+    %16 = "verona.constant(2)"() : () -> !verona.class<"int">
+    %17 = verona.call "*"[%arg0 : !verona.class<"U32">] (%16 : !verona.class<"int">) : !verona.unknown
+    br ^bb9(%17 : !verona.unknown)
   ^bb8:  // pred: ^bb5
-    %21 = "verona.constant(50)"() : () -> !verona.class<"int">
-    %22 = verona.call ">="[%arg0 : !verona.class<"U32">] (%21 : !verona.class<"int">) : !verona.unknown
-    %23 = "verona.cast"(%22) : (!verona.unknown) -> i1
-    cond_br %23, ^bb10, ^bb11
-  ^bb9(%24: !verona.unknown):  // 2 preds: ^bb7, ^bb12
-    br ^bb6(%24 : !verona.unknown)
+    %18 = "verona.constant(50)"() : () -> !verona.class<"int">
+    %19 = verona.call ">="[%arg0 : !verona.class<"U32">] (%18 : !verona.class<"int">) : !verona.unknown
+    %20 = "verona.cast"(%19) : (!verona.unknown) -> i1
+    cond_br %20, ^bb10, ^bb11
+  ^bb9(%21: !verona.unknown):  // 2 preds: ^bb7, ^bb12
+    br ^bb6(%21 : !verona.unknown)
   ^bb10:  // pred: ^bb8
-    %25 = "verona.constant(10)"() : () -> !verona.class<"int">
-    %26 = verona.call "/"[%arg0 : !verona.class<"U32">] (%25 : !verona.class<"int">) : !verona.unknown
-    %27 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
-    br ^bb12(%27 : !verona.unknown)
+    %22 = "verona.constant(10)"() : () -> !verona.class<"int">
+    %23 = verona.call "/"[%arg0 : !verona.class<"U32">] (%22 : !verona.class<"int">) : !verona.unknown
+    br ^bb12(%23 : !verona.unknown)
   ^bb11:  // pred: ^bb8
-    %28 = "verona.constant(10)"() : () -> !verona.class<"int">
-    %29 = verona.call "=="[%arg0 : !verona.class<"U32">] (%28 : !verona.class<"int">) : !verona.unknown
-    %30 = "verona.cast"(%29) : (!verona.unknown) -> i1
-    cond_br %30, ^bb13, ^bb14
-  ^bb12(%31: !verona.unknown):  // 2 preds: ^bb10, ^bb15
-    br ^bb9(%31 : !verona.unknown)
+    %24 = "verona.constant(10)"() : () -> !verona.class<"int">
+    %25 = verona.call "=="[%arg0 : !verona.class<"U32">] (%24 : !verona.class<"int">) : !verona.unknown
+    %26 = "verona.cast"(%25) : (!verona.unknown) -> i1
+    cond_br %26, ^bb13, ^bb14
+  ^bb12(%27: !verona.unknown):  // 2 preds: ^bb10, ^bb15
+    br ^bb9(%27 : !verona.unknown)
   ^bb13:  // pred: ^bb11
-    %32 = "verona.constant(10)"() : () -> !verona.class<"int">
-    %33 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
-    br ^bb15(%33 : !verona.unknown)
+    %28 = "verona.constant(10)"() : () -> !verona.class<"int">
+    %29 = "verona.cast"(%28) : (!verona.class<"int">) -> !verona.unknown
+    br ^bb15(%29 : !verona.unknown)
   ^bb14:  // pred: ^bb11
-    %34 = "verona.constant(20)"() : () -> !verona.class<"int">
-    %35 = verona.call "!="[%arg0 : !verona.class<"U32">] (%34 : !verona.class<"int">) : !verona.unknown
-    %36 = "verona.cast"(%35) : (!verona.unknown) -> i1
-    cond_br %36, ^bb16, ^bb17
-  ^bb15(%37: !verona.unknown):  // 2 preds: ^bb13, ^bb18
-    br ^bb12(%37 : !verona.unknown)
+    %30 = "verona.constant(20)"() : () -> !verona.class<"int">
+    %31 = verona.call "!="[%arg0 : !verona.class<"U32">] (%30 : !verona.class<"int">) : !verona.unknown
+    %32 = "verona.cast"(%31) : (!verona.unknown) -> i1
+    cond_br %32, ^bb16, ^bb17
+  ^bb15(%33: !verona.unknown):  // 2 preds: ^bb13, ^bb18
+    br ^bb12(%33 : !verona.unknown)
   ^bb16:  // pred: ^bb14
-    %38 = "verona.constant(42)"() : () -> !verona.class<"int">
-    %39 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
-    br ^bb18(%39 : !verona.unknown)
+    %34 = "verona.constant(42)"() : () -> !verona.class<"int">
+    %35 = "verona.cast"(%34) : (!verona.class<"int">) -> !verona.unknown
+    br ^bb18(%35 : !verona.unknown)
   ^bb17:  // pred: ^bb14
-    %40 = "verona.constant(0)"() : () -> !verona.class<"int">
-    %41 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
-    br ^bb18(%41 : !verona.unknown)
-  ^bb18(%42: !verona.unknown):  // 2 preds: ^bb16, ^bb17
-    br ^bb15(%42 : !verona.unknown)
+    %36 = "verona.constant(0)"() : () -> !verona.class<"int">
+    %37 = "verona.cast"(%36) : (!verona.class<"int">) -> !verona.unknown
+    br ^bb18(%37 : !verona.unknown)
+  ^bb18(%38: !verona.unknown):  // 2 preds: ^bb16, ^bb17
+    br ^bb15(%38 : !verona.unknown)
   }
 }

--- a/testsuite/mlir/mlir-parse/nested-while/mlir.txt
+++ b/testsuite/mlir/mlir-parse/nested-while/mlir.txt
@@ -1,38 +1,28 @@
 module @"$module" {
   func @f(%arg0: !verona.class<"S64">) -> !verona.class<"S64"> attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !verona.class<"S64">
-    %1 = "verona.store"(%arg0, %0) : (!verona.class<"S64">, !verona.class<"S64">) -> !verona.unknown
-    br ^bb1
-  ^bb1:  // 2 preds: ^bb0, ^bb6
-    %2 = "verona.load"(%0) : (!verona.class<"S64">) -> !verona.unknown
-    %3 = "verona.constant(50)"() : () -> !verona.class<"int">
-    %4 = verona.call "<"[%2 : !verona.unknown] (%3 : !verona.class<"int">) : !verona.unknown
-    %5 = "verona.cast"(%4) : (!verona.unknown) -> i1
-    cond_br %5, ^bb2, ^bb3
-  ^bb2:  // pred: ^bb1
+    %0 = "verona.cast"(%arg0) : (!verona.class<"S64">) -> !verona.unknown
+    br ^bb1(%0 : !verona.unknown)
+  ^bb1(%1: !verona.unknown):  // 2 preds: ^bb0, ^bb6
+    %2 = "verona.constant(50)"() : () -> !verona.class<"int">
+    %3 = verona.call "<"[%1 : !verona.unknown] (%2 : !verona.class<"int">) : !verona.unknown
+    %4 = "verona.cast"(%3) : (!verona.unknown) -> i1
+    cond_br %4, ^bb2(%1 : !verona.unknown), ^bb3(%1 : !verona.unknown)
+  ^bb2(%5: !verona.unknown):  // pred: ^bb1
     %6 = "verona.constant(1)"() : () -> !verona.class<"int">
-    %7 = "verona.alloca"() : () -> !verona.unknown
-    %8 = "verona.store"(%6, %7) : (!verona.class<"int">, !verona.unknown) -> !verona.unknown
-    br ^bb4
-  ^bb3:  // pred: ^bb1
-    %9 = "verona.load"(%0) : (!verona.class<"S64">) -> !verona.unknown
-    %10 = "verona.cast"(%9) : (!verona.unknown) -> !verona.class<"S64">
-    return %10 : !verona.class<"S64">
-  ^bb4:  // 2 preds: ^bb2, ^bb5
-    %11 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
-    %12 = "verona.constant(10)"() : () -> !verona.class<"int">
-    %13 = verona.call "<"[%11 : !verona.unknown] (%12 : !verona.class<"int">) : !verona.unknown
-    %14 = "verona.cast"(%13) : (!verona.unknown) -> i1
-    cond_br %14, ^bb5, ^bb6
-  ^bb5:  // pred: ^bb4
-    %15 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
-    %16 = "verona.load"(%0) : (!verona.class<"S64">) -> !verona.unknown
-    %17 = verona.call "+"[%15 : !verona.unknown] (%16 : !verona.unknown) : !verona.unknown
-    %18 = "verona.store"(%17, %7) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    br ^bb4
-  ^bb6:  // pred: ^bb4
-    %19 = "verona.load"(%7) : (!verona.unknown) -> !verona.unknown
-    %20 = "verona.store"(%19, %0) : (!verona.unknown, !verona.class<"S64">) -> !verona.unknown
-    br ^bb1
+    %7 = "verona.cast"(%6) : (!verona.class<"int">) -> !verona.unknown
+    br ^bb4(%7 : !verona.unknown)
+  ^bb3(%8: !verona.unknown):  // pred: ^bb1
+    %9 = "verona.cast"(%8) : (!verona.unknown) -> !verona.class<"S64">
+    return %9 : !verona.class<"S64">
+  ^bb4(%10: !verona.unknown):  // 2 preds: ^bb2, ^bb5
+    %11 = "verona.constant(10)"() : () -> !verona.class<"int">
+    %12 = verona.call "<"[%10 : !verona.unknown] (%11 : !verona.class<"int">) : !verona.unknown
+    %13 = "verona.cast"(%12) : (!verona.unknown) -> i1
+    cond_br %13, ^bb5(%10 : !verona.unknown), ^bb6(%10 : !verona.unknown)
+  ^bb5(%14: !verona.unknown):  // pred: ^bb4
+    %15 = verona.call "+"[%14 : !verona.unknown] (%5 : !verona.unknown) : !verona.unknown
+    br ^bb4(%14 : !verona.unknown)
+  ^bb6(%16: !verona.unknown):  // pred: ^bb4
+    br ^bb1(%5 : !verona.unknown)
   }
 }

--- a/testsuite/mlir/mlir-parse/nested-while/mlir.txt
+++ b/testsuite/mlir/mlir-parse/nested-while/mlir.txt
@@ -21,8 +21,8 @@ module @"$module" {
     cond_br %13, ^bb5(%10 : !verona.unknown), ^bb6(%10 : !verona.unknown)
   ^bb5(%14: !verona.unknown):  // pred: ^bb4
     %15 = verona.call "+"[%14 : !verona.unknown] (%5 : !verona.unknown) : !verona.unknown
-    br ^bb4(%14 : !verona.unknown)
+    br ^bb4(%15 : !verona.unknown)
   ^bb6(%16: !verona.unknown):  // pred: ^bb4
-    br ^bb1(%5 : !verona.unknown)
+    br ^bb1(%16 : !verona.unknown)
   }
 }

--- a/testsuite/mlir/mlir-parse/types/mlir.txt
+++ b/testsuite/mlir/mlir-parse/types/mlir.txt
@@ -1,13 +1,7 @@
 module @"$module" {
   func @foo(%arg0: !verona.meet<class<"S32">, iso>, %arg1: !verona.meet<class<"U64">, imm>) -> !verona.join<meet<class<"S32">, iso>, meet<class<"U64">, imm>, meet<class<"U32">, mut>> attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !verona.meet<class<"S32">, iso>
-    %1 = "verona.store"(%arg0, %0) : (!verona.meet<class<"S32">, iso>, !verona.meet<class<"S32">, iso>) -> !verona.unknown
-    %2 = "verona.alloca"() : () -> !verona.meet<class<"U64">, imm>
-    %3 = "verona.store"(%arg1, %2) : (!verona.meet<class<"U64">, imm>, !verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %4 = "verona.load"(%0) : (!verona.meet<class<"S32">, iso>) -> !verona.unknown
-    %5 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %6 = verona.call "+"[%4 : !verona.unknown] (%5 : !verona.unknown) : !verona.unknown
-    %7 = "verona.cast"(%6) : (!verona.unknown) -> !verona.join<meet<class<"S32">, iso>, meet<class<"U64">, imm>, meet<class<"U32">, mut>>
-    return %7 : !verona.join<meet<class<"S32">, iso>, meet<class<"U64">, imm>, meet<class<"U32">, mut>>
+    %0 = verona.call "+"[%arg0 : !verona.meet<class<"S32">, iso>] (%arg1 : !verona.meet<class<"U64">, imm>) : !verona.unknown
+    %1 = "verona.cast"(%0) : (!verona.unknown) -> !verona.join<meet<class<"S32">, iso>, meet<class<"U64">, imm>, meet<class<"U32">, mut>>
+    return %1 : !verona.join<meet<class<"S32">, iso>, meet<class<"U64">, imm>, meet<class<"U32">, mut>>
   }
 }

--- a/testsuite/mlir/mlir-parse/variables.verona
+++ b/testsuite/mlir/mlir-parse/variables.verona
@@ -4,11 +4,15 @@
 foo(a: S32 & iso, b: U64 & imm): S64
 {
   // New variable, new name
-  let var = a + b;
+  let x = a + b;
   {
     // New scope, different variable
-    let var = a * b;
+    let x = a * b;
   }
-  // Re-assignment of the first variable
-  var = a - b;
+  // Re-assignment of the first variable, update SSA value
+  x = a - b;
+  // Re-assignment again, using the new SSA value
+  x = x + 1;
+  // Returns the new value (updated again)
+  x;
 }

--- a/testsuite/mlir/mlir-parse/variables/mlir.txt
+++ b/testsuite/mlir/mlir-parse/variables/mlir.txt
@@ -3,7 +3,9 @@ module @"$module" {
     %0 = verona.call "+"[%arg0 : !verona.meet<class<"S32">, iso>] (%arg1 : !verona.meet<class<"U64">, imm>) : !verona.unknown
     %1 = verona.call "*"[%arg0 : !verona.meet<class<"S32">, iso>] (%arg1 : !verona.meet<class<"U64">, imm>) : !verona.unknown
     %2 = verona.call "-"[%arg0 : !verona.meet<class<"S32">, iso>] (%arg1 : !verona.meet<class<"U64">, imm>) : !verona.unknown
-    %3 = "verona.cast"(%0) : (!verona.unknown) -> !verona.class<"S64">
-    return %3 : !verona.class<"S64">
+    %3 = "verona.constant(1)"() : () -> !verona.class<"int">
+    %4 = verona.call "+"[%2 : !verona.unknown] (%3 : !verona.class<"int">) : !verona.unknown
+    %5 = "verona.cast"(%4) : (!verona.unknown) -> !verona.class<"S64">
+    return %5 : !verona.class<"S64">
   }
 }

--- a/testsuite/mlir/mlir-parse/variables/mlir.txt
+++ b/testsuite/mlir/mlir-parse/variables/mlir.txt
@@ -1,24 +1,9 @@
 module @"$module" {
   func @foo(%arg0: !verona.meet<class<"S32">, iso>, %arg1: !verona.meet<class<"U64">, imm>) -> !verona.class<"S64"> attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !verona.meet<class<"S32">, iso>
-    %1 = "verona.store"(%arg0, %0) : (!verona.meet<class<"S32">, iso>, !verona.meet<class<"S32">, iso>) -> !verona.unknown
-    %2 = "verona.alloca"() : () -> !verona.meet<class<"U64">, imm>
-    %3 = "verona.store"(%arg1, %2) : (!verona.meet<class<"U64">, imm>, !verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %4 = "verona.load"(%0) : (!verona.meet<class<"S32">, iso>) -> !verona.unknown
-    %5 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %6 = verona.call "+"[%4 : !verona.unknown] (%5 : !verona.unknown) : !verona.unknown
-    %7 = "verona.alloca"() : () -> !verona.unknown
-    %8 = "verona.store"(%6, %7) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    %9 = "verona.load"(%0) : (!verona.meet<class<"S32">, iso>) -> !verona.unknown
-    %10 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %11 = verona.call "*"[%9 : !verona.unknown] (%10 : !verona.unknown) : !verona.unknown
-    %12 = "verona.alloca"() : () -> !verona.unknown
-    %13 = "verona.store"(%11, %12) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    %14 = "verona.load"(%0) : (!verona.meet<class<"S32">, iso>) -> !verona.unknown
-    %15 = "verona.load"(%2) : (!verona.meet<class<"U64">, imm>) -> !verona.unknown
-    %16 = verona.call "-"[%14 : !verona.unknown] (%15 : !verona.unknown) : !verona.unknown
-    %17 = "verona.store"(%16, %7) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    %18 = "verona.cast"(%17) : (!verona.unknown) -> !verona.class<"S64">
-    return %18 : !verona.class<"S64">
+    %0 = verona.call "+"[%arg0 : !verona.meet<class<"S32">, iso>] (%arg1 : !verona.meet<class<"U64">, imm>) : !verona.unknown
+    %1 = verona.call "*"[%arg0 : !verona.meet<class<"S32">, iso>] (%arg1 : !verona.meet<class<"U64">, imm>) : !verona.unknown
+    %2 = verona.call "-"[%arg0 : !verona.meet<class<"S32">, iso>] (%arg1 : !verona.meet<class<"U64">, imm>) : !verona.unknown
+    %3 = "verona.cast"(%0) : (!verona.unknown) -> !verona.class<"S64">
+    return %3 : !verona.class<"S64">
   }
 }

--- a/testsuite/mlir/mlir-parse/while-cont-brk/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while-cont-brk/mlir.txt
@@ -1,41 +1,30 @@
 module @"$module" {
   func @f(%arg0: !verona.class<"U32">, %arg1: !verona.class<"S32">) -> !verona.class<"F16"> attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !verona.class<"U32">
-    %1 = "verona.store"(%arg0, %0) : (!verona.class<"U32">, !verona.class<"U32">) -> !verona.unknown
-    %2 = "verona.alloca"() : () -> !verona.class<"S32">
-    %3 = "verona.store"(%arg1, %2) : (!verona.class<"S32">, !verona.class<"S32">) -> !verona.unknown
-    br ^bb1
-  ^bb1:  // 3 preds: ^bb0, ^bb4, ^bb7
-    %4 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
-    %5 = "verona.constant(5)"() : () -> !verona.class<"int">
-    %6 = verona.call "<"[%4 : !verona.unknown] (%5 : !verona.class<"int">) : !verona.unknown
-    %7 = "verona.cast"(%6) : (!verona.unknown) -> i1
-    cond_br %7, ^bb2, ^bb3
-  ^bb2:  // pred: ^bb1
-    %8 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
-    %9 = "verona.constant(1)"() : () -> !verona.class<"int">
-    %10 = verona.call "+"[%8 : !verona.unknown] (%9 : !verona.class<"int">) : !verona.unknown
-    %11 = "verona.store"(%10, %0) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
-    %12 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
-    %13 = "verona.load"(%2) : (!verona.class<"S32">) -> !verona.unknown
-    %14 = verona.call "<"[%12 : !verona.unknown] (%13 : !verona.unknown) : !verona.unknown
-    %15 = "verona.cast"(%14) : (!verona.unknown) -> i1
-    cond_br %15, ^bb4, ^bb5
-  ^bb3:  // 2 preds: ^bb1, ^bb6
-    %16 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
-    %17 = "verona.cast"(%16) : (!verona.unknown) -> !verona.class<"F16">
-    return %17 : !verona.class<"F16">
+    %0 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
+    br ^bb1(%0 : !verona.unknown)
+  ^bb1(%1: !verona.unknown):  // 3 preds: ^bb0, ^bb4, ^bb7
+    %2 = "verona.constant(5)"() : () -> !verona.class<"int">
+    %3 = verona.call "<"[%1 : !verona.unknown] (%2 : !verona.class<"int">) : !verona.unknown
+    %4 = "verona.cast"(%3) : (!verona.unknown) -> i1
+    cond_br %4, ^bb2(%1 : !verona.unknown), ^bb3(%1 : !verona.unknown)
+  ^bb2(%5: !verona.unknown):  // pred: ^bb1
+    %6 = "verona.constant(1)"() : () -> !verona.class<"int">
+    %7 = verona.call "+"[%5 : !verona.unknown] (%6 : !verona.class<"int">) : !verona.unknown
+    %8 = verona.call "<"[%7 : !verona.unknown] (%arg1 : !verona.class<"S32">) : !verona.unknown
+    %9 = "verona.cast"(%8) : (!verona.unknown) -> i1
+    cond_br %9, ^bb4, ^bb5
+  ^bb3(%10: !verona.unknown):  // 2 preds: ^bb1, ^bb6
+    %11 = "verona.cast"(%10) : (!verona.unknown) -> !verona.class<"F16">
+    return %11 : !verona.class<"F16">
   ^bb4:  // pred: ^bb2
-    br ^bb1
+    br ^bb1(%7 : !verona.unknown)
   ^bb5:  // pred: ^bb2
-    %18 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
-    %19 = "verona.load"(%2) : (!verona.class<"S32">) -> !verona.unknown
-    %20 = verona.call ">"[%18 : !verona.unknown] (%19 : !verona.unknown) : !verona.unknown
-    %21 = "verona.cast"(%20) : (!verona.unknown) -> i1
-    cond_br %21, ^bb6, ^bb7
+    %12 = verona.call ">"[%7 : !verona.unknown] (%arg1 : !verona.class<"S32">) : !verona.unknown
+    %13 = "verona.cast"(%12) : (!verona.unknown) -> i1
+    cond_br %13, ^bb6, ^bb7
   ^bb6:  // pred: ^bb5
-    br ^bb3
+    br ^bb3(%7 : !verona.unknown)
   ^bb7:  // pred: ^bb5
-    br ^bb1
+    br ^bb1(%5 : !verona.unknown)
   }
 }

--- a/testsuite/mlir/mlir-parse/while-cont-brk/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while-cont-brk/mlir.txt
@@ -25,6 +25,6 @@ module @"$module" {
   ^bb6:  // pred: ^bb5
     br ^bb3(%7 : !verona.unknown)
   ^bb7:  // pred: ^bb5
-    br ^bb1(%5 : !verona.unknown)
+    br ^bb1(%7 : !verona.unknown)
   }
 }

--- a/testsuite/mlir/mlir-parse/while-context/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while-context/mlir.txt
@@ -13,7 +13,7 @@ module @"$module" {
     %8 = "verona.constant(3)"() : () -> !verona.class<"int">
     %9 = verona.call "+"[%7 : !verona.class<"int">] (%8 : !verona.class<"int">) : !verona.unknown
     %10 = verona.call "+"[%6 : !verona.unknown] (%9 : !verona.unknown) : !verona.unknown
-    br ^bb1(%6 : !verona.unknown)
+    br ^bb1(%10 : !verona.unknown)
   ^bb3(%11: !verona.unknown):  // pred: ^bb1
     %12 = "verona.cast"(%11) : (!verona.unknown) -> !verona.class<"F64">
     return %12 : !verona.class<"F64">

--- a/testsuite/mlir/mlir-parse/while-context/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while-context/mlir.txt
@@ -1,34 +1,21 @@
 module @"$module" {
   func @f(%arg0: !verona.class<"F32">) -> !verona.class<"F64"> attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !verona.class<"F32">
-    %1 = "verona.store"(%arg0, %0) : (!verona.class<"F32">, !verona.class<"F32">) -> !verona.unknown
-    %2 = "verona.constant(1)"() : () -> !verona.class<"int">
-    %3 = "verona.alloca"() : () -> !verona.unknown
-    %4 = "verona.store"(%2, %3) : (!verona.class<"int">, !verona.unknown) -> !verona.unknown
-    br ^bb1
-  ^bb1:  // 2 preds: ^bb0, ^bb2
-    %5 = "verona.load"(%0) : (!verona.class<"F32">) -> !verona.unknown
-    %6 = "verona.constant(5)"() : () -> !verona.class<"int">
-    %7 = verona.call "<"[%5 : !verona.unknown] (%6 : !verona.class<"int">) : !verona.unknown
-    %8 = "verona.cast"(%7) : (!verona.unknown) -> i1
-    cond_br %8, ^bb2, ^bb3
-  ^bb2:  // pred: ^bb1
-    %9 = "verona.constant(2)"() : () -> !verona.class<"int">
-    %10 = "verona.alloca"() : () -> !verona.unknown
-    %11 = "verona.store"(%9, %10) : (!verona.class<"int">, !verona.unknown) -> !verona.unknown
-    %12 = "verona.load"(%10) : (!verona.unknown) -> !verona.unknown
-    %13 = "verona.constant(3)"() : () -> !verona.class<"int">
-    %14 = verona.call "+"[%12 : !verona.unknown] (%13 : !verona.class<"int">) : !verona.unknown
-    %15 = "verona.alloca"() : () -> !verona.unknown
-    %16 = "verona.store"(%14, %15) : (!verona.unknown, !verona.unknown) -> !verona.unknown
-    %17 = "verona.load"(%0) : (!verona.class<"F32">) -> !verona.unknown
-    %18 = "verona.load"(%15) : (!verona.unknown) -> !verona.unknown
-    %19 = verona.call "+"[%17 : !verona.unknown] (%18 : !verona.unknown) : !verona.unknown
-    %20 = "verona.store"(%19, %0) : (!verona.unknown, !verona.class<"F32">) -> !verona.unknown
-    br ^bb1
-  ^bb3:  // pred: ^bb1
-    %21 = "verona.load"(%0) : (!verona.class<"F32">) -> !verona.unknown
-    %22 = "verona.cast"(%21) : (!verona.unknown) -> !verona.class<"F64">
-    return %22 : !verona.class<"F64">
+    %0 = "verona.constant(1)"() : () -> !verona.class<"int">
+    %1 = "verona.cast"(%arg0) : (!verona.class<"F32">) -> !verona.unknown
+    br ^bb1(%1 : !verona.unknown)
+  ^bb1(%2: !verona.unknown):  // 2 preds: ^bb0, ^bb2
+    %3 = "verona.constant(5)"() : () -> !verona.class<"int">
+    %4 = verona.call "<"[%2 : !verona.unknown] (%3 : !verona.class<"int">) : !verona.unknown
+    %5 = "verona.cast"(%4) : (!verona.unknown) -> i1
+    cond_br %5, ^bb2(%2 : !verona.unknown), ^bb3(%2 : !verona.unknown)
+  ^bb2(%6: !verona.unknown):  // pred: ^bb1
+    %7 = "verona.constant(2)"() : () -> !verona.class<"int">
+    %8 = "verona.constant(3)"() : () -> !verona.class<"int">
+    %9 = verona.call "+"[%7 : !verona.class<"int">] (%8 : !verona.class<"int">) : !verona.unknown
+    %10 = verona.call "+"[%6 : !verona.unknown] (%9 : !verona.unknown) : !verona.unknown
+    br ^bb1(%6 : !verona.unknown)
+  ^bb3(%11: !verona.unknown):  // pred: ^bb1
+    %12 = "verona.cast"(%11) : (!verona.unknown) -> !verona.class<"F64">
+    return %12 : !verona.class<"F64">
   }
 }

--- a/testsuite/mlir/mlir-parse/while-if/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while-if/mlir.txt
@@ -17,8 +17,8 @@ module @"$module" {
   ^bb4:  // pred: ^bb2
     %10 = "verona.constant(1)"() : () -> !verona.class<"int">
     %11 = verona.call "+"[%5 : !verona.unknown] (%10 : !verona.class<"int">) : !verona.unknown
-    br ^bb5(%5 : !verona.unknown)
+    br ^bb5(%11 : !verona.unknown)
   ^bb5(%12: !verona.unknown):  // 2 preds: ^bb2, ^bb4
-    br ^bb1(%5 : !verona.unknown)
+    br ^bb1(%12 : !verona.unknown)
   }
 }

--- a/testsuite/mlir/mlir-parse/while-if/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while-if/mlir.txt
@@ -1,33 +1,24 @@
 module @"$module" {
   func @f(%arg0: !verona.class<"U32">, %arg1: !verona.class<"S32">) -> !verona.class<"U32"> attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !verona.class<"U32">
-    %1 = "verona.store"(%arg0, %0) : (!verona.class<"U32">, !verona.class<"U32">) -> !verona.unknown
-    %2 = "verona.alloca"() : () -> !verona.class<"S32">
-    %3 = "verona.store"(%arg1, %2) : (!verona.class<"S32">, !verona.class<"S32">) -> !verona.unknown
-    br ^bb1
-  ^bb1:  // 2 preds: ^bb0, ^bb5
-    %4 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
-    %5 = "verona.constant(5)"() : () -> !verona.class<"int">
-    %6 = verona.call "<"[%4 : !verona.unknown] (%5 : !verona.class<"int">) : !verona.unknown
+    %0 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
+    br ^bb1(%0 : !verona.unknown)
+  ^bb1(%1: !verona.unknown):  // 2 preds: ^bb0, ^bb5
+    %2 = "verona.constant(5)"() : () -> !verona.class<"int">
+    %3 = verona.call "<"[%1 : !verona.unknown] (%2 : !verona.class<"int">) : !verona.unknown
+    %4 = "verona.cast"(%3) : (!verona.unknown) -> i1
+    cond_br %4, ^bb2(%1 : !verona.unknown), ^bb3(%1 : !verona.unknown)
+  ^bb2(%5: !verona.unknown):  // pred: ^bb1
+    %6 = verona.call "!="[%5 : !verona.unknown] (%arg1 : !verona.class<"S32">) : !verona.unknown
     %7 = "verona.cast"(%6) : (!verona.unknown) -> i1
-    cond_br %7, ^bb2, ^bb3
-  ^bb2:  // pred: ^bb1
-    %8 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
-    %9 = "verona.load"(%2) : (!verona.class<"S32">) -> !verona.unknown
-    %10 = verona.call "!="[%8 : !verona.unknown] (%9 : !verona.unknown) : !verona.unknown
-    %11 = "verona.cast"(%10) : (!verona.unknown) -> i1
-    cond_br %11, ^bb4, ^bb5
-  ^bb3:  // pred: ^bb1
-    %12 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
-    %13 = "verona.cast"(%12) : (!verona.unknown) -> !verona.class<"U32">
-    return %13 : !verona.class<"U32">
+    cond_br %7, ^bb4, ^bb5(%5 : !verona.unknown)
+  ^bb3(%8: !verona.unknown):  // pred: ^bb1
+    %9 = "verona.cast"(%8) : (!verona.unknown) -> !verona.class<"U32">
+    return %9 : !verona.class<"U32">
   ^bb4:  // pred: ^bb2
-    %14 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
-    %15 = "verona.constant(1)"() : () -> !verona.class<"int">
-    %16 = verona.call "+"[%14 : !verona.unknown] (%15 : !verona.class<"int">) : !verona.unknown
-    %17 = "verona.store"(%16, %0) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
-    br ^bb5
-  ^bb5:  // 2 preds: ^bb2, ^bb4
-    br ^bb1
+    %10 = "verona.constant(1)"() : () -> !verona.class<"int">
+    %11 = verona.call "+"[%5 : !verona.unknown] (%10 : !verona.class<"int">) : !verona.unknown
+    br ^bb5(%5 : !verona.unknown)
+  ^bb5(%12: !verona.unknown):  // 2 preds: ^bb2, ^bb4
+    br ^bb1(%5 : !verona.unknown)
   }
 }

--- a/testsuite/mlir/mlir-parse/while/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while/mlir.txt
@@ -10,7 +10,7 @@ module @"$module" {
   ^bb2(%5: !verona.unknown):  // pred: ^bb1
     %6 = "verona.constant(1)"() : () -> !verona.class<"int">
     %7 = verona.call "+"[%5 : !verona.unknown] (%6 : !verona.class<"int">) : !verona.unknown
-    br ^bb1(%5 : !verona.unknown)
+    br ^bb1(%7 : !verona.unknown)
   ^bb3(%8: !verona.unknown):  // pred: ^bb1
     br ^bb4(%8 : !verona.unknown)
   ^bb4(%9: !verona.unknown):  // 2 preds: ^bb3, ^bb5
@@ -20,7 +20,7 @@ module @"$module" {
   ^bb5(%12: !verona.unknown):  // pred: ^bb4
     %13 = "verona.constant(1)"() : () -> !verona.class<"int">
     %14 = verona.call "-"[%12 : !verona.unknown] (%13 : !verona.class<"int">) : !verona.unknown
-    br ^bb4(%12 : !verona.unknown)
+    br ^bb4(%14 : !verona.unknown)
   ^bb6(%15: !verona.unknown):  // pred: ^bb4
     %16 = "verona.cast"(%15) : (!verona.unknown) -> !verona.class<"U32">
     return %16 : !verona.class<"U32">

--- a/testsuite/mlir/mlir-parse/while/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while/mlir.txt
@@ -1,35 +1,28 @@
 module @"$module" {
   func @f(%arg0: !verona.class<"U32">) -> !verona.class<"U32"> attributes {class = !verona.class<"$module">} {
-    %0 = "verona.alloca"() : () -> !verona.class<"U32">
-    %1 = "verona.store"(%arg0, %0) : (!verona.class<"U32">, !verona.class<"U32">) -> !verona.unknown
-    br ^bb1
-  ^bb1:  // 2 preds: ^bb0, ^bb2
-    %2 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
-    %3 = "verona.constant(5)"() : () -> !verona.class<"int">
-    %4 = verona.call "<"[%2 : !verona.unknown] (%3 : !verona.class<"int">) : !verona.unknown
-    %5 = "verona.cast"(%4) : (!verona.unknown) -> i1
-    cond_br %5, ^bb2, ^bb3
-  ^bb2:  // pred: ^bb1
-    %6 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
-    %7 = "verona.constant(1)"() : () -> !verona.class<"int">
-    %8 = verona.call "+"[%6 : !verona.unknown] (%7 : !verona.class<"int">) : !verona.unknown
-    %9 = "verona.store"(%8, %0) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
-    br ^bb1
-  ^bb3:  // pred: ^bb1
-    br ^bb4
-  ^bb4:  // 2 preds: ^bb3, ^bb5
+    %0 = "verona.cast"(%arg0) : (!verona.class<"U32">) -> !verona.unknown
+    br ^bb1(%0 : !verona.unknown)
+  ^bb1(%1: !verona.unknown):  // 2 preds: ^bb0, ^bb2
+    %2 = "verona.constant(5)"() : () -> !verona.class<"int">
+    %3 = verona.call "<"[%1 : !verona.unknown] (%2 : !verona.class<"int">) : !verona.unknown
+    %4 = "verona.cast"(%3) : (!verona.unknown) -> i1
+    cond_br %4, ^bb2(%1 : !verona.unknown), ^bb3(%1 : !verona.unknown)
+  ^bb2(%5: !verona.unknown):  // pred: ^bb1
+    %6 = "verona.constant(1)"() : () -> !verona.class<"int">
+    %7 = verona.call "+"[%5 : !verona.unknown] (%6 : !verona.class<"int">) : !verona.unknown
+    br ^bb1(%5 : !verona.unknown)
+  ^bb3(%8: !verona.unknown):  // pred: ^bb1
+    br ^bb4(%8 : !verona.unknown)
+  ^bb4(%9: !verona.unknown):  // 2 preds: ^bb3, ^bb5
     %10 = "verona.constant(false)"() : () -> !verona.class<"bool">
     %11 = "verona.cast"(%10) : (!verona.class<"bool">) -> i1
-    cond_br %11, ^bb5, ^bb6
-  ^bb5:  // pred: ^bb4
-    %12 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
+    cond_br %11, ^bb5(%9 : !verona.unknown), ^bb6(%9 : !verona.unknown)
+  ^bb5(%12: !verona.unknown):  // pred: ^bb4
     %13 = "verona.constant(1)"() : () -> !verona.class<"int">
     %14 = verona.call "-"[%12 : !verona.unknown] (%13 : !verona.class<"int">) : !verona.unknown
-    %15 = "verona.store"(%14, %0) : (!verona.unknown, !verona.class<"U32">) -> !verona.unknown
-    br ^bb4
-  ^bb6:  // pred: ^bb4
-    %16 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown
-    %17 = "verona.cast"(%16) : (!verona.unknown) -> !verona.class<"U32">
-    return %17 : !verona.class<"U32">
+    br ^bb4(%12 : !verona.unknown)
+  ^bb6(%15: !verona.unknown):  // pred: ^bb4
+    %16 = "verona.cast"(%15) : (!verona.unknown) -> !verona.class<"U32">
+    return %16 : !verona.class<"U32">
   }
 }


### PR DESCRIPTION
This is a big change in two areas: conditionals and loops. 

Essentially, it moves away from `alloca` for all variables to use SSA values and track them via `writes minus defs` in the AST and use those as arguments to the basic blocks. This allowed us to remove a lot of code that was generating loads and stores, checking for allocas and makes the IR much leaner and simpler to process.

It has two main shortcomings:
1. Because of the flat analysis (on the AST), it may add additional arguments to basic blocks that don't need it, especially in loops' back-edges. This can later be removed with a pass that looks at back-edges and clean them up, or possibly a more generic pass that builds on the existing MLIR block argument pass.
2. To avoid complexity in the basic type check (on `verify`), all block arguments have type `unknown`. A type check pass can populate those with the right level of abstraction, considering the types of branch operands and arguments that reach each other, and make sure all types are covariant, contra-variant and whatever is needed in each case.

The current consensus is that there will be a stage, possibly right after type inference, where there could be no `unknown` types at all in the IR, and no new ones can be created. From then on, *all* type validation should pass after every transformation.

Both of these shortcomings have solutions that shouldn't explode in complexity, so for the time being, it should be fine.

Fixes #322.