### PR TITLE
Add copyright/license check to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,9 +58,11 @@ endforeach ()
 
 ## Clang-format target
 include(cmake/clangformat.cmake)
-
 clangformat_targets()
 
+## Check copyright/license target
+include(cmake/copyright.cmake)
+copyright_targets()
 
 # ExternalProject is used to trick the CMake into building LLVM before Verona.
 # We use two External Projects, so that the LLVM build can complete and install

--- a/cmake/copyright.cmake
+++ b/cmake/copyright.cmake
@@ -1,0 +1,11 @@
+macro(copyright_targets)
+  # This macro finds all sources and checks that they all have the correct
+  # copyright headers. Needs bash, grep, tee, xargs, git.
+  find_program(BASH NAMES bash)
+
+  message(STATUS "Generating copyright/license target")
+  add_custom_target(
+    copyright
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
+    COMMAND bash utils/copyright_check.sh)
+endmacro()

--- a/devops/ci.yml
+++ b/devops/ci.yml
@@ -204,12 +204,6 @@ jobs:
 
   - script: |
       set -eo pipefail
-      git submodule init
-      git submodule update --depth 1 --recursive
-    displayName: 'Update submodules'
-
-  - script: |
-      set -eo pipefail
       wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
       sudo apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main"
       sudo apt-get update
@@ -232,9 +226,6 @@ jobs:
 
   - script: |
       set -eo pipefail
-      files=`git ls-files -- '*.cpp' '*.cc' '*.h' '*.hh' '*.verona' '*.td' '*.mlir' | xargs`
-      grep -L "Copyright Microsoft and Project Verona Contributors."  $files | tee header_missing
-      [ ! -s header_missing ]
-      grep -L "SPDX-License-Identifier: MIT" $files | tee header_missing
-      [ ! -s header_missing ]
+      make copyright
+    workingDirectory: build
     displayName: 'Check Copyright and License'

--- a/utils/copyright_check.sh
+++ b/utils/copyright_check.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+STATUS=0
+
+files=`git ls-files -- '*.cpp' '*.cc' '*.h' '*.hh' '*.verona' '*.td' '*.mlir' | xargs`
+grep -L "Copyright Microsoft and Project Verona Contributors."  $files > header_missing
+if [ -s header_missing ]; then
+  echo "Copyright missing on:"
+  cat header_missing
+  STATUS=1
+fi
+
+grep -L "SPDX-License-Identifier: MIT" $files > header_missing
+if [ -s header_missing ]; then
+  echo "License missing on:"
+  cat header_missing
+  STATUS=1
+fi
+
+rm -f header_missing
+
+exit $STATUS


### PR DESCRIPTION
This helps us running `ninja copyright` to check locally without having to rely on the CI or running it by hand. Should work on anything that has `bash` including Windows.

I tested both checks by changing/removing the headers from some files and the output (and exit status) are as expected.