### PR TITLE
Remove the `mark_pending`/`unmark_pending` methods.

### DIFF
--- a/src/rt/object/object.h
+++ b/src/rt/object/object.h
@@ -597,18 +597,6 @@ namespace verona::rt
       get_header().bits &= ~(size_t)RegionMD::MARKED;
     }
 
-    inline void mark_pending()
-    {
-      assert(get_class() == RegionMD::UNMARKED);
-      get_header().bits |= (uint8_t)RegionMD::PENDING;
-    }
-
-    inline void unmark_pending()
-    {
-      assert(get_class() == RegionMD::PENDING);
-      get_header().bits &= ~(size_t)RegionMD::PENDING;
-    }
-
   public:
     inline EpochMark get_epoch_mark()
     {


### PR DESCRIPTION
They aren't used anywhere. `mark_pending` was identical to
`set_pending` anyway, which does get used. In practice,
`unmark_pending` is actually done with the `set_atomic`/`set_scc`
methods.