### PR TITLE
Support matching with an interface type.

### DIFF
--- a/src/interpreter/bytecode.h
+++ b/src/interpreter/bytecode.h
@@ -27,9 +27,11 @@
  * - 32-bit number of fields
  * - 32-bit size of the methods vtables
  * - 32-bit number of methods
+ * - 32-bit number of subtypes
  * - 32-bit offset to finaliser
  * - For each field, 32-bit selector index
  * - For each method, 32-bit selector index and 32-bit absolute offset
+ * - For each subtype, 32-bit descriptor index.
  *
  * Methods:
  * - 16-bit name length, followed by the name bytes

--- a/src/interpreter/object.cc
+++ b/src/interpreter/object.cc
@@ -9,12 +9,14 @@
 namespace verona::interpreter
 {
   VMDescriptor::VMDescriptor(
+    bytecode::DescriptorIdx index,
     std::string_view name,
     size_t method_slots,
     size_t field_slots,
     size_t field_count,
     uint32_t finaliser_ip)
-  : name(name),
+  : index(index),
+    name(name),
     methods(std::make_unique<uint32_t[]>(method_slots)),
     fields(std::make_unique<uint32_t[]>(field_slots)),
     field_count(field_count),
@@ -36,6 +38,10 @@ namespace verona::interpreter
     // TODO: Can be optimised if we look at the types of all the fields
     rt::Descriptor::finaliser =
       finaliser_ip > 0 ? VMObject::finaliser_fn : VMObject::collect_iso_fields;
+
+    // Make sure `subtypes` is reflexive. This simplifies code that uses the
+    // set, by removing special casing.
+    subtypes.insert(index);
   }
 
   VMObject::VMObject(VMObject* region, const VMDescriptor* desc)

--- a/src/interpreter/object.h
+++ b/src/interpreter/object.h
@@ -5,6 +5,7 @@
 #include "interpreter/bytecode.h"
 #include "interpreter/value.h"
 
+#include <unordered_set>
 #include <verona.h>
 
 namespace verona::interpreter
@@ -12,16 +13,19 @@ namespace verona::interpreter
   struct VMDescriptor : public rt::Descriptor
   {
     VMDescriptor(
+      bytecode::DescriptorIdx index,
       std::string_view name,
       size_t method_slots,
       size_t field_slots,
       size_t field_count,
       uint32_t finaliser_ip);
 
+    const bytecode::DescriptorIdx index;
     const std::string name;
     const size_t field_count;
     std::unique_ptr<uint32_t[]> fields;
     std::unique_ptr<uint32_t[]> methods;
+    std::unordered_set<bytecode::DescriptorIdx> subtypes;
     const uint32_t finaliser_ip;
   };
 

--- a/src/interpreter/vm.cc
+++ b/src/interpreter/vm.cc
@@ -361,8 +361,12 @@ namespace verona::interpreter
       case Value::ISO:
       case Value::IMM:
       case Value::MUT:
-        result = (src->object->descriptor() == descriptor);
+      {
+        auto it = descriptor->subtypes.find(src->object->descriptor()->index);
+        result = (it != descriptor->subtypes.end());
         break;
+      }
+
       case Value::COWN_UNOWNED:
         // This type should only appear in message.
         abort();

--- a/testsuite/features/run-pass/match-structural.verona
+++ b/testsuite/features/run-pass/match-structural.verona
@@ -1,0 +1,46 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+// Test pattern matching against interface types.
+// Classes A and B implement I, but C does not.
+// All of A, B and C implement Any.
+
+interface I {
+  m(self: mut);
+}
+class A {
+  m(self: mut) { }
+}
+class B {
+  m(self: mut) { }
+}
+class C { }
+interface Any { }
+
+class Main
+{
+  do_match(x: Any & mut)
+  {
+    match x {
+      var _: A => Builtin.print("A\n"),
+      var _: I => Builtin.print("I\n"),
+      var _: Any => Builtin.print("Any\n"),
+    }
+  }
+
+  main() {
+    // CHECK-L: A
+    // CHECK-L: I
+    // CHECK-L: Any
+    Main.do_match(mut-view (new A));
+    Main.do_match(mut-view (new B));
+    Main.do_match(mut-view (new C));
+  }
+}
+
+static_assert(A subtype I);
+static_assert(B subtype I);
+static_assert(C not subtype I);
+static_assert(A subtype Any);
+static_assert(B subtype Any);
+static_assert(C subtype Any);


### PR DESCRIPTION
For every interface, codegen emits the list of subtypes. During
matching, rather than requiring strict equality of descriptors, we
search through the subtypes of the match type looking for the
descriptor of the object being matched on.