### PR TITLE
Move LLVM to dd2dac2fd07

### DIFF
--- a/devops/ci.yml
+++ b/devops/ci.yml
@@ -124,22 +124,23 @@ jobs:
     displayName: 'Dependencies'
 
   - script: |
+      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
       mkdir build
       cd build
-      cmake .. -G"Visual Studio 16 2019" -DENABLE_ASSERTS=ON -DVERONA_CI_BUILD=On -DRT_TESTS=$(RTTests) -DCMAKE_CXX_FLAGS="$(CXXFLAGS)"
+      cmake .. -GNinja -DCMAKE_BUILD_TYPE=$(BuildType) -DENABLE_ASSERTS=ON -DVERONA_CI_BUILD=On -DRT_TESTS=$(RTTests) -DCMAKE_CXX_FLAGS="$(CXXFLAGS)"
     displayName: 'CMake'
 
-  - task: MSBuild@1
+  - script: |
+      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+      cd build
+      ninja
     displayName: 'Compile'
-    inputs:
-      solution: build/verona.sln
-      msbuildArguments: '/m /p:Configuration=$(BuildType)'
 
-  - task: MSBuild@1
+  - script: |
+      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+      cd build
+      ninja check
     displayName: 'Test'
-    inputs:
-      solution: build/check.vcxproj
-      msbuildArguments: '/m /p:Configuration=$(BuildType)'
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'

--- a/devops/llvm.yml
+++ b/devops/llvm.yml
@@ -28,7 +28,7 @@ jobs:
 
   - script: |
       set -eo pipefail
-      git checkout master
+      git checkout main
       git pull
       git checkout $(GOOD_HASH)
     displayName: 'Move tree to known good LLVM commit for Verona'
@@ -96,7 +96,7 @@ jobs:
     displayName: 'Install CMake'
 
   - script: |
-      git checkout master
+      git checkout main
       git pull
       git checkout $(GOOD_HASH)
     displayName: 'Prepare tree'
@@ -151,7 +151,7 @@ jobs:
 
   - script: |
       set -eo pipefail
-      git checkout master
+      git checkout main
       git pull
       git checkout $(GOOD_HASH)
     displayName: 'Move tree to known good LLVM commit for Verona'

--- a/devops/llvm.yml
+++ b/devops/llvm.yml
@@ -20,13 +20,6 @@ jobs:
         BuildType: Release
         BuildName: release
         Sanitizer:
-      Clang Debug+ASAN:
-        CC: clang
-        CXX: clang++
-        CXXFLAGS: -stdlib=libstdc++
-        BuildType: Debug
-        BuildName: debug
-        Sanitizer: Address
   variables:
   - name: PKG_NAME
     value: verona-llvm-install-x86_64-linux-$(BuildName)-$(GOOD_HASH)
@@ -80,9 +73,6 @@ jobs:
   timeoutInMinutes: 120
   strategy:
     matrix:
-      Debug:
-        BuildType: Debug
-        BuildName: debug
       Release:
         BuildType: Release
         BuildName: release
@@ -152,9 +142,6 @@ jobs:
       Release:
         BuildType: Release
         BuildName: release
-      Debug:
-        BuildType: Debug
-        BuildName: debug
   variables:
   - name: PKG_NAME
     value: verona-llvm-install-x86_64-darwin-$(BuildName)-$(GOOD_HASH)

--- a/devops/llvm.yml
+++ b/devops/llvm.yml
@@ -45,7 +45,7 @@ jobs:
     displayName: 'CMake'
     inputs:
       cmakeArgs: |
-        ../llvm -GNinja -DCMAKE_BUILD_TYPE=$(BuildType) -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_COMPILER=$(CXX) -DCMAKE_CXX_FLAGS=$(CXXFLAGS) -DLLVM_USE_SANITIZER=$(Sanitizer) -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_ENABLE_LLD=ON -DLLVM_ENABLE_EH=ON -DLLVM_ENABLE_RTTI=ON -DCMAKE_INSTALL_PREFIX=install
+        ../llvm -GNinja -DCMAKE_BUILD_TYPE=$(BuildType) -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_COMPILER=$(CXX) -DCMAKE_CXX_FLAGS=$(CXXFLAGS) -DLLVM_USE_SANITIZER=$(Sanitizer) -DLLVM_ENABLE_PROJECTS="clang;mlir" -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_ENABLE_LLD=ON -DLLVM_ENABLE_EH=ON -DLLVM_ENABLE_RTTI=ON -DCMAKE_INSTALL_PREFIX=install -DMLIR_INCLUDE_TESTS=OFF
 
   - script: |
       set -eo pipefail
@@ -92,7 +92,7 @@ jobs:
     displayName: 'Install Choco'
 
   - powershell: |
-      C:\ProgramData\chocolatey\bin\choco install --accept-license -y cmake
+      C:\ProgramData\chocolatey\bin\choco install --accept-license -y cmake ninja
     displayName: 'Install CMake'
 
   - script: |
@@ -103,16 +103,17 @@ jobs:
 
   - script: |
       rd /s /q build
+      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
       mkdir build
       cd build
-      "C:\Program Files\CMake\bin\cmake.exe" ..\llvm -G"Visual Studio 16 2019" -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_ENABLE_EH=ON -DLLVM_ENABLE_RTTI=ON -DCMAKE_INSTALL_PREFIX=install
+      "C:\Program Files\CMake\bin\cmake.exe" ..\llvm -GNinja -DCMAKE_BUILD_TYPE=$(BuildType) -DLLVM_ENABLE_PROJECTS="clang;mlir" -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_ENABLE_EH=ON -DLLVM_ENABLE_RTTI=ON -DCMAKE_INSTALL_PREFIX=install -DMLIR_INCLUDE_TESTS=OFF
     displayName: 'CMake'
 
-  - task: MSBuild@1
-    displayName: 'Build LLVM'
-    inputs:
-      solution: build/INSTALL.vcxproj
-      msbuildArguments: '/m /p:Configuration=$(BuildType)'
+  - script: |
+      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+      cd build
+      "C:\ProgramData\chocolatey\lib\ninja\tools\ninja.exe" install
+    displayName: 'Compile'
 
   - script: |
       rd /s /q $(PKG_NAME).tar.gz
@@ -159,7 +160,7 @@ jobs:
     displayName: 'CMake'
     inputs:
       cmakeArgs: |
-        ../llvm -DCMAKE_BUILD_TYPE=$(BuildType) -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_ENABLE_EH=ON -DLLVM_ENABLE_RTTI=ON -DCMAKE_INSTALL_PREFIX=install
+        ../llvm -DCMAKE_BUILD_TYPE=$(BuildType) -DLLVM_ENABLE_PROJECTS="clang;mlir" -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_ENABLE_EH=ON -DLLVM_ENABLE_RTTI=ON -DCMAKE_INSTALL_PREFIX=install -DMLIR_INCLUDE_TESTS=OFF
 
   - script: |
       set -eo pipefail

--- a/src/mlir/dialect/VeronaDialect.cc
+++ b/src/mlir/dialect/VeronaDialect.cc
@@ -6,7 +6,6 @@
 #include "VeronaOps.h"
 #include "VeronaTypes.h"
 #include "mlir/IR/DialectImplementation.h"
-#include "mlir/IR/StandardTypes.h"
 
 namespace mlir::verona
 {

--- a/src/mlir/dialect/VeronaOps.cc
+++ b/src/mlir/dialect/VeronaOps.cc
@@ -8,7 +8,6 @@
 #include "VeronaTypes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/OpImplementation.h"
-#include "mlir/IR/StandardTypes.h"
 
 #include "llvm/ADT/StringSet.h"
 

--- a/src/mlir/dialect/VeronaOps.h
+++ b/src/mlir/dialect/VeronaOps.h
@@ -5,7 +5,6 @@
 
 #include "dialect/TypecheckInterface.h"
 #include "mlir/IR/Dialect.h"
-#include "mlir/IR/Function.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"

--- a/src/mlir/dialect/VeronaTypes.cc
+++ b/src/mlir/dialect/VeronaTypes.cc
@@ -6,7 +6,6 @@
 #include "dialect/VeronaOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
-#include "mlir/IR/StandardTypes.h"
 
 #include "llvm/ADT/TypeSwitch.h"
 

--- a/src/mlir/driver.h
+++ b/src/mlir/driver.h
@@ -6,7 +6,7 @@
 #include "ast/ast.h"
 #include "dialect/VeronaDialect.h"
 #include "error.h"
-#include "mlir/IR/Module.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/PassManager.h"
 
 #include "llvm/Support/SourceMgr.h"

--- a/src/mlir/generator.cc
+++ b/src/mlir/generator.cc
@@ -8,7 +8,6 @@
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Dialect.h"
-#include "mlir/IR/StandardTypes.h"
 #include "mlir/IR/Types.h"
 
 namespace
@@ -123,7 +122,7 @@ namespace mlir::verona
         if (auto err = func.takeError())
           return std::move(err);
         // Associate function with module (late mangling)
-        func->setAttr("class", TypeAttr::get(type));
+        func->getOperation()->setAttr("class", TypeAttr::get(type));
         // Add qualifiers as attributes
         llvm::SmallVector<::ast::Ast, 4> quals;
         AST::getFunctionQualifiers(quals, node);
@@ -133,7 +132,8 @@ namespace mlir::verona
           for (auto qual : quals)
             qualAttrs.push_back(
               StringAttr::get(AST::getTokenValue(qual), context));
-          func->setAttr("qualifiers", ArrayAttr::get(qualAttrs, context));
+          func->getOperation()->setAttr(
+            "qualifiers", ArrayAttr::get(qualAttrs, context));
         }
         // Push function to scope
         scope.push_back(*func);
@@ -811,6 +811,7 @@ namespace mlir::verona
     // Create function
     auto funcTy = builder.getFunctionType(types, retTy);
     auto func = mlir::FuncOp::create(loc, name, funcTy);
+    func.setVisibility(mlir::SymbolTable::Visibility::Private);
     return functionTable.insert(name, func);
   }
 

--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -8,10 +8,9 @@
 #include "dialect/VeronaTypes.h"
 #include "error.h"
 #include "mlir/IR/Builders.h"
-#include "mlir/IR/Function.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/MLIRContext.h"
-#include "mlir/IR/Module.h"
-#include "mlir/IR/StandardTypes.h"
 #include "mlir/Target/LLVMIR.h"
 #include "symbol.h"
 

--- a/src/mlir/symbol.h
+++ b/src/mlir/symbol.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "ast/ast.h"
-#include "mlir/IR/Function.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Types.h"
 #include "mlir/IR/Value.h"
 

--- a/testsuite/mlir/mlir-parse/call/mlir.txt
+++ b/testsuite/mlir/mlir-parse/call/mlir.txt
@@ -1,5 +1,5 @@
-module @"$module" {
-  func @foo(%arg0: !verona.imm, %arg1: !verona.meet<class<"U64">, imm>) -> !verona.meet<class<"U64">, imm> attributes {class = !verona.class<"$module">} {
+module @"$module"  {
+  func private @foo(%arg0: !verona.imm, %arg1: !verona.meet<class<"U64">, imm>) -> !verona.meet<class<"U64">, imm> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.imm
     %1 = "verona.store"(%arg0, %0) : (!verona.imm, !verona.imm) -> !verona.unknown
     %2 = "verona.alloca"() : () -> !verona.meet<class<"U64">, imm>
@@ -46,7 +46,7 @@ module @"$module" {
   ^bb5:  // pred: ^bb2
     br ^bb3
   }
-  func @apply() attributes {class = !verona.class<"$module">} {
+  func private @apply() attributes {class = !verona.class<"$module">} {
     %0 = "verona.constant(10)"() : () -> !verona.class<"int">
     %1 = "verona.alloca"() : () -> !verona.imm
     %2 = "verona.store"(%0, %1) : (!verona.class<"int">, !verona.imm) -> !verona.unknown

--- a/testsuite/mlir/mlir-parse/class/mlir.txt
+++ b/testsuite/mlir/mlir-parse/class/mlir.txt
@@ -1,23 +1,23 @@
-module @"$module" {
-  module @C {
+module @"$module"  {
+  module @C  {
   }
-  module @D {
+  module @D  {
   }
-  module @E {
-    module @NestE {
+  module @E  {
+    module @NestE  {
     }
   }
-  module @F {
+  module @F  {
   }
-  module @G {
-    func @foo(%arg0: !verona.class<"U32">) -> !verona.class<"F32"> attributes {class = !verona.class<"G", "$parent" : class<"$module">>, qualifiers = ["static"]} {
+  module @G  {
+    func private @foo(%arg0: !verona.class<"U32">) -> !verona.class<"F32"> attributes {class = !verona.class<"G", "$parent" : class<"$module">>, qualifiers = ["static"]} {
       %0 = "verona.alloca"() : () -> !verona.class<"U32">
       %1 = "verona.store"(%arg0, %0) : (!verona.class<"U32">, !verona.class<"U32">) -> !verona.unknown
       %2 = "verona.constant(3.14)"() : () -> !verona.class<"float">
       %3 = "verona.cast"(%2) : (!verona.class<"float">) -> !verona.class<"F32">
       return %3 : !verona.class<"F32">
     }
-    func @baz(%arg0: !verona.class<"F32">) -> !verona.class<"F32"> attributes {class = !verona.class<"G", "$parent" : class<"$module">>, qualifiers = ["static"]} {
+    func private @baz(%arg0: !verona.class<"F32">) -> !verona.class<"F32"> attributes {class = !verona.class<"G", "$parent" : class<"$module">>, qualifiers = ["static"]} {
       %0 = "verona.alloca"() : () -> !verona.class<"F32">
       %1 = "verona.store"(%arg0, %0) : (!verona.class<"F32">, !verona.class<"F32">) -> !verona.unknown
       %2 = "verona.load"(%0) : (!verona.class<"F32">) -> !verona.unknown
@@ -29,9 +29,9 @@ module @"$module" {
       return %7 : !verona.class<"F32">
     }
   }
-  module @POD {
+  module @POD  {
   }
-  func @bar(%arg0: !verona.class<"C", "$parent" : class<"$module">>, %arg1: !verona.class<"D", "$parent" : class<"$module">, "f" : meet<class<"U64">, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : class<"F32">, "i" : class<"F64">, "j" : class<"bool">>, %arg2: !verona.class<"E", "$parent" : class<"$module">, "a" : class<"D", "$parent" : class<"$module">, "f" : meet<class<"U64">, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : class<"F32">, "i" : class<"F64">, "j" : class<"bool">>, "b" : class<"E">, "c" : class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, "d" : class<"G", "$parent" : class<"$module">>>, %arg3: !verona.class<"NestE", "$parent" : class<"E", "$parent" : class<"$module">, "a" : class<"D", "$parent" : class<"$module">, "f" : meet<class<"U64">, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : class<"F32">, "i" : class<"F64">, "j" : class<"bool">>, "b" : class<"E">, "c" : class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, "d" : class<"G", "$parent" : class<"$module">>>, "x" : class<"G", "$parent" : class<"$module">>>, %arg4: !verona.class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, %arg5: !verona.class<"G", "$parent" : class<"$module">>) attributes {class = !verona.class<"$module">} {
+  func private @bar(%arg0: !verona.class<"C", "$parent" : class<"$module">>, %arg1: !verona.class<"D", "$parent" : class<"$module">, "f" : meet<class<"U64">, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : class<"F32">, "i" : class<"F64">, "j" : class<"bool">>, %arg2: !verona.class<"E", "$parent" : class<"$module">, "a" : class<"D", "$parent" : class<"$module">, "f" : meet<class<"U64">, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : class<"F32">, "i" : class<"F64">, "j" : class<"bool">>, "b" : class<"E">, "c" : class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, "d" : class<"G", "$parent" : class<"$module">>>, %arg3: !verona.class<"NestE", "$parent" : class<"E", "$parent" : class<"$module">, "a" : class<"D", "$parent" : class<"$module">, "f" : meet<class<"U64">, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : class<"F32">, "i" : class<"F64">, "j" : class<"bool">>, "b" : class<"E">, "c" : class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, "d" : class<"G", "$parent" : class<"$module">>>, "x" : class<"G", "$parent" : class<"$module">>>, %arg4: !verona.class<"F", "$parent" : class<"$module">, "e" : class<"G", "$parent" : class<"$module">>>, %arg5: !verona.class<"G", "$parent" : class<"$module">>) attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.class<"C", "$parent" : class<"$module">>
     %1 = "verona.store"(%arg0, %0) : (!verona.class<"C", "$parent" : class<"$module">>, !verona.class<"C", "$parent" : class<"$module">>) -> !verona.unknown
     %2 = "verona.alloca"() : () -> !verona.class<"D", "$parent" : class<"$module">, "f" : meet<class<"U64">, imm>, "g" : meet<class<"C", "$parent" : class<"$module">>, mut>, "h" : class<"F32">, "i" : class<"F64">, "j" : class<"bool">>

--- a/testsuite/mlir/mlir-parse/conditional/mlir.txt
+++ b/testsuite/mlir/mlir-parse/conditional/mlir.txt
@@ -1,5 +1,5 @@
-module @"$module" {
-  func @f(%arg0: !verona.class<"U16">) -> !verona.class<"S16"> attributes {class = !verona.class<"$module">} {
+module @"$module"  {
+  func private @f(%arg0: !verona.class<"U16">) -> !verona.class<"S16"> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.class<"U16">
     %1 = "verona.store"(%arg0, %0) : (!verona.class<"U16">, !verona.class<"U16">) -> !verona.unknown
     %2 = "verona.load"(%0) : (!verona.class<"U16">) -> !verona.unknown

--- a/testsuite/mlir/mlir-parse/constant/mlir.txt
+++ b/testsuite/mlir/mlir-parse/constant/mlir.txt
@@ -1,5 +1,5 @@
-module @"$module" {
-  func @f() attributes {class = !verona.class<"$module">} {
+module @"$module"  {
+  func private @f() attributes {class = !verona.class<"$module">} {
     %0 = "verona.constant(42)"() : () -> !verona.class<"int">
     %1 = "verona.alloca"() : () -> !verona.unknown
     %2 = "verona.store"(%0, %1) : (!verona.class<"int">, !verona.unknown) -> !verona.unknown

--- a/testsuite/mlir/mlir-parse/dialect/mlir.txt
+++ b/testsuite/mlir/mlir-parse/dialect/mlir.txt
@@ -1,4 +1,4 @@
-module {
+module  {
   func @bar(%arg0: !verona.meet<class<"U64">, imm>, %arg1: !verona.meet<class<"U64">, imm>) {
     %0 = verona.new_region @C [] : !verona.meet<class<"C", "$parent" : class<"$module">>, iso>
     %1 = verona.view %0 : !verona.meet<class<"C", "$parent" : class<"$module">>, iso> -> !verona.meet<class<"C", "$parent" : class<"$module">>, mut>

--- a/testsuite/mlir/mlir-parse/for-sugar/mlir.txt
+++ b/testsuite/mlir/mlir-parse/for-sugar/mlir.txt
@@ -1,5 +1,5 @@
-module @"$module" {
-  func @for_sum(%arg0: !verona.class<"List">) -> !verona.class<"U32"> attributes {class = !verona.class<"$module">} {
+module @"$module"  {
+  func private @for_sum(%arg0: !verona.class<"List">) -> !verona.class<"U32"> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.class<"List">
     %1 = "verona.store"(%arg0, %0) : (!verona.class<"List">, !verona.class<"List">) -> !verona.unknown
     %2 = "verona.constant(0)"() : () -> !verona.class<"int">
@@ -32,7 +32,7 @@ module @"$module" {
     %23 = "verona.cast"(%22) : (!verona.unknown) -> !verona.class<"U32">
     return %23 : !verona.class<"U32">
   }
-  func @while_sum(%arg0: !verona.class<"List">) -> !verona.class<"U32"> attributes {class = !verona.class<"$module">} {
+  func private @while_sum(%arg0: !verona.class<"List">) -> !verona.class<"U32"> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.class<"List">
     %1 = "verona.store"(%arg0, %0) : (!verona.class<"List">, !verona.class<"List">) -> !verona.unknown
     %2 = "verona.constant(0)"() : () -> !verona.class<"int">

--- a/testsuite/mlir/mlir-parse/for/mlir.txt
+++ b/testsuite/mlir/mlir-parse/for/mlir.txt
@@ -1,6 +1,6 @@
-module @"$module" {
-  func @foo(!verona.class<"S32">) attributes {class = !verona.class<"$module">}
-  func @f(%arg0: !verona.class<"U64">) attributes {class = !verona.class<"$module">} {
+module @"$module"  {
+  func private @foo(!verona.class<"S32">) attributes {class = !verona.class<"$module">}
+  func private @f(%arg0: !verona.class<"U64">) attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.class<"U64">
     %1 = "verona.store"(%arg0, %0) : (!verona.class<"U64">, !verona.class<"U64">) -> !verona.unknown
     %2 = "verona.constant(0)"() : () -> !verona.class<"int">
@@ -27,7 +27,7 @@ module @"$module" {
   ^bb3:  // pred: ^bb1
     return
   }
-  func @f2(%arg0: !verona.class<"U64">) attributes {class = !verona.class<"$module">} {
+  func private @f2(%arg0: !verona.class<"U64">) attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.class<"U64">
     %1 = "verona.store"(%arg0, %0) : (!verona.class<"U64">, !verona.class<"U64">) -> !verona.unknown
     %2 = "verona.constant(0)"() : () -> !verona.class<"int">

--- a/testsuite/mlir/mlir-parse/function/mlir.txt
+++ b/testsuite/mlir/mlir-parse/function/mlir.txt
@@ -1,23 +1,23 @@
-module @"$module" {
-  module @A {
-    func @foo() -> !verona.class<"bool"> attributes {class = !verona.class<"A", "$parent" : class<"$module">>, qualifiers = ["static"]} {
+module @"$module"  {
+  module @A  {
+    func private @foo() -> !verona.class<"bool"> attributes {class = !verona.class<"A", "$parent" : class<"$module">>, qualifiers = ["static"]} {
       %0 = "verona.constant(true)"() : () -> !verona.class<"bool">
       return %0 : !verona.class<"bool">
     }
   }
-  module @B {
-    func @foo() -> !verona.class<"bool"> attributes {class = !verona.class<"B", "$parent" : class<"$module">>, qualifiers = ["static"]} {
+  module @B  {
+    func private @foo() -> !verona.class<"bool"> attributes {class = !verona.class<"B", "$parent" : class<"$module">>, qualifiers = ["static"]} {
       %0 = "verona.constant(false)"() : () -> !verona.class<"bool">
       return %0 : !verona.class<"bool">
     }
   }
-  func @empty_declaration() attributes {class = !verona.class<"$module">}
-  func @single_arg(!verona.class<"S16">) attributes {class = !verona.class<"$module">}
-  func @args_and_ret(!verona.class<"U32">, !verona.class<"S32">) -> !verona.class<"F64"> attributes {class = !verona.class<"$module">}
-  func @empty_return() attributes {class = !verona.class<"$module">} {
+  func private @empty_declaration() attributes {class = !verona.class<"$module">}
+  func private @single_arg(!verona.class<"S16">) attributes {class = !verona.class<"$module">}
+  func private @args_and_ret(!verona.class<"U32">, !verona.class<"S32">) -> !verona.class<"F64"> attributes {class = !verona.class<"$module">}
+  func private @empty_return() attributes {class = !verona.class<"$module">} {
     return
   }
-  func @foo(%arg0: !verona.imm, %arg1: !verona.meet<class<"U64">, imm>) -> !verona.meet<class<"U64">, imm> attributes {class = !verona.class<"$module">} {
+  func private @foo(%arg0: !verona.imm, %arg1: !verona.meet<class<"U64">, imm>) -> !verona.meet<class<"U64">, imm> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.imm
     %1 = "verona.store"(%arg0, %0) : (!verona.imm, !verona.imm) -> !verona.unknown
     %2 = "verona.alloca"() : () -> !verona.meet<class<"U64">, imm>
@@ -34,7 +34,7 @@ module @"$module" {
     %13 = "verona.cast"(%12) : (!verona.unknown) -> !verona.meet<class<"U64">, imm>
     return %13 : !verona.meet<class<"U64">, imm>
   }
-  func @apply() attributes {class = !verona.class<"$module">} {
+  func private @apply() attributes {class = !verona.class<"$module">} {
     return
   }
 }

--- a/testsuite/mlir/mlir-parse/lookup/mlir.txt
+++ b/testsuite/mlir/mlir-parse/lookup/mlir.txt
@@ -1,4 +1,4 @@
-module {
+module  {
   func @test_class_mut(%arg0: !verona.meet<class<"C1", "f" : meet<class<"D1">, mut>>, mut>) -> !verona.meet<class<"D1">, mut> {
     %0 = verona.field_read %arg0["f"] : !verona.meet<class<"C1", "f" : meet<class<"D1">, mut>>, mut> -> !verona.meet<class<"D1">, mut>
     return %0 : !verona.meet<class<"D1">, mut>

--- a/testsuite/mlir/mlir-parse/nested-conditional/mlir.txt
+++ b/testsuite/mlir/mlir-parse/nested-conditional/mlir.txt
@@ -1,5 +1,5 @@
-module @"$module" {
-  func @f(%arg0: !verona.class<"U32">) -> !verona.class<"U32"> attributes {class = !verona.class<"$module">} {
+module @"$module"  {
+  func private @f(%arg0: !verona.class<"U32">) -> !verona.class<"U32"> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.class<"U32">
     %1 = "verona.store"(%arg0, %0) : (!verona.class<"U32">, !verona.class<"U32">) -> !verona.unknown
     %2 = "verona.load"(%0) : (!verona.class<"U32">) -> !verona.unknown

--- a/testsuite/mlir/mlir-parse/nested-while/mlir.txt
+++ b/testsuite/mlir/mlir-parse/nested-while/mlir.txt
@@ -1,5 +1,5 @@
-module @"$module" {
-  func @f(%arg0: !verona.class<"S64">) -> !verona.class<"S64"> attributes {class = !verona.class<"$module">} {
+module @"$module"  {
+  func private @f(%arg0: !verona.class<"S64">) -> !verona.class<"S64"> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.class<"S64">
     %1 = "verona.store"(%arg0, %0) : (!verona.class<"S64">, !verona.class<"S64">) -> !verona.unknown
     br ^bb1

--- a/testsuite/mlir/mlir-parse/subsumption/mlir.txt
+++ b/testsuite/mlir/mlir-parse/subsumption/mlir.txt
@@ -1,4 +1,4 @@
-module {
+module  {
   func @test1(%arg0: !verona.meet<class<"U64">, imm>) {
     %0 = verona.copy %arg0 : !verona.meet<class<"U64">, imm> -> !verona.class<"U64">
     %1 = verona.copy %0 : !verona.class<"U64"> -> !verona.join<class<"U64">, class<"S64">>

--- a/testsuite/mlir/mlir-parse/types/mlir.txt
+++ b/testsuite/mlir/mlir-parse/types/mlir.txt
@@ -1,5 +1,5 @@
-module @"$module" {
-  func @foo(%arg0: !verona.meet<class<"S32">, iso>, %arg1: !verona.meet<class<"U64">, imm>) -> !verona.join<meet<class<"S32">, iso>, meet<class<"U64">, imm>, meet<class<"U32">, mut>> attributes {class = !verona.class<"$module">} {
+module @"$module"  {
+  func private @foo(%arg0: !verona.meet<class<"S32">, iso>, %arg1: !verona.meet<class<"U64">, imm>) -> !verona.join<meet<class<"S32">, iso>, meet<class<"U64">, imm>, meet<class<"U32">, mut>> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.meet<class<"S32">, iso>
     %1 = "verona.store"(%arg0, %0) : (!verona.meet<class<"S32">, iso>, !verona.meet<class<"S32">, iso>) -> !verona.unknown
     %2 = "verona.alloca"() : () -> !verona.meet<class<"U64">, imm>

--- a/testsuite/mlir/mlir-parse/variables/mlir.txt
+++ b/testsuite/mlir/mlir-parse/variables/mlir.txt
@@ -1,5 +1,5 @@
-module @"$module" {
-  func @foo(%arg0: !verona.meet<class<"S32">, iso>, %arg1: !verona.meet<class<"U64">, imm>) -> !verona.class<"S64"> attributes {class = !verona.class<"$module">} {
+module @"$module"  {
+  func private @foo(%arg0: !verona.meet<class<"S32">, iso>, %arg1: !verona.meet<class<"U64">, imm>) -> !verona.class<"S64"> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.meet<class<"S32">, iso>
     %1 = "verona.store"(%arg0, %0) : (!verona.meet<class<"S32">, iso>, !verona.meet<class<"S32">, iso>) -> !verona.unknown
     %2 = "verona.alloca"() : () -> !verona.meet<class<"U64">, imm>

--- a/testsuite/mlir/mlir-parse/while-cont-brk/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while-cont-brk/mlir.txt
@@ -1,5 +1,5 @@
-module @"$module" {
-  func @f(%arg0: !verona.class<"U32">, %arg1: !verona.class<"S32">) -> !verona.class<"F16"> attributes {class = !verona.class<"$module">} {
+module @"$module"  {
+  func private @f(%arg0: !verona.class<"U32">, %arg1: !verona.class<"S32">) -> !verona.class<"F16"> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.class<"U32">
     %1 = "verona.store"(%arg0, %0) : (!verona.class<"U32">, !verona.class<"U32">) -> !verona.unknown
     %2 = "verona.alloca"() : () -> !verona.class<"S32">

--- a/testsuite/mlir/mlir-parse/while-context/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while-context/mlir.txt
@@ -1,5 +1,5 @@
-module @"$module" {
-  func @f(%arg0: !verona.class<"F32">) -> !verona.class<"F64"> attributes {class = !verona.class<"$module">} {
+module @"$module"  {
+  func private @f(%arg0: !verona.class<"F32">) -> !verona.class<"F64"> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.class<"F32">
     %1 = "verona.store"(%arg0, %0) : (!verona.class<"F32">, !verona.class<"F32">) -> !verona.unknown
     %2 = "verona.constant(1)"() : () -> !verona.class<"int">

--- a/testsuite/mlir/mlir-parse/while-if/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while-if/mlir.txt
@@ -1,5 +1,5 @@
-module @"$module" {
-  func @f(%arg0: !verona.class<"U32">, %arg1: !verona.class<"S32">) -> !verona.class<"U32"> attributes {class = !verona.class<"$module">} {
+module @"$module"  {
+  func private @f(%arg0: !verona.class<"U32">, %arg1: !verona.class<"S32">) -> !verona.class<"U32"> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.class<"U32">
     %1 = "verona.store"(%arg0, %0) : (!verona.class<"U32">, !verona.class<"U32">) -> !verona.unknown
     %2 = "verona.alloca"() : () -> !verona.class<"S32">

--- a/testsuite/mlir/mlir-parse/while/mlir.txt
+++ b/testsuite/mlir/mlir-parse/while/mlir.txt
@@ -1,5 +1,5 @@
-module @"$module" {
-  func @f(%arg0: !verona.class<"U32">) -> !verona.class<"U32"> attributes {class = !verona.class<"$module">} {
+module @"$module"  {
+  func private @f(%arg0: !verona.class<"U32">) -> !verona.class<"U32"> attributes {class = !verona.class<"$module">} {
     %0 = "verona.alloca"() : () -> !verona.class<"U32">
     %1 = "verona.store"(%arg0, %0) : (!verona.class<"U32">, !verona.class<"U32">) -> !verona.unknown
     br ^bb1


### PR DESCRIPTION
The new commit fixes a problem on MSVC builds and doesn't seem to break anything upstream either, with the specific commit passing on many buildbots. Appropriate changes to the MLIR code to match included.

Additional changes:
* We're not building debug versions of LLVM anymore. We don't use them, they were huge and had random build failures on Windows. It's better to build a custom debug version for what we need locally when we do need than having multiple cached builds on storage that we never use.
* Moved LLVM's default branch from "master" to "main"
* Building Clang in addition to MLIR. The FFI code will depend on that, so we need the libraries in there.

There is still one build failure (Windows) because of a pegmatite library export issue that @mjp41 has identified. Once that's fixed, we can merge this.