### PR TITLE
Widen the set of types that may be used in pattern matching

### DIFF
--- a/src/compiler/ast.h
+++ b/src/compiler/ast.h
@@ -583,9 +583,6 @@ namespace verona::compiler
   struct TypeExpression : public SourceLocatableMixin<ASTContainer>
   {};
 
-  struct StringTypeExpr final : public TypeExpression
-  {};
-
   struct SymbolTypeExpr final : public TypeExpression
   {
     ASTChild<Name> name;

--- a/src/compiler/codegen/descriptor.cc
+++ b/src/compiler/codegen/descriptor.cc
@@ -177,6 +177,7 @@ namespace verona::compiler
       gen.u32(selectors.get(Selector::method("main", TypeList())));
 
       emit_optional_special_descriptor("U64");
+      emit_optional_special_descriptor("String");
     }
 
   private:

--- a/src/compiler/codegen/ir.h
+++ b/src/compiler/codegen/ir.h
@@ -356,15 +356,16 @@ namespace verona::compiler
     void visit_term(const MatchTerminator& term)
     {
       Register input = variable(term.input);
+      Register match_result = allocator_.get();
 
       for (const auto& arm : term.arms)
       {
         TypePtr reified_pattern = reify(arm.type);
-        Register result = EmitMatch(this).visit_type(reified_pattern, input);
+        EmitMatch(this, input).visit_type(reified_pattern, match_result);
 
         size_t opcode_start = gen_.current_offset();
         gen_.opcode(Opcode::JumpIf);
-        gen_.reg(result);
+        gen_.reg(match_result);
         reference_basic_block(arm.target, opcode_start);
       }
       gen_.opcode(Opcode::Unreachable);
@@ -451,33 +452,30 @@ namespace verona::compiler
      * value being matched on is located. It returns a register which holds the
      * boolean result.
      */
-    struct EmitMatch : public TypeVisitor<Register, Register>
+    struct EmitMatch : public TypeVisitor<void, Register>
     {
-      EmitMatch(IRGenerator* parent) : parent(parent) {}
+      EmitMatch(IRGenerator* parent, Register input)
+      : parent(parent), input(input)
+      {}
 
-      Register
-      visit_entity_type(const EntityTypePtr& entity, Register input) override
+      void
+      visit_entity_type(const EntityTypePtr& entity, Register output) override
       {
-        Register result = parent->allocator_.get();
         Register descriptor = parent->allocator_.get();
 
         Descriptor index =
           parent->entity_descriptor(entity->definition, entity->arguments);
         parent->emit_load_descriptor(descriptor, index);
         parent->gen_.opcode(Opcode::MatchDescriptor);
-        parent->gen_.reg(result);
+        parent->gen_.reg(output);
         parent->gen_.reg(input);
         parent->gen_.reg(descriptor);
-
-        return result;
       }
 
-      Register visit_capability(
-        const CapabilityTypePtr& capability, Register input) override
+      void visit_capability(
+        const CapabilityTypePtr& capability, Register output) override
       {
-        Register result = parent->allocator_.get();
         bytecode::Capability kind;
-
         switch (capability->kind)
         {
           case CapabilityKind::Isolated:
@@ -500,21 +498,86 @@ namespace verona::compiler
         }
 
         parent->gen_.opcode(Opcode::MatchCapability);
-        parent->gen_.reg(result);
+        parent->gen_.reg(output);
         parent->gen_.reg(input);
         parent->gen_.u8(static_cast<uint8_t>(kind));
-        return result;
       }
 
-      Register visit_base_type(const TypePtr& type, Register input) override
+      void visit_union(const UnionTypePtr& type, Register output) override
+      {
+        emit_connective_match(
+          output, type->elements, 0, bytecode::BinaryOperator::Or);
+      }
+
+      void visit_intersection(
+        const IntersectionTypePtr& type, Register output) override
+      {
+        emit_connective_match(
+          output, type->elements, 0, bytecode::BinaryOperator::And);
+      }
+
+      void visit_base_type(const TypePtr& type, Register input) override
       {
         fmt::print(
           std::cerr, "Matching against type {} is not supported\n", *type);
         abort();
       }
 
+      /**
+       * Emit the match code for a union or intersection type. This matches the
+       * input against every elements of the connective, and combines the
+       * results using `op`. If the connective is empty, we directly produce
+       * `identity` as the result.
+       *
+       * TODO: this could generate more efficient code by short-circuting the
+       * process. For instance when matching on (A & B), if the A match fails
+       * there is no point in trying to match against B.
+       *
+       * Additionally this makes very inefficient use of register allocation,
+       * just like the rest of the code generator.
+       */
+      void emit_connective_match(
+        Register output,
+        const TypeSet& elements,
+        uint64_t identity,
+        bytecode::BinaryOperator op)
+      {
+        if (elements.empty())
+        {
+          parent->gen_.opcode(Opcode::Int64);
+          parent->gen_.reg(output);
+          parent->gen_.u64(identity);
+        }
+        else
+        {
+          // Unions and intersections are always normalised such that they are
+          // elided when they only have a single component.
+          assert(elements.size() > 1);
+
+          // We evaluate the first element and place the result in `output`.
+          // We then evaluate each subsequent element into `rhs`, and fold the
+          // results into `output` using the specified boolean operator.
+          auto it = elements.begin();
+          visit_type(*it, output);
+          it++;
+
+          Register rhs = parent->allocator_.get();
+          for (; it != elements.end(); it++)
+          {
+            visit_type(*it, rhs);
+
+            parent->gen_.opcode(Opcode::BinOp);
+            parent->gen_.reg(output);
+            parent->gen_.u8(static_cast<uint8_t>(op));
+            parent->gen_.reg(output);
+            parent->gen_.reg(rhs);
+          }
+        }
+      }
+
     private:
       IRGenerator* parent;
+      Register input;
     };
 
     const Reachability& reachability_;

--- a/src/compiler/freevars.h
+++ b/src/compiler/freevars.h
@@ -198,11 +198,6 @@ namespace verona::compiler
       return FreeVariables();
     }
 
-    FreeVariables visit_string_type(const StringTypePtr& ty) final
-    {
-      return FreeVariables();
-    }
-
     FreeVariables visit_fixpoint_type(const FixpointTypePtr& ty) final
     {
       FreeVariables result = free_variables(ty->inner);

--- a/src/compiler/intern.cc
+++ b/src/compiler/intern.cc
@@ -315,8 +315,7 @@ namespace verona::compiler
       type->dyncast<DelayedFieldViewType>() || type->dyncast<EntityOfType>() ||
       type->dyncast<EntityType>() || type->dyncast<HasAppliedMethodType>() ||
       type->dyncast<HasFieldType>() || type->dyncast<HasMethodType>() ||
-      type->dyncast<StringType>() || type->dyncast<IsEntityType>() ||
-      type->dyncast<UnitType>())
+      type->dyncast<IsEntityType>() || type->dyncast<UnitType>())
       return type;
 
     if (type->dyncast<TypeParameter>() || type->dyncast<InferType>())
@@ -397,8 +396,7 @@ namespace verona::compiler
       type->dyncast<DelayedFieldViewType>() || type->dyncast<EntityOfType>() ||
       type->dyncast<EntityType>() || type->dyncast<HasAppliedMethodType>() ||
       type->dyncast<HasFieldType>() || type->dyncast<HasMethodType>() ||
-      type->dyncast<StringType>() || type->dyncast<IsEntityType>() ||
-      type->dyncast<UnitType>())
+      type->dyncast<IsEntityType>() || type->dyncast<UnitType>())
       return type;
 
     // TODO: We never actually create UnapplyRegionType anymore, so we could
@@ -416,7 +414,7 @@ namespace verona::compiler
     if (left->dyncast<EntityType>() || left->dyncast<EntityOfType>())
       return mk_top();
 
-    if (right->dyncast<EntityType>() || right->dyncast<StringType>())
+    if (right->dyncast<EntityType>())
       return right;
 
     if (auto isect = left->dyncast<IntersectionType>())
@@ -668,11 +666,6 @@ namespace verona::compiler
     return intern(IsEntityType());
   }
 
-  StringTypePtr TypeInterner::mk_string_type()
-  {
-    return intern(StringType());
-  }
-
   FixpointTypePtr TypeInterner::mk_fixpoint(TypePtr inner)
   {
     assert(is_interned(inner));
@@ -747,9 +740,9 @@ namespace verona::compiler
 
     // These are all entity-like types already.
     if (
-      inner->dyncast<EntityType>() || inner->dyncast<StringType>() ||
-      inner->dyncast<UnitType>() || inner->dyncast<EntityOfType>() ||
-      inner->dyncast<HasFieldType>() || inner->dyncast<HasMethodType>() ||
+      inner->dyncast<EntityType>() || inner->dyncast<UnitType>() ||
+      inner->dyncast<EntityOfType>() || inner->dyncast<HasFieldType>() ||
+      inner->dyncast<HasMethodType>() ||
       inner->dyncast<HasAppliedMethodType>() ||
       inner->dyncast<DelayedFieldViewType>())
       return inner;
@@ -845,9 +838,8 @@ namespace verona::compiler
       type->dyncast<DelayedFieldViewType>() || type->dyncast<EntityOfType>() ||
       type->dyncast<EntityType>() || type->dyncast<HasAppliedMethodType>() ||
       type->dyncast<HasFieldType>() || type->dyncast<HasMethodType>() ||
-      type->dyncast<StringType>() || type->dyncast<IsEntityType>() ||
-      type->dyncast<StaticType>() || type->dyncast<UnitType>() ||
-      type->dyncast<TypeParameter>())
+      type->dyncast<IsEntityType>() || type->dyncast<StaticType>() ||
+      type->dyncast<UnitType>() || type->dyncast<TypeParameter>())
       return type;
 
     if (
@@ -948,9 +940,8 @@ namespace verona::compiler
       type->dyncast<DelayedFieldViewType>() || type->dyncast<EntityOfType>() ||
       type->dyncast<EntityType>() || type->dyncast<HasAppliedMethodType>() ||
       type->dyncast<HasFieldType>() || type->dyncast<HasMethodType>() ||
-      type->dyncast<StringType>() || type->dyncast<IsEntityType>() ||
-      type->dyncast<StaticType>() || type->dyncast<UnitType>() ||
-      type->dyncast<TypeParameter>())
+      type->dyncast<IsEntityType>() || type->dyncast<StaticType>() ||
+      type->dyncast<UnitType>() || type->dyncast<TypeParameter>())
       return type;
 
     if (
@@ -1147,7 +1138,6 @@ namespace verona::compiler
     DISPATCH(PathCompressionType);
     DISPATCH(RangeType);
     DISPATCH(StaticType);
-    DISPATCH(StringType);
     DISPATCH(TypeParameter);
     DISPATCH(UnapplyRegionType);
     DISPATCH(UnionType);

--- a/src/compiler/intern.h
+++ b/src/compiler/intern.h
@@ -93,7 +93,6 @@ namespace verona::compiler
     IsEntityTypePtr mk_is_entity();
 
     UnitTypePtr mk_unit();
-    StringTypePtr mk_string_type();
 
     FixpointTypePtr mk_fixpoint(TypePtr inner);
     FixpointVariableTypePtr mk_fixpoint_variable(uint64_t depth);

--- a/src/compiler/mapper.cc
+++ b/src/compiler/mapper.cc
@@ -120,11 +120,6 @@ namespace verona::compiler
     return context().mk_is_entity();
   }
 
-  TypePtr RecursiveTypeMapper::visit_string_type(const StringTypePtr& ty)
-  {
-    return context().mk_string_type();
-  }
-
   TypePtr RecursiveTypeMapper::visit_fixpoint_type(const FixpointTypePtr& ty)
   {
     return context().mk_fixpoint(apply(ty->inner));

--- a/src/compiler/mapper.h
+++ b/src/compiler/mapper.h
@@ -181,7 +181,6 @@ namespace verona::compiler
     TypePtr
     visit_has_applied_method_type(const HasAppliedMethodTypePtr& ty) override;
     TypePtr visit_is_entity_type(const IsEntityTypePtr& ty) override;
-    TypePtr visit_string_type(const StringTypePtr& ty) override;
     TypePtr visit_fixpoint_type(const FixpointTypePtr& ty) override;
     TypePtr
     visit_fixpoint_variable_type(const FixpointVariableTypePtr& ty) override;

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -83,9 +83,8 @@ namespace verona::compiler
 
     Rule keyword = term(
       "while"_E | "if" | "class" | "interface" | "primitive" | "var" | "unit" |
-      "match" | "String" | "iso" | "mut" | "imm" | "mut-view" | "in" |
-      "static_assert" | "not" | "subtype" | "when" | "from" | "where" | "else" |
-      "builtin");
+      "match" | "iso" | "mut" | "imm" | "mut-view" | "in" | "static_assert" |
+      "not" | "subtype" | "when" | "from" | "where" | "else" | "builtin");
 
     Rule self = term("self");
     Rule self_def = self;
@@ -186,13 +185,12 @@ namespace verona::compiler
 
     Rule capability_kind = isolated | mutable_ | immutable;
     Rule capability_type = capability_kind;
-    Rule string_type = "String"_E;
     Rule symbol_type = ref_ident >> -brackets(comma_sep(type));
     Rule union_type = sep_by2(type1, "|");
     Rule intersection_type = sep_by2(type1, "&");
     Rule viewpoint_type = type1 >> "->" >> (viewpoint_type | type1);
 
-    Rule type1 = parens(type) | symbol_type | capability_type | string_type;
+    Rule type1 = parens(type) | symbol_type | capability_type;
     Rule type = union_type | intersection_type | viewpoint_type | type1;
 
     Rule type_param_kind_class = "class"_E;
@@ -335,7 +333,6 @@ namespace verona::compiler
     BindAST<BinaryOperatorExpr> binary_operator_expr = g.binary_operator_expr;
 
     BindAST<CapabilityTypeExpr> capability_type = g.capability_type;
-    BindAST<StringTypeExpr> string_type = g.string_type;
     BindAST<IntersectionTypeExpr> intersection_type = g.intersection_type;
     BindAST<SymbolTypeExpr> symbol_type = g.symbol_type;
     BindAST<UnionTypeExpr> union_type = g.union_type;

--- a/src/compiler/printing.cc
+++ b/src/compiler/printing.cc
@@ -255,10 +255,6 @@ namespace verona::compiler
     {
       print("(is-entity)");
     }
-    void visit_string_type(const StringTypePtr& ty) final
-    {
-      print("(string)");
-    }
     void visit_fixpoint_type(const FixpointTypePtr& ty) final
     {
       print("(fixpoint {})", *ty->inner);
@@ -332,11 +328,6 @@ namespace verona::compiler
     void visit_type_sequence(const BoundedTypeSequence& seq)
     {
       print("[{}]", comma_sep(seq.types));
-    }
-
-    void visit_string_type_expr(StringTypeExpr& te)
-    {
-      print("(string)");
     }
 
     void visit_symbol_type_expr(SymbolTypeExpr& te)

--- a/src/compiler/resolution.cc
+++ b/src/compiler/resolution.cc
@@ -468,11 +468,6 @@ namespace verona::compiler
       push_scope([&]() { visit_expr(*expr.inner); });
     }
 
-    TypePtr visit_string_type_expr(StringTypeExpr& te)
-    {
-      return context_.mk_string_type();
-    }
-
     TypePtr visit_symbol_type_expr(SymbolTypeExpr& te)
     {
       te.symbol = resolve(te.name);

--- a/src/compiler/type.h
+++ b/src/compiler/type.h
@@ -477,19 +477,6 @@ namespace verona::compiler
   };
   typedef std::shared_ptr<const IsEntityType> IsEntityTypePtr;
 
-  struct StringType final : public Type
-  {
-    bool operator<(const StringType& other) const
-    {
-      return false;
-    }
-
-  private:
-    StringType() {}
-    friend TypeInterner;
-  };
-  typedef std::shared_ptr<const StringType> StringTypePtr;
-
   struct FixpointType : public Type
   {
     TypePtr inner;

--- a/src/compiler/type_visitor.h
+++ b/src/compiler/type_visitor.h
@@ -7,6 +7,7 @@
 
 #include <fmt/ostream.h>
 #include <iostream>
+
 /**
  * Visitors for the Type representation.
  *
@@ -116,10 +117,6 @@ namespace verona::compiler
       else if (auto ty_ = ty->dyncast<IsEntityType>())
       {
         return visit_is_entity_type(ty_, std::forward<Args>(args)...);
-      }
-      else if (auto ty_ = ty->dyncast<StringType>())
-      {
-        return visit_string_type(ty_, std::forward<Args>(args)...);
       }
       else if (auto ty_ = ty->dyncast<FixpointType>())
       {
@@ -248,10 +245,6 @@ namespace verona::compiler
     {
       return visit_base_type(ty, std::forward<Args>(args)...);
     }
-    virtual Return visit_string_type(const StringTypePtr& ty, Args... args)
-    {
-      return visit_base_type(ty, std::forward<Args>(args)...);
-    }
     virtual Return visit_fixpoint_type(const FixpointTypePtr& ty, Args... args)
     {
       return visit_base_type(ty, std::forward<Args>(args)...);
@@ -342,7 +335,6 @@ namespace verona::compiler
       this->visit_type(ty->inner, args...);
     }
 
-    void visit_string_type(const StringTypePtr& ty, Args... args) override {}
     void visit_type_parameter(const TypeParameterPtr& ty, Args... args) override
     {}
     void visit_unit_type(const UnitTypePtr& ty, Args... args) override {}

--- a/src/compiler/typecheck/capability_predicate.cc
+++ b/src/compiler/typecheck/capability_predicate.cc
@@ -107,10 +107,6 @@ namespace verona::compiler
     {
       return CapabilityPredicate::Sendable | CapabilityPredicate::NonLinear;
     }
-    PredicateSet visit_string_type(const StringTypePtr& type) final
-    {
-      return CapabilityPredicate::Sendable | CapabilityPredicate::NonLinear;
-    }
 
     PredicateSet visit_union(const UnionTypePtr& type) final
     {

--- a/src/compiler/typecheck/constraint.cc
+++ b/src/compiler/typecheck/constraint.cc
@@ -354,18 +354,6 @@ namespace verona::compiler
     }
 
     /*
-     * --------------------
-     *   String <: String
-     */
-    if (auto left = c.left->dyncast<StringType>())
-    {
-      if (auto right = c.right->dyncast<StringType>())
-      {
-        return Trivial();
-      }
-    }
-
-    /*
      * We define rules on intersections rather than rely on backtracking,
      * because we want a single solution that includes all elements of the
      * conjunction, rather than one solution per conjunction.
@@ -534,18 +522,10 @@ namespace verona::compiler
      * -------------------
      *  C[T] <: is-entity
      *
-     * ---------------------
-     *  String <: is-entity
-     *
      */
-    if (c.right->dyncast<IsEntityType>())
+    if (c.right->dyncast<IsEntityType>() && c.left->dyncast<EntityType>())
     {
-      // TODO: the definition of what an "entity-like" type is is kind of
-      // scattered around the code-base.
-      if (c.left->dyncast<EntityType>() || c.left->dyncast<StringType>())
-      {
-        return Trivial();
-      }
+      return Trivial();
     }
 
     /**
@@ -734,9 +714,7 @@ namespace verona::compiler
       if (auto not_child_of = c.right->dyncast<NotChildOfType>())
       {
         // These are types that are used without any capability.
-        if (
-          c.left->dyncast<StaticType>() || c.left->dyncast<StringType>() ||
-          c.left->dyncast<UnitType>())
+        if (c.left->dyncast<StaticType>() || c.left->dyncast<UnitType>())
           return Trivial();
 
         if (auto left_cap = c.left->dyncast<CapabilityType>())

--- a/src/compiler/typecheck/infer.cc
+++ b/src/compiler/typecheck/infer.cc
@@ -491,7 +491,9 @@ namespace verona::compiler
       std::vector<Variable>& dead_variables,
       const StringLiteralStmt& stmt)
     {
-      set_type(assignment, stmt.output, context_.mk_string_type());
+      TypePtr u64 = get_entity("String");
+      TypePtr type = context_.mk_intersection(u64, context_.mk_immutable());
+      set_type(assignment, stmt.output, type);
     }
 
     void visit_stmt(

--- a/src/compiler/visitor.h
+++ b/src/compiler/visitor.h
@@ -214,11 +214,7 @@ namespace verona::compiler
   public:
     virtual Return visit_type_expression(TypeExpression& te, Args... args)
     {
-      if (auto expr_ = dynamic_cast<StringTypeExpr*>(&te))
-      {
-        return visit_string_type_expr(*expr_, std::forward<Args>(args)...);
-      }
-      else if (auto expr_ = dynamic_cast<SymbolTypeExpr*>(&te))
+      if (auto expr_ = dynamic_cast<SymbolTypeExpr*>(&te))
       {
         return visit_symbol_type_expr(*expr_, std::forward<Args>(args)...);
       }
@@ -257,10 +253,6 @@ namespace verona::compiler
         typeid(te).name(),
         typeid(*this).name());
       abort();
-    }
-    virtual Return visit_string_type_expr(StringTypeExpr& te, Args... args)
-    {
-      return visit_base_type_expression(te, std::forward<Args>(args)...);
     }
     virtual Return visit_symbol_type_expr(SymbolTypeExpr& te, Args... args)
     {

--- a/src/interpreter/bytecode.cc
+++ b/src/interpreter/bytecode.cc
@@ -68,4 +68,23 @@ namespace verona::bytecode
     }
     return out;
   }
+
+  std::ostream& operator<<(std::ostream& out, const Capability& self)
+  {
+    switch (self)
+    {
+      case Capability::Iso:
+        fmt::print(out, "ISO");
+        break;
+      case Capability::Mut:
+        fmt::print(out, "MUT");
+        break;
+      case Capability::Imm:
+        fmt::print(out, "IMM");
+        break;
+
+        EXHAUSTIVE_SWITCH;
+    }
+    return out;
+  }
 }

--- a/src/interpreter/bytecode.h
+++ b/src/interpreter/bytecode.h
@@ -20,6 +20,7 @@
  * - 32-bit descriptor index of Main class
  * - 32-bit selector index of main method
  * - 32-bit descriptor index of U64 class (optional)
+ * - 32-bit descriptor index of String class (optional)
  *
  * Descriptor:
  * - 16-bit name length, followed by the name bytes

--- a/src/interpreter/bytecode.h
+++ b/src/interpreter/bytecode.h
@@ -211,7 +211,8 @@ namespace verona::bytecode
     JumpIf, // src(u8), target(u16)
     Load, // dst(u8), base(u8), selector(u32)
     LoadDescriptor, // dst(u8), descriptor_id(u32)
-    Match, // dst(u8), src(u8), descriptor(u8)
+    MatchCapability, // dst(u8), src(u8), cap(u8)
+    MatchDescriptor, // dst(u8), src(u8), descriptor(u8)
     Merge, // into(u8), src(u8)
     Move, // dst(u8), src(u8)
     MutView, // dst(u8), src(u8)
@@ -250,6 +251,15 @@ namespace verona::bytecode
     Or,
 
     maximum_value = Or,
+  };
+
+  enum class Capability : uint8_t
+  {
+    Iso,
+    Mut,
+    Imm,
+
+    maximum_value = Imm,
   };
 
   template<typename... Args>
@@ -350,10 +360,17 @@ namespace verona::bytecode
   };
 
   template<>
-  struct OpcodeSpec<Opcode::Match>
+  struct OpcodeSpec<Opcode::MatchCapability>
+  {
+    using Operands = OpcodeOperands<Register, Register, Capability>;
+    constexpr static std::string_view format = "MATCH_CAPABILITY {}, {}, {}";
+  };
+
+  template<>
+  struct OpcodeSpec<Opcode::MatchDescriptor>
   {
     using Operands = OpcodeOperands<Register, Register, Register>;
-    constexpr static std::string_view format = "MATCH {}, {}, {}";
+    constexpr static std::string_view format = "MATCH_DESCRIPTOR {}, {}, {}";
   };
 
   template<>
@@ -463,4 +480,5 @@ namespace verona::bytecode
 
   std::ostream& operator<<(std::ostream& out, const Register& self);
   std::ostream& operator<<(std::ostream& out, const BinaryOperator& self);
+  std::ostream& operator<<(std::ostream& out, const Capability& self);
 }

--- a/src/interpreter/code.h
+++ b/src/interpreter/code.h
@@ -27,6 +27,7 @@ namespace verona::interpreter
     const VMDescriptor* main;
     SelectorIdx main_selector;
     const VMDescriptor* u64;
+    const VMDescriptor* string;
   };
 
   class Code
@@ -150,6 +151,8 @@ namespace verona::interpreter
       special_descriptors_.main = get_descriptor(load<DescriptorIdx>(ip));
       special_descriptors_.main_selector = load<SelectorIdx>(ip);
       special_descriptors_.u64 =
+        get_optional_descriptor(load<DescriptorIdx>(ip));
+      special_descriptors_.string =
         get_optional_descriptor(load<DescriptorIdx>(ip));
     }
 

--- a/src/interpreter/vm.h
+++ b/src/interpreter/vm.h
@@ -142,7 +142,23 @@ namespace verona::interpreter
      */
     void write(Register reg, Value value);
 
-    const VMDescriptor* find_dispatch_descriptor(Register receiver) const;
+    /**
+     * Find the descriptor used to invoke methods. Generally, this is the same
+     * as the "match descriptor". However, if `value` is itself a descriptor
+     * pointer, we allow methods to be called on it (ie. static method calls),
+     * but matching will always fail.
+     *
+     * Aborts the VM if methods may not be invoked on this kind of value.
+     */
+    const VMDescriptor* find_dispatch_descriptor(const Value& value) const;
+
+    /**
+     * Find the descriptor of the value, for use in pattern matching.
+     *
+     * Returns null if the given value does not have a suitable descriptor (eg.
+     * descriptors themselves don't have descriptors).
+     */
+    const VMDescriptor* find_match_descriptor(const Value& value) const;
 
     template<typename... Args>
     void trace(std::string_view fmt, Args&&... args) const

--- a/src/interpreter/vm.h
+++ b/src/interpreter/vm.h
@@ -71,7 +71,8 @@ namespace verona::interpreter
     void opcode_jump_if(uint64_t condition, int16_t offset);
     Value opcode_load(const Value& base, SelectorIdx selector);
     Value opcode_load_descriptor(DescriptorIdx desc_idx);
-    Value opcode_match(const Value& src, const VMDescriptor* descriptor);
+    Value opcode_match_descriptor(const Value& src, const VMDescriptor* desc);
+    Value opcode_match_capability(const Value& src, bytecode::Capability cap);
     Value opcode_move(Register src);
     Value opcode_mut_view(const Value& src);
     Value
@@ -86,8 +87,7 @@ namespace verona::interpreter
     Value opcode_store(const Value& base, SelectorIdx selector, Value src);
     Value opcode_string(std::string_view imm);
     void opcode_trace_region(const Value& region);
-    void
-    opcode_when(CodePtr selector, uint8_t cown_count, uint8_t capture_count);
+    void opcode_when(CodePtr offset, uint8_t cown_count, uint8_t capture_count);
     void opcode_unreachable();
 
     enum class OnReturn

--- a/src/stdlib/builtin.verona
+++ b/src/stdlib/builtin.verona
@@ -12,12 +12,12 @@ class Builtin {
   // Selection of print functions that simply pass to the underlying C++
   // formatter.  This is a hack to get some examples with output until we have 
   // implemented IO.
-  builtin print(format: String);
-  builtin print1[T0](format: String, arg0: T0);
-  builtin print2[T0, T1](format: String, arg0: T0, arg1: T1);
-  builtin print3[T0, T1, T2](format: String, arg0: T0, arg1: T1, arg2: T2);
-  builtin print4[T0, T1, T2, T3](format: String, arg0: T0, arg1: T1, arg2: T2, arg3: T3);
-  builtin print5[T0, T1, T2, T3, T4](format: String, arg0: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4);
+  builtin print(format: String & imm);
+  builtin print1[T0](format: String & imm, arg0: T0);
+  builtin print2[T0, T1](format: String & imm, arg0: T0, arg1: T1);
+  builtin print3[T0, T1, T2](format: String & imm, arg0: T0, arg1: T1, arg2: T2);
+  builtin print4[T0, T1, T2, T3](format: String & imm, arg0: T0, arg1: T1, arg2: T2, arg3: T3);
+  builtin print5[T0, T1, T2, T3, T4](format: String & imm, arg0: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4);
 
   // Freeze an isolated object graph
   builtin freeze[class T](x: T & iso): T & imm;
@@ -109,3 +109,5 @@ primitive U64 {
   builtin and(self: imm, other: U64 & imm): U64 & imm;
   builtin or(self: imm, other: U64 & imm): U64 & imm;
 }
+
+primitive String {}

--- a/testsuite/demo/run-pass/bank3.verona
+++ b/testsuite/demo/run-pass/bank3.verona
@@ -13,7 +13,7 @@
  **/
 class Log 
 {
-  print(fmt: String, v1: U64 & imm, v2: U64 & imm)
+  print(fmt: String & imm, v1: U64 & imm, v2: U64 & imm)
   {
     Builtin.print2(fmt, v1, v2);
   }

--- a/testsuite/features/run-pass/match-capability.verona
+++ b/testsuite/features/run-pass/match-capability.verona
@@ -1,3 +1,6 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
 class A { }
 class Main
 {

--- a/testsuite/features/run-pass/match-capability.verona
+++ b/testsuite/features/run-pass/match-capability.verona
@@ -1,0 +1,21 @@
+class A { }
+class Main
+{
+  do_match(x: A & (mut | iso | imm))
+  {
+    match x {
+      var _: mut => Builtin.print("mut\n"),
+      var _: iso => Builtin.print("iso\n"),
+      var _: imm => Builtin.print("imm\n"),
+    }
+  }
+
+  main() {
+    // CHECK-L: mut
+    // CHECK-L: iso
+    // CHECK-L: imm
+    Main.do_match(mut-view (new A));
+    Main.do_match(new A);
+    Main.do_match(Builtin.freeze(new A));
+  }
+}

--- a/testsuite/features/run-pass/match-complex.verona
+++ b/testsuite/features/run-pass/match-complex.verona
@@ -48,7 +48,7 @@ class Main
   main() {
     // CHECK-L: 2
     // CHECK-L: 1
-    // CHECK-L: 1 
+    // CHECK-L: 1
     // CHECK-L: 0
     Main.do_match1(mut-view (new A));
     Main.do_match1(mut-view (new B));

--- a/testsuite/features/run-pass/match-complex.verona
+++ b/testsuite/features/run-pass/match-complex.verona
@@ -1,0 +1,71 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+// Test matching against complex types, involving classes, interfaces,
+// capabilities, unions and intersections.
+
+interface I1 { m1(self: mut); }
+interface I2 { m2(self: mut); }
+interface Any { }
+
+class A {
+  m1(self: mut) {}
+  m2(self: mut) {}
+}
+class B {
+  m1(self: mut) {}
+}
+class C {
+  m2(self: mut) {}
+}
+class D { }
+
+class Main
+{
+  // Prints the number of interfaces out of I1 or I2 that the
+  // argument matches against.
+  do_match1(x: Any & mut)
+  {
+    Builtin.print1("{}\n", match x {
+      var _: I1 & I2 => 2,
+      var _: I1 | I2 => 1,
+      var _: Any => 0,
+    })
+  }
+
+  // Prints a description of the argument's type.
+  do_match2(x: (A | B) & (mut | iso | imm))
+  {
+    Builtin.print1("{}\n", match x {
+      var x: A & iso => "A & iso",
+      var x: A & (imm | mut) => "A & (imm | mut)",
+      var x: B & mut => "B & mut",
+      var x: B & (iso | imm) => "B & (iso | imm)",
+    });
+  }
+
+
+  main() {
+    // CHECK-L: 2
+    // CHECK-L: 1
+    // CHECK-L: 1 
+    // CHECK-L: 0
+    Main.do_match1(mut-view (new A));
+    Main.do_match1(mut-view (new B));
+    Main.do_match1(mut-view (new C));
+    Main.do_match1(mut-view (new D));
+
+    // CHECK-L: A & iso
+    // CHECK-L: B & (iso | imm)
+    // CHECK-L: A & (imm | mut)
+    // CHECK-L: B & mut
+    // CHECK-L: A & (imm | mut)
+    // CHECK-L: B & (iso | imm)
+    Main.do_match2(new A);
+    Main.do_match2(new B);
+    Main.do_match2(mut-view (new A));
+    Main.do_match2(mut-view (new B));
+    Main.do_match2(Builtin.freeze (new A));
+    Main.do_match2(Builtin.freeze (new B));
+  }
+}

--- a/testsuite/features/run-pass/match-primitive.verona
+++ b/testsuite/features/run-pass/match-primitive.verona
@@ -1,0 +1,51 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+// Test matching of primitives values, such as cowns, strings and integers.
+
+interface Add[class T] {
+  add(self: imm, other: T & imm): U64 & imm;
+}
+
+class A { }
+class B { }
+class C { }
+interface Any { }
+
+class Main
+{
+  do_match(x: Any & imm)
+  {
+    // Note that due to type parameter invariance, `cown[A]` is not a subtype
+    // `cown[Any]`. Therefore, matching on a cown[A] prints the expected
+    // output, even though cown[Any] is above in the matching order.  An actual
+    // `cown[Any]` can be created, using eg. the any_cown method.
+    Builtin.print1("{}\n", match x {
+      var _: Add[U64] => "Add[U64]",
+      var _: cown[Any] => "cown[Any]",
+      var _: cown[A] => "cown[A]",
+      var _: cown[B] => "cown[B]",
+      var _: Any => "Any",
+    });
+  }
+
+  any_cown(x: Any & iso) : cown[Any] & imm
+  {
+    cown.create(x)
+  }
+
+  main() {
+    // CHECK-L: Add[U64]
+    // CHECK-L: cown[A]
+    // CHECK-L: cown[B]
+    // CHECK-L: Any
+    // CHECK-L: cown[Any]
+    // CHECK-L: Any
+    Main.do_match(123);
+    Main.do_match(cown.create(new A));
+    Main.do_match(cown.create(new B));
+    Main.do_match(cown.create(new C));
+    Main.do_match(Main.any_cown(new A));
+    Main.do_match("Hello");
+  }
+}


### PR DESCRIPTION
This adds support for matching on primitives (cown, string, U64), capabilities, and union/intersection types.

This is done by:
- Turning String into a primitive, rather than being hardcoded in the compiler
- Add a `MatchCapability` opcode to the VM. The existing `Match` opcode is renamed to `MatchDescriptor`.
- Use a `TypeVisitor` to explore the match pattern, and using boolean operators to decompose complex types.