### PR TITLE
Fix the use of RT_TESTS in CI.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,11 +168,17 @@ if (NOT DEFINED VERONA_LLVM_LOCATION)
   ProcessorCount(N)
 
   # Adds a target check that runs the tests.
-  add_custom_target(check DEPENDS verona rt_tests)
-  add_custom_command(TARGET check 
+  add_custom_target(check
     COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIG> -j ${N} --output-on-failure --timeout 400 --interactive-debug-mode 0
     USES_TERMINAL
   )
+
+  # If RT_TESTS are enabled, we need to make sure they are
+  # up-to-date before we run tests.
+  if (RT_TESTS)
+    add_dependencies(check rt_tests)
+  endif()
+
   return ()
 endif()
 

--- a/devops/ci.yml
+++ b/devops/ci.yml
@@ -13,21 +13,22 @@ jobs:
     vmImage: 'ubuntu-18.04'
   steps:
   - script: |
-      echo " - PR Build"
-      if  git diff --ignore-submodules=dirty origin/master --name-only | grep -v "^doc" | grep -v "^experiments" | grep -v "\.md$"; then
-        echo Src changes;
-        echo "##vso[task.setvariable variable=docOnly;isOutput=true]false" #set variable to testRuntime to On
-        echo "Determine if runtime changed."
-        if git diff --ignore-submodules=dirty --quiet origin/master -- src/rt; then
-          echo " - Runtime unchanged!"
-          echo "##vso[task.setvariable variable=testRuntime;isOutput=true]Off" #set variable to testRuntime to Off
-        else
-          echo " - Runtime changed!"
-          echo "##vso[task.setvariable variable=testRuntime;isOutput=true]On" #set variable to testRuntime to On
-        fi
+      echo "Determine if any code has changed."
+      if git diff --ignore-submodules=dirty --quiet origin/master -- ':!docs' ':!experiments' ':!*.md'; then
+        echo " - Documentation change only"
+        echo "##vso[task.setvariable variable=docOnly;isOutput=true]true" #set variable docOnly to true
       else
-        echo Doc changes only;
-        echo "##vso[task.setvariable variable=docOnly;isOutput=true]true" #set variable to testRuntime to On
+        echo " - Source has changed"
+        echo "##vso[task.setvariable variable=docOnly;isOutput=true]false" #set variable docOnly to false
+      fi
+
+      echo "Determine if runtime changed."
+      if git diff --ignore-submodules=dirty --quiet origin/master -- src/rt; then
+        echo " - Runtime is unchanged!"
+        echo "##vso[task.setvariable variable=testRuntime;isOutput=true]Off" #set variable testRuntime to Off
+      else
+        echo " - Runtime has changed!"
+        echo "##vso[task.setvariable variable=testRuntime;isOutput=true]On" #set variable testRuntime to On
       fi
     displayName: 'Check for runtime changes'
     name: setVarStep

--- a/devops/ci.yml
+++ b/devops/ci.yml
@@ -172,7 +172,7 @@ jobs:
 
   - script: |
       set -eo pipefail
-      sudo pip install wheel OutputCheck
+      sudo pip3 install wheel OutputCheck
     displayName: 'Dependencies'
 
   - task: CMake@1

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -171,7 +171,7 @@ jobs:
 
   - script: |
       set -eo pipefail
-      sudo pip install wheel OutputCheck
+      sudo pip3 install wheel OutputCheck
     displayName:  'Dependencies'
 
   - task: CMake@1


### PR DESCRIPTION
With `RT_TESTS=Off`, we were not adding any `rt_tests` target, but check was still depending on it.
This is what is currently breaking CI in #364.