### PR TITLE
Removed the dependencies of the runtime on std::endl outside of systematic testing

### DIFF
--- a/src/rt/object/object.h
+++ b/src/rt/object/object.h
@@ -617,7 +617,7 @@ namespace verona::rt
     {
       Systematic::cout() << "Object epoch: " << this << " (" << get_class()
                          << ") " << get_epoch_mark() << " -> " << e
-                         << std::endl;
+                         << Systematic::endl;
 
       // We only require relaxed consistency here as we can perfectly see old
       // values as we know that we will only need up-to-date values once we have

--- a/src/rt/region/freeze.h
+++ b/src/rt/region/freeze.h
@@ -237,7 +237,7 @@ namespace verona::rt
             case Object::COWN:
             {
               Systematic::cout()
-                << "External reference during freeze: " << r << std::endl;
+                << "External reference during freeze: " << r << Systematic::endl;
               // External reference
               r->incref();
               break;

--- a/src/rt/region/freeze.h
+++ b/src/rt/region/freeze.h
@@ -236,8 +236,8 @@ namespace verona::rt
             case Object::RC:
             case Object::COWN:
             {
-              Systematic::cout()
-                << "External reference during freeze: " << r << Systematic::endl;
+              Systematic::cout() << "External reference during freeze: " << r
+                                 << Systematic::endl;
               // External reference
               r->incref();
               break;

--- a/src/rt/region/immutable.h
+++ b/src/rt/region/immutable.h
@@ -180,7 +180,8 @@ namespace verona::rt
 
         case Object::COWN:
         {
-          Systematic::cout() << "Immutable releasing cown: " << w << Systematic::endl;
+          Systematic::cout()
+            << "Immutable releasing cown: " << w << Systematic::endl;
           cown::release(alloc, (Cown*)w);
           break;
         }

--- a/src/rt/region/immutable.h
+++ b/src/rt/region/immutable.h
@@ -52,7 +52,7 @@ namespace verona::rt
           case Object::SCC_PTR:
           {
             Systematic::cout()
-              << "Immutable Scan: reaches immutable: " << o << std::endl;
+              << "Immutable Scan: reaches immutable: " << o << Systematic::endl;
             if (o->in_epoch(epoch))
               continue;
 
@@ -66,7 +66,7 @@ namespace verona::rt
           case Object::COWN:
           {
             Systematic::cout()
-              << "Immutable Scan: reaches cown: " << o << std::endl;
+              << "Immutable Scan: reaches cown: " << o << Systematic::endl;
             cown::mark_for_scan(o, epoch);
             break;
           }
@@ -180,7 +180,7 @@ namespace verona::rt
 
         case Object::COWN:
         {
-          Systematic::cout() << "Immutable releasing cown: " << w << std::endl;
+          Systematic::cout() << "Immutable releasing cown: " << w << Systematic::endl;
           cown::release(alloc, (Cown*)w);
           break;
         }

--- a/src/rt/region/region.h
+++ b/src/rt/region/region.h
@@ -141,7 +141,7 @@ namespace verona::rt
         o = recurse.pop();
         assert(o->debug_is_iso());
         Systematic::cout() << "Region Scan: scanning region: " << o
-                           << std::endl;
+                           << Systematic::endl;
         switch (Region::get_type(o->get_region()))
         {
           case RegionType::Trace:
@@ -267,7 +267,7 @@ namespace verona::rt
             [[fallthrough]];
           case Object::RC:
             Systematic::cout()
-              << "Region Scan: reaches immutable: " << p << std::endl;
+              << "Region Scan: reaches immutable: " << p << Systematic::endl;
             Immutable::mark_and_scan(alloc, p, epoch);
             break;
 
@@ -276,14 +276,14 @@ namespace verona::rt
             {
               Systematic::cout()
                 << "Region Scan: pushing subregion to worklist: " << p
-                << std::endl;
+                << Systematic::endl;
               recurse.push(p);
             }
             break;
 
           case Object::COWN:
             Systematic::cout()
-              << "Region Scan: reaches cown: " << p << std::endl;
+              << "Region Scan: reaches cown: " << p << Systematic::endl;
             cown::mark_for_scan(p, epoch);
             break;
 

--- a/src/rt/region/region_arena.h
+++ b/src/rt/region/region_arena.h
@@ -549,7 +549,8 @@ namespace verona::rt
       // Don't trace or finalise o, we'll do it when looping over the large
       // object ring or the arena list.
 
-      Systematic::cout() << "Region release: arena region: " << o << Systematic::endl;
+      Systematic::cout() << "Region release: arena region: " << o
+                         << Systematic::endl;
 
       // Clean up all the non-trivial objects, by running the finaliser and
       // destructor, and collecting iso regions.

--- a/src/rt/region/region_arena.h
+++ b/src/rt/region/region_arena.h
@@ -549,7 +549,7 @@ namespace verona::rt
       // Don't trace or finalise o, we'll do it when looping over the large
       // object ring or the arena list.
 
-      Systematic::cout() << "Region release: arena region: " << o << std::endl;
+      Systematic::cout() << "Region release: arena region: " << o << Systematic::endl;
 
       // Clean up all the non-trivial objects, by running the finaliser and
       // destructor, and collecting iso regions.

--- a/src/rt/region/region_trace.h
+++ b/src/rt/region/region_trace.h
@@ -605,12 +605,14 @@ namespace verona::rt
       {
         Systematic::cout() << "Region release failed due to additional roots"
                            << Systematic::endl;
-        additional_entry_points.forall(
-          [](Object* o) { Systematic::cout() << " root" << o << Systematic::endl; });
+        additional_entry_points.forall([](Object* o) {
+          Systematic::cout() << " root" << o << Systematic::endl;
+        });
         abort();
       }
 
-      Systematic::cout() << "Region release: trace region: " << o << Systematic::endl;
+      Systematic::cout() << "Region release: trace region: " << o
+                         << Systematic::endl;
 
       // Sweep everything, including the entrypoint.
       sweep<SweepAll::Yes>(alloc, o, collect);

--- a/src/rt/region/region_trace.h
+++ b/src/rt/region/region_trace.h
@@ -237,7 +237,7 @@ namespace verona::rt
      **/
     static void gc(Alloc* alloc, Object* o)
     {
-      Systematic::cout() << "Region GC called for: " << o << std::endl;
+      Systematic::cout() << "Region GC called for: " << o << Systematic::endl;
       assert(o->debug_is_iso());
       assert(is_trace_region(o->get_region()));
 
@@ -247,7 +247,7 @@ namespace verona::rt
 
       // Copy additional roots into f.
       reg->additional_entry_points.forall([&f](Object* o) {
-        Systematic::cout() << "Additional root: " << o << std::endl;
+        Systematic::cout() << "Additional root: " << o << Systematic::endl;
         f.push(o);
       });
 
@@ -261,7 +261,7 @@ namespace verona::rt
         o = collect.pop();
         assert(o->debug_is_iso());
         Systematic::cout() << "Region GC: releasing unreachable subregion: "
-                           << o << std::endl;
+                           << o << Systematic::endl;
 
         // Note that we need to dispatch because `r` is a different region
         // metadata object.
@@ -410,7 +410,7 @@ namespace verona::rt
             break;
 
           case Object::UNMARKED:
-            Systematic::cout() << "Mark" << p << std::endl;
+            Systematic::cout() << "Mark" << p << Systematic::endl;
             p->mark();
             p->trace(dfs);
             break;
@@ -553,7 +553,7 @@ namespace verona::rt
           case Object::UNMARKED:
           {
             Object* q = p->get_next();
-            Systematic::cout() << "Sweep " << p << std::endl;
+            Systematic::cout() << "Sweep " << p << Systematic::endl;
             sweep_object<ring>(alloc, p, o, &gc, collect);
 
             if (ring != primary_ring && prev == this)
@@ -604,13 +604,13 @@ namespace verona::rt
       if (!additional_entry_points.empty())
       {
         Systematic::cout() << "Region release failed due to additional roots"
-                           << std::endl;
+                           << Systematic::endl;
         additional_entry_points.forall(
-          [](Object* o) { Systematic::cout() << " root" << o << std::endl; });
+          [](Object* o) { Systematic::cout() << " root" << o << Systematic::endl; });
         abort();
       }
 
-      Systematic::cout() << "Region release: trace region: " << o << std::endl;
+      Systematic::cout() << "Region release: trace region: " << o << Systematic::endl;
 
       // Sweep everything, including the entrypoint.
       sweep<SweepAll::Yes>(alloc, o, collect);

--- a/src/rt/region/rememberedset.h
+++ b/src/rt/region/rememberedset.h
@@ -131,7 +131,8 @@ namespace verona::rt
         case Object::RC:
         {
           assert(o->debug_is_immutable());
-          Systematic::cout() << "RS releasing: immutable: " << o << Systematic::endl;
+          Systematic::cout()
+            << "RS releasing: immutable: " << o << Systematic::endl;
           Immutable::release(alloc, o);
           break;
         }

--- a/src/rt/region/rememberedset.h
+++ b/src/rt/region/rememberedset.h
@@ -131,14 +131,14 @@ namespace verona::rt
         case Object::RC:
         {
           assert(o->debug_is_immutable());
-          Systematic::cout() << "RS releasing: immutable: " << o << std::endl;
+          Systematic::cout() << "RS releasing: immutable: " << o << Systematic::endl;
           Immutable::release(alloc, o);
           break;
         }
 
         case Object::COWN:
         {
-          Systematic::cout() << "RS releasing: cown: " << o << std::endl;
+          Systematic::cout() << "RS releasing: cown: " << o << Systematic::endl;
           cown::release(alloc, (Cown*)o);
           break;
         }

--- a/src/rt/sched/base_noticeboard.h
+++ b/src/rt/sched/base_noticeboard.h
@@ -94,7 +94,7 @@ namespace verona::rt
         return;
       }
       Systematic::cout() << "Flushing values on noticeboard: " << this
-                         << std::endl;
+                         << Systematic::endl;
       flush_n(alloc, update_buffer.size());
     }
 

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -751,10 +751,8 @@ namespace verona::rt
     static void schedule(size_t count, Cown** cowns, Args&&... args)
     {
       static_assert(std::is_base_of_v<Behaviour, Be>);
-#ifdef USE_SYSTEMATIC_TESTING
       Systematic::cout() << "Schedule behaviour of type: " << typeid(Be).name()
                          << Systematic::endl;
-#endif
 
       auto* alloc = ThreadAlloc::get();
       auto* be =

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -261,7 +261,8 @@ namespace verona::rt
         if (!o->is_live(Scheduler::epoch()))
         {
           Systematic::cout()
-            << "Not performing recursive deallocation on: " << o << Systematic::endl;
+            << "Not performing recursive deallocation on: " << o
+            << Systematic::endl;
           // The cown may have already been swept, just remove weak count, let
           // sweeping/cown stub collection deal with the rest.
           a->weak_count.fetch_sub(1);
@@ -282,7 +283,8 @@ namespace verona::rt
      **/
     void weak_release(Alloc* alloc)
     {
-      Systematic::cout() << "Cown " << this << " weak release" << Systematic::endl;
+      Systematic::cout() << "Cown " << this << " weak release"
+                         << Systematic::endl;
       if (weak_count.fetch_sub(1) == 1)
       {
         auto* t = owning_thread();
@@ -310,7 +312,8 @@ namespace verona::rt
 
     void weak_acquire()
     {
-      Systematic::cout() << "Cown " << this << " weak acquire" << Systematic::endl;
+      Systematic::cout() << "Cown " << this << " weak acquire"
+                         << Systematic::endl;
       assert(weak_count > 0);
       weak_count++;
     }
@@ -502,7 +505,8 @@ namespace verona::rt
         auto m = MultiMessage::make_message(alloc, body, epoch);
         auto* next = body->cowns[body->index];
         Systematic::cout() << "MultiMessage " << m << ": fast requesting "
-                           << next << ", index " << body->index << Systematic::endl;
+                           << next << ", index " << body->index
+                           << Systematic::endl;
 
         if (body->index > 0)
         {
@@ -602,7 +606,8 @@ namespace verona::rt
       EpochMark e = m->get_epoch();
 
       Systematic::cout() << "MultiMessage " << m << " index " << body.index
-                         << " acquired " << cown << " epoch " << e << Systematic::endl;
+                         << " acquired " << cown << " epoch " << e
+                         << Systematic::endl;
 
       // If we are in should_scan, and we observe a message in this epoch,
       // then all future messages must have been sent while in pre-scan or
@@ -622,7 +627,8 @@ namespace verona::rt
       {
         if (e != Scheduler::local()->send_epoch)
         {
-          Systematic::cout() << "Message not in current epoch" << Systematic::endl;
+          Systematic::cout()
+            << "Message not in current epoch" << Systematic::endl;
           // We can only see messages from other epochs during the prescan and
           // scan phases.  The message epochs must be up-to-date in all other
           // phases.  We can also see messages sent by threads that have made
@@ -647,7 +653,8 @@ namespace verona::rt
         {
           if (cown->get_epoch_mark() != Scheduler::local()->send_epoch)
           {
-            Systematic::cout() << "Contains unscanned cown." << Systematic::endl;
+            Systematic::cout()
+              << "Contains unscanned cown." << Systematic::endl;
 
             // Count message as this contains a cown, that has a message queue
             // that could potentially have old messages in.
@@ -1228,7 +1235,8 @@ namespace verona::rt
         yield();
         assert(
           bp_state.load(std::memory_order_acquire).priority() != Priority::Low);
-        Systematic::cout() << "Collecting (sweep) cown " << this << Systematic::endl;
+        Systematic::cout() << "Collecting (sweep) cown " << this
+                           << Systematic::endl;
         collect(alloc);
       }
 

--- a/src/rt/sched/epoch.h
+++ b/src/rt/sched/epoch.h
@@ -179,7 +179,7 @@ namespace verona::rt
           auto dn = (DecNode*)dec_list.dequeue();
           auto o = dn->o;
           alloc->dealloc<sizeof(DecNode)>(dn);
-          Systematic::cout() << "Delayed decref on " << o << std::endl;
+          Systematic::cout() << "Delayed decref on " << o << Systematic::endl;
           Immutable::release(alloc, o);
         }
 
@@ -283,7 +283,7 @@ namespace verona::rt
       {
         if (!not_in_epoch(o, e))
         {
-          Systematic::cout() << "Ejecting other thread" << std::endl;
+          Systematic::cout() << "Ejecting other thread" << Systematic::endl;
           o->eject();
         }
 

--- a/src/rt/sched/multimessage.h
+++ b/src/rt/sched/multimessage.h
@@ -60,7 +60,7 @@ namespace verona::rt
         (e == EpochMark::EPOCH_B));
 
       Systematic::cout() << "MultiMessage epoch: " << this << " " << get_epoch()
-                         << " -> " << e << std::endl;
+                         << " -> " << e << Systematic::endl;
 
       body = (MultiMessageBody*)((uintptr_t)get_body() | (size_t)e);
 
@@ -79,7 +79,7 @@ namespace verona::rt
     {
       MultiMessage* m = make(alloc, epoch, body);
       Systematic::cout() << "MultiMessage " << m << " payload " << body << " ("
-                         << epoch << ")" << std::endl;
+                         << epoch << ")" << Systematic::endl;
       return m;
     }
 

--- a/src/rt/sched/noticeboard.h
+++ b/src/rt/sched/noticeboard.h
@@ -86,8 +86,8 @@ namespace verona::rt
           // only protect incref with epoch
           Epoch e(alloc);
           local_content = get<T>();
-          Systematic::cout()
-            << "Inc ref from noticeboard peek" << local_content << Systematic::endl;
+          Systematic::cout() << "Inc ref from noticeboard peek" << local_content
+                             << Systematic::endl;
           local_content->incref();
         }
         // It's possible that the following three things happen:
@@ -99,8 +99,8 @@ namespace verona::rt
         // to be scanned.
         if (Scheduler::should_scan())
         {
-          Systematic::cout()
-            << "Scan from noticeboard peek" << local_content << Systematic::endl;
+          Systematic::cout() << "Scan from noticeboard peek" << local_content
+                             << Systematic::endl;
           ObjectStack f(alloc);
           local_content->trace(f);
           Cown::scan_stack(alloc, Scheduler::epoch(), f);

--- a/src/rt/sched/noticeboard.h
+++ b/src/rt/sched/noticeboard.h
@@ -60,7 +60,7 @@ namespace verona::rt
         auto local_content = get<T>();
         Systematic::cout() << "Updating noticeboard " << this << " old value "
                            << local_content << " new value " << new_o
-                           << std::endl;
+                           << Systematic::endl;
         e.dec_in_epoch(local_content);
         put(new_o);
       }
@@ -87,7 +87,7 @@ namespace verona::rt
           Epoch e(alloc);
           local_content = get<T>();
           Systematic::cout()
-            << "Inc ref from noticeboard peek" << local_content << std::endl;
+            << "Inc ref from noticeboard peek" << local_content << Systematic::endl;
           local_content->incref();
         }
         // It's possible that the following three things happen:
@@ -100,7 +100,7 @@ namespace verona::rt
         if (Scheduler::should_scan())
         {
           Systematic::cout()
-            << "Scan from noticeboard peek" << local_content << std::endl;
+            << "Scan from noticeboard peek" << local_content << Systematic::endl;
           ObjectStack f(alloc);
           local_content->trace(f);
           Cown::scan_stack(alloc, Scheduler::epoch(), f);

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -145,12 +145,12 @@ namespace verona::rt
     inline void schedule_fifo(T* a)
     {
       Systematic::cout() << "Enqueue cown " << a << " (" << a->get_epoch_mark()
-                         << ")" << std::endl;
+                         << ")" << Systematic::endl;
 
       // Scheduling on this thread, from this thread.
       if (!a->scanned(send_epoch))
       {
-        Systematic::cout() << "Enqueue unscanned cown " << a << std::endl;
+        Systematic::cout() << "Enqueue unscanned cown " << a << Systematic::endl;
         scheduled_unscanned_cown = true;
       }
       assert(!a->queue.is_sleeping());
@@ -168,7 +168,7 @@ namespace verona::rt
     {
       // A lifo scheduled cown is coming from an external source, such as
       // asynchronous I/O.
-      Systematic::cout() << "LIFO schedule cown " << a << std::endl;
+      Systematic::cout() << "LIFO schedule cown " << a << Systematic::endl;
 
       q.enqueue_front(ThreadAlloc::get(), a);
       stats.lifo();
@@ -182,7 +182,7 @@ namespace verona::rt
       if (is_token_consumed())
       {
         Systematic::cout() << "Put token " << get_token_cown()
-                           << " in scheduler queue." << std::endl;
+                           << " in scheduler queue." << Systematic::endl;
         if (n_ld_tokens > 0)
         {
           dec_n_ld_tokens();
@@ -192,7 +192,7 @@ namespace verona::rt
 
         if (Scheduler::get().fair)
         {
-          Systematic::cout() << "Should steal for fairness!" << std::endl;
+          Systematic::cout() << "Should steal for fairness!" << Systematic::endl;
           should_steal_for_fairness = true;
         }
       }
@@ -214,7 +214,7 @@ namespace verona::rt
      */
     void mute_set_clear()
     {
-      Systematic::cout() << "Clear mute set" << std::endl;
+      Systematic::cout() << "Clear mute set" << Systematic::endl;
       for (auto entry = mute_set.begin(); entry != mute_set.end(); ++entry)
       {
         // This operation should be safe if the cown has been collected but the
@@ -276,7 +276,7 @@ namespace verona::rt
         {
           cown = q.dequeue(alloc);
           if (cown != nullptr)
-            Systematic::cout() << "Pop cown " << cown << std::endl;
+            Systematic::cout() << "Pop cown " << cown << Systematic::endl;
         }
 
         if (cown == nullptr)
@@ -296,7 +296,7 @@ namespace verona::rt
         }
 
         Systematic::cout() << "Schedule cown " << cown << " ("
-                           << cown->get_epoch_mark() << ")" << std::endl;
+                           << cown->get_epoch_mark() << ")" << Systematic::endl;
 
         // This prevents the LD protocol advancing if this cown has not been
         // scanned. This catches various cases where we have stolen, or
@@ -307,13 +307,13 @@ namespace verona::rt
         // stealing, and running on same cown as previous loop.
         if (Scheduler::should_scan() && (cown->get_epoch_mark() != send_epoch))
         {
-          Systematic::cout() << "Unscanned cown next" << std::endl;
+          Systematic::cout() << "Unscanned cown next" << Systematic::endl;
           scheduled_unscanned_cown = true;
         }
 
         ld_protocol();
 
-        Systematic::cout() << "Running cown " << cown << std::endl;
+        Systematic::cout() << "Running cown " << cown << Systematic::endl;
 
         bool reschedule = cown->run(alloc, state, send_epoch);
 
@@ -342,7 +342,7 @@ namespace verona::rt
             {
               if (q.is_empty())
               {
-                Systematic::cout() << "Queue empty" << std::endl;
+                Systematic::cout() << "Queue empty" << Systematic::endl;
                 // We have effectively reached token cown.
                 n_ld_tokens = 0;
 
@@ -358,7 +358,7 @@ namespace verona::rt
               {
                 Systematic::cout()
                   << "Reschedule cown " << cown << " ("
-                  << cown->get_epoch_mark() << ")" << std::endl;
+                  << cown->get_epoch_mark() << ")" << Systematic::endl;
               }
             }
           }
@@ -376,7 +376,7 @@ namespace verona::rt
 
       assert(mute_set.size() == 0);
 
-      Systematic::cout() << "Begin teardown (phase 1)" << std::endl;
+      Systematic::cout() << "Begin teardown (phase 1)" << Systematic::endl;
 
       cown = list;
       while (cown != nullptr)
@@ -386,18 +386,18 @@ namespace verona::rt
         cown = cown->next;
       }
 
-      Systematic::cout() << "End teardown (phase 1)" << std::endl;
+      Systematic::cout() << "End teardown (phase 1)" << Systematic::endl;
 
       Epoch(ThreadAlloc::get()).flush_local();
       Scheduler::get().enter_barrier();
 
-      Systematic::cout() << "Begin teardown (phase 2)" << std::endl;
+      Systematic::cout() << "Begin teardown (phase 2)" << Systematic::endl;
 
       GlobalEpoch::advance();
 
       collect_cown_stubs<true>();
 
-      Systematic::cout() << "End teardown (phase 2)" << std::endl;
+      Systematic::cout() << "End teardown (phase 2)" << Systematic::endl;
 
       q.destroy(alloc);
     }
@@ -416,7 +416,7 @@ namespace verona::rt
         {
           // stats.steal();
           Systematic::cout() << "Fast-steal cown " << cown << " from "
-                             << victim->systematic_id << std::endl;
+                             << victim->systematic_id << Systematic::endl;
           result = cown;
           return true;
         }
@@ -431,7 +431,7 @@ namespace verona::rt
     void dec_n_ld_tokens()
     {
       assert(n_ld_tokens == 1 || n_ld_tokens == 2);
-      Systematic::cout() << "Reached LD token" << std::endl;
+      Systematic::cout() << "Reached LD token" << Systematic::endl;
       n_ld_tokens--;
     }
 
@@ -488,7 +488,7 @@ namespace verona::rt
           {
             stats.steal();
             Systematic::cout() << "Stole cown " << cown << " from "
-                               << victim->systematic_id << std::endl;
+                               << victim->systematic_id << Systematic::endl;
             return cown;
           }
         }
@@ -566,11 +566,11 @@ namespace verona::rt
         if (sched != this)
         {
           Systematic::cout() << "Reached token: stolen from "
-                             << sched->systematic_id << std::endl;
+                             << sched->systematic_id << Systematic::endl;
         }
         else
         {
-          Systematic::cout() << "Reached token" << std::endl;
+          Systematic::cout() << "Reached token" << Systematic::endl;
         }
 
         return false;
@@ -581,7 +581,7 @@ namespace verona::rt
       if (cown->owning_thread() == nullptr)
       {
         Systematic::cout() << "Bind cown to scheduler thread: " << this
-                           << std::endl;
+                           << Systematic::endl;
         cown->set_owning_thread(this);
         cown->next = list;
         list = cown;
@@ -596,13 +596,13 @@ namespace verona::rt
       if (state == ThreadState::NotInLD)
       {
         Systematic::cout() << "==============================================="
-                           << std::endl;
+                           << Systematic::endl;
         Systematic::cout() << "==============================================="
-                           << std::endl;
+                           << Systematic::endl;
         Systematic::cout() << "==============================================="
-                           << std::endl;
+                           << Systematic::endl;
         Systematic::cout() << "==============================================="
-                           << std::endl;
+                           << Systematic::endl;
 
         ld_state_change(ThreadState::WantLD);
       }
@@ -624,7 +624,7 @@ namespace verona::rt
       if ((state == ThreadState::AllInScan) && ld_checkpoint_reached())
       {
         Systematic::cout() << "Scheduler unscanned flag: "
-                           << scheduled_unscanned_cown << std::endl;
+                           << scheduled_unscanned_cown << Systematic::endl;
 
         if (!scheduled_unscanned_cown && Scheduler::no_inflight_messages())
         {
@@ -662,7 +662,7 @@ namespace verona::rt
         if (first)
         {
           first = false;
-          Systematic::cout() << "LD protocol loop" << std::endl;
+          Systematic::cout() << "LD protocol loop" << Systematic::endl;
         }
 
         ld_state_change(snext);
@@ -730,7 +730,7 @@ namespace verona::rt
     void ld_state_change(ThreadState::State snext)
     {
       Systematic::cout() << "Scheduler state change: " << state << " -> "
-                         << snext << std::endl;
+                         << snext << Systematic::endl;
       state = snext;
     }
 
@@ -744,7 +744,7 @@ namespace verona::rt
       // scanning.
       send_epoch = EpochMark::EPOCH_NONE;
 
-      Systematic::cout() << "send_epoch (1): " << send_epoch << std::endl;
+      Systematic::cout() << "send_epoch (1): " << send_epoch << Systematic::endl;
     }
 
     void enqueue_token()
@@ -758,7 +758,7 @@ namespace verona::rt
     {
       send_epoch = (prev_epoch == EpochMark::EPOCH_B) ? EpochMark::EPOCH_A :
                                                         EpochMark::EPOCH_B;
-      Systematic::cout() << "send_epoch (2): " << send_epoch << std::endl;
+      Systematic::cout() << "send_epoch (2): " << send_epoch << Systematic::endl;
 
       // Send empty messages to all cowns that can be LIFO scheduled.
 
@@ -775,7 +775,7 @@ namespace verona::rt
 
       n_ld_tokens = 2;
       scheduled_unscanned_cown = false;
-      Systematic::cout() << "Enqueued LD check point" << std::endl;
+      Systematic::cout() << "Enqueued LD check point" << Systematic::endl;
     }
 
     void collect_cowns()
@@ -817,14 +817,14 @@ namespace verona::rt
         {
           if (c->weak_count != 0)
           {
-            Systematic::cout() << "Leaking cown " << c << std::endl;
+            Systematic::cout() << "Leaking cown " << c << Systematic::endl;
             if (Scheduler::get_detect_leaks())
             {
               *p = c->next;
               continue;
             }
           }
-          Systematic::cout() << "Stub collect cown " << c << std::endl;
+          Systematic::cout() << "Stub collect cown " << c << Systematic::endl;
           // TODO: Investigate systematic testing coverage here.
           auto epoch = c->epoch_when_popped;
           auto outdated =
@@ -833,7 +833,7 @@ namespace verona::rt
           {
             count++;
             *p = c->next;
-            Systematic::cout() << "Stub collected cown " << c << std::endl;
+            Systematic::cout() << "Stub collected cown " << c << Systematic::endl;
             c->dealloc(alloc);
             continue;
           }
@@ -841,7 +841,7 @@ namespace verona::rt
           {
             if (!outdated)
               Systematic::cout()
-                << "Cown " << c << " not outdated." << std::endl;
+                << "Cown " << c << " not outdated." << Systematic::endl;
           }
         }
         p = &(c->next);

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -150,7 +150,8 @@ namespace verona::rt
       // Scheduling on this thread, from this thread.
       if (!a->scanned(send_epoch))
       {
-        Systematic::cout() << "Enqueue unscanned cown " << a << Systematic::endl;
+        Systematic::cout() << "Enqueue unscanned cown " << a
+                           << Systematic::endl;
         scheduled_unscanned_cown = true;
       }
       assert(!a->queue.is_sleeping());
@@ -192,7 +193,8 @@ namespace verona::rt
 
         if (Scheduler::get().fair)
         {
-          Systematic::cout() << "Should steal for fairness!" << Systematic::endl;
+          Systematic::cout()
+            << "Should steal for fairness!" << Systematic::endl;
           should_steal_for_fairness = true;
         }
       }
@@ -744,7 +746,8 @@ namespace verona::rt
       // scanning.
       send_epoch = EpochMark::EPOCH_NONE;
 
-      Systematic::cout() << "send_epoch (1): " << send_epoch << Systematic::endl;
+      Systematic::cout() << "send_epoch (1): " << send_epoch
+                         << Systematic::endl;
     }
 
     void enqueue_token()
@@ -758,7 +761,8 @@ namespace verona::rt
     {
       send_epoch = (prev_epoch == EpochMark::EPOCH_B) ? EpochMark::EPOCH_A :
                                                         EpochMark::EPOCH_B;
-      Systematic::cout() << "send_epoch (2): " << send_epoch << Systematic::endl;
+      Systematic::cout() << "send_epoch (2): " << send_epoch
+                         << Systematic::endl;
 
       // Send empty messages to all cowns that can be LIFO scheduled.
 
@@ -833,7 +837,8 @@ namespace verona::rt
           {
             count++;
             *p = c->next;
-            Systematic::cout() << "Stub collected cown " << c << Systematic::endl;
+            Systematic::cout()
+              << "Stub collected cown " << c << Systematic::endl;
             c->dealloc(alloc);
             continue;
           }

--- a/src/rt/sched/threadpool.h
+++ b/src/rt/sched/threadpool.h
@@ -79,7 +79,7 @@ namespace verona::rt
     static void record_inflight_message()
     {
       Systematic::cout() << "Increase inflight count: "
-                         << get().inflight_count + 1 << std::endl;
+                         << get().inflight_count + 1 << Systematic::endl;
       local()->scheduled_unscanned_cown = true;
       get().inflight_count++;
     }
@@ -87,14 +87,14 @@ namespace verona::rt
     static void recv_inflight_message()
     {
       Systematic::cout() << "Decrease inflight count: "
-                         << get().inflight_count - 1 << std::endl;
+                         << get().inflight_count - 1 << Systematic::endl;
       get().inflight_count--;
     }
 
     static bool no_inflight_messages()
     {
       Systematic::cout() << "Check inflight count: " << get().inflight_count
-                         << std::endl;
+                         << Systematic::endl;
       return get().inflight_count == 0;
     }
 
@@ -106,7 +106,7 @@ namespace verona::rt
       auto prev_count =
         s.external_event_sources.fetch_add(1, std::memory_order_seq_cst);
       Systematic::cout() << "Add external event source (now "
-                         << (prev_count + 1) << ")" << std::endl;
+                         << (prev_count + 1) << ")" << Systematic::endl;
     }
 
     /// Decrement the external event source count. This will allow runtime
@@ -118,14 +118,14 @@ namespace verona::rt
         s.external_event_sources.fetch_sub(1, std::memory_order_seq_cst);
       assert(prev_count != 0);
       Systematic::cout() << "Remove external event source (now "
-                         << (prev_count - 1) << ")" << std::endl;
+                         << (prev_count - 1) << ")" << Systematic::endl;
       if (prev_count == 1)
         s.unpause();
     }
 
     static void set_fair(bool fair)
     {
-      Systematic::cout() << "Set fair: " << fair << std::endl;
+      Systematic::cout() << "Set fair: " << fair << Systematic::endl;
       auto& s = get();
       s.fair = fair;
     }
@@ -279,7 +279,7 @@ namespace verona::rt
       if (in_prescan())
       {
         // During pre-scan alloc in previous epoch.
-        Systematic::cout() << "Alloc cown during pre-scan" << std::endl;
+        Systematic::cout() << "Alloc cown during pre-scan" << Systematic::endl;
         return t->prev_epoch;
       }
 
@@ -391,7 +391,7 @@ namespace verona::rt
       size_t i = 0;
       T* t = first_thread;
 
-      Systematic::cout() << "Starting all threads" << std::endl;
+      Systematic::cout() << "Starting all threads" << Systematic::endl;
 
       do
       {
@@ -407,7 +407,7 @@ namespace verona::rt
         delete t;
         t = next;
       } while (t != first_thread);
-      Systematic::cout() << "All threads stopped" << std::endl;
+      Systematic::cout() << "All threads stopped" << Systematic::endl;
 
       first_thread = nullptr;
       incarnation++;
@@ -444,7 +444,7 @@ namespace verona::rt
 
       {
         std::unique_lock<std::mutex> lock(m);
-        Systematic::cout() << "Pausing" << std::endl;
+        Systematic::cout() << "Pausing" << Systematic::endl;
         if (active_thread_count > 1)
         {
           active_thread_count--;
@@ -456,7 +456,7 @@ namespace verona::rt
           cv.wait(lock);
 #endif
           active_thread_count++;
-          Systematic::cout() << "Unpausing" << std::endl;
+          Systematic::cout() << "Unpausing" << Systematic::endl;
           return true;
         }
 
@@ -490,7 +490,7 @@ namespace verona::rt
           {
             if (!t->q.is_empty())
             {
-              Systematic::cout() << "Still work left" << std::endl;
+              Systematic::cout() << "Still work left" << Systematic::endl;
               runtime_pausing++;
 #ifdef USE_SYSTEMATIC_TESTING
               cv_notify_all();
@@ -502,10 +502,10 @@ namespace verona::rt
             t = t->next;
           } while (t != first_thread);
 
-          Systematic::cout() << "Runtime pausing" << std::endl;
+          Systematic::cout() << "Runtime pausing" << Systematic::endl;
           cv.wait(lock);
 
-          Systematic::cout() << "Runtime unpausing" << std::endl;
+          Systematic::cout() << "Runtime unpausing" << Systematic::endl;
           runtime_pausing++;
           cv.notify_all();
 
@@ -513,7 +513,7 @@ namespace verona::rt
         }
 
         // Used to handle deallocating all the state of the threads.
-        Systematic::cout() << "Teardown beginning" << std::endl;
+        Systematic::cout() << "Teardown beginning" << Systematic::endl;
         teardown_in_progress = true;
 
         t = first_thread;
@@ -525,9 +525,9 @@ namespace verona::rt
           t->stop();
           t = t->next;
         } while (t != first_thread);
-        Systematic::cout() << "Teardown: all threads stopped" << std::endl;
+        Systematic::cout() << "Teardown: all threads stopped" << Systematic::endl;
       }
-      Systematic::cout() << "cv_notify_all() for teardown" << std::endl;
+      Systematic::cout() << "cv_notify_all() for teardown" << Systematic::endl;
 #ifdef USE_SYSTEMATIC_TESTING
       T* t = first_thread;
       do
@@ -539,7 +539,7 @@ namespace verona::rt
       cv.notify_all();
 #endif
       Systematic::cout() << "Teardown: all threads beginning teardown"
-                         << std::endl;
+                         << Systematic::endl;
       return true;
     }
 
@@ -560,7 +560,7 @@ namespace verona::rt
           cv.notify_all();
 #endif
         } while (runtime_pausing == pausing);
-        Systematic::cout() << "Unpausing other threads." << std::endl;
+        Systematic::cout() << "Unpausing other threads." << Systematic::endl;
 
         return true;
       }
@@ -586,7 +586,7 @@ namespace verona::rt
 #else
       cv.notify_all();
 #endif
-      Systematic::cout() << "Unpausing other threads." << std::endl;
+      Systematic::cout() << "Unpausing other threads." << Systematic::endl;
 
       return true;
     }

--- a/src/rt/sched/threadpool.h
+++ b/src/rt/sched/threadpool.h
@@ -525,7 +525,8 @@ namespace verona::rt
           t->stop();
           t = t->next;
         } while (t != first_thread);
-        Systematic::cout() << "Teardown: all threads stopped" << Systematic::endl;
+        Systematic::cout() << "Teardown: all threads stopped"
+                           << Systematic::endl;
       }
       Systematic::cout() << "cv_notify_all() for teardown" << Systematic::endl;
 #ifdef USE_SYSTEMATIC_TESTING

--- a/src/rt/test/harness.h
+++ b/src/rt/test/harness.h
@@ -10,10 +10,12 @@
 using namespace verona::rt;
 using namespace std::chrono;
 
+#ifdef USE_FLIGHT_RECORDER
 extern "C" void dump_flight_recorder()
 {
   Systematic::SysLog::dump_flight_recorder();
 }
+#endif
 
 #define check(x) \
   if (!(x)) \

--- a/src/rt/test/harness.h
+++ b/src/rt/test/harness.h
@@ -51,17 +51,17 @@ public:
 
     if (seed_upper < seed_lower)
     {
-      Systematic::cout() << "Seed_upper " << seed_upper << " seed_lower "
-                         << seed_lower << Systematic::endl;
+      std::cout << "Seed_upper " << seed_upper << " seed_lower " << seed_lower
+                << std::endl;
       abort();
     }
 
     cores = opt.is<size_t>("--cores", 4);
-    Systematic::cout() << " --cores " << cores << Systematic::endl;
+    std::cout << " --cores " << cores << std::endl;
 
     detect_leaks = !opt.has("--allow_leaks");
     if (!detect_leaks)
-      Systematic::cout() << " --allow_leaks " << Systematic::endl;
+      std::cout << " --allow_leaks " << std::endl;
     Scheduler::set_detect_leaks(detect_leaks);
 
 #if defined(_WIN32) && defined(CI_BUILD)
@@ -84,7 +84,7 @@ public:
 #endif
     for (seed = seed_lower + random; seed < seed_upper + random; seed++)
     {
-      Systematic::cout() << "Seed: " << seed << Systematic::endl;
+      std::cout << "Seed: " << seed << std::endl;
 
       Scheduler& sched = Scheduler::get();
 #ifdef USE_SYSTEMATIC_TESTING
@@ -108,9 +108,9 @@ public:
       if (detect_leaks)
         snmalloc::current_alloc_pool()->debug_check_empty();
       high_resolution_clock::time_point t1 = high_resolution_clock::now();
-      Systematic::cout() << "Time so far: "
-                         << duration_cast<seconds>((t1 - start)).count()
-                         << " seconds" << Systematic::endl;
+      std::cout << "Time so far: "
+                << duration_cast<seconds>((t1 - start)).count() << " seconds"
+                << std::endl;
     }
   }
 

--- a/src/rt/test/harness.h
+++ b/src/rt/test/harness.h
@@ -10,12 +10,10 @@
 using namespace verona::rt;
 using namespace std::chrono;
 
-#ifdef USE_FLIGHT_RECORDER
 extern "C" void dump_flight_recorder()
 {
   Systematic::SysLog::dump_flight_recorder();
 }
-#endif
 
 #define check(x) \
   if (!(x)) \
@@ -53,17 +51,17 @@ public:
 
     if (seed_upper < seed_lower)
     {
-      std::cout << "Seed_upper " << seed_upper << " seed_lower " << seed_lower
-                << std::endl;
+      Systematic::cout() << "Seed_upper " << seed_upper << " seed_lower "
+                         << seed_lower << Systematic::endl;
       abort();
     }
 
     cores = opt.is<size_t>("--cores", 4);
-    std::cout << " --cores " << cores << std::endl;
+    Systematic::cout() << " --cores " << cores << Systematic::endl;
 
     detect_leaks = !opt.has("--allow_leaks");
     if (!detect_leaks)
-      std::cout << " --allow_leaks " << std::endl;
+      Systematic::cout() << " --allow_leaks " << Systematic::endl;
     Scheduler::set_detect_leaks(detect_leaks);
 
 #if defined(_WIN32) && defined(CI_BUILD)
@@ -86,7 +84,7 @@ public:
 #endif
     for (seed = seed_lower + random; seed < seed_upper + random; seed++)
     {
-      std::cout << "Seed: " << seed << std::endl;
+      Systematic::cout() << "Seed: " << seed << Systematic::endl;
 
       Scheduler& sched = Scheduler::get();
 #ifdef USE_SYSTEMATIC_TESTING
@@ -110,9 +108,9 @@ public:
       if (detect_leaks)
         snmalloc::current_alloc_pool()->debug_check_empty();
       high_resolution_clock::time_point t1 = high_resolution_clock::now();
-      std::cout << "Time so far: "
-                << duration_cast<seconds>((t1 - start)).count() << " seconds"
-                << std::endl;
+      Systematic::cout() << "Time so far: "
+                         << duration_cast<seconds>((t1 - start)).count()
+                         << " seconds" << Systematic::endl;
     }
   }
 

--- a/src/rt/test/systematic.h
+++ b/src/rt/test/systematic.h
@@ -367,12 +367,12 @@ namespace Systematic
 
     static void dump_flight_recorder(size_t id = 0)
     {
+      static std::atomic_flag dump_in_progress = ATOMIC_FLAG_INIT;
+
+      snmalloc::FlagLock f(dump_in_progress);
+
       if constexpr (flight_recorder)
       {
-        static std::atomic_flag dump_in_progress = ATOMIC_FLAG_INIT;
-
-        snmalloc::FlagLock f(dump_in_progress);
-
         std::cerr << "Dump started by " << (id != 0 ? id : get_systematic_id())
                   << std::endl;
         ThreadLocalLog::dump(std::cerr);

--- a/src/rt/test/systematic.h
+++ b/src/rt/test/systematic.h
@@ -57,9 +57,9 @@ namespace Systematic
 #endif
 
 #ifdef USE_SYSTEMATIC_TESTING
-    static constexpr bool systematic = true;
+  static constexpr bool systematic = true;
 #else
-    static constexpr bool systematic = false;
+  static constexpr bool systematic = false;
 #endif
 
 #ifdef USE_FLIGHT_RECORDER
@@ -295,7 +295,7 @@ namespace Systematic
 
       o.flush();
     }
-  #endif
+#endif
   };
 
   template<typename T>
@@ -364,19 +364,20 @@ namespace Systematic
     }
 #endif
 
-#ifdef USE_FLIGHT_RECORDER
     static void dump_flight_recorder(size_t id = 0)
     {
-      static std::atomic_flag dump_in_progress = ATOMIC_FLAG_INIT;
+      if constexpr (flight_recorder)
+      {
+        static std::atomic_flag dump_in_progress = ATOMIC_FLAG_INIT;
 
-      snmalloc::FlagLock f(dump_in_progress);
+        snmalloc::FlagLock f(dump_in_progress);
 
-      std::cerr << "Dump started by " << (id != 0 ? id : get_systematic_id())
-                << std::endl;
-      ThreadLocalLog::dump(std::cerr);
-      std::cerr << "Dump complete!" << std::endl;
+        std::cerr << "Dump started by " << (id != 0 ? id : get_systematic_id())
+                  << std::endl;
+        ThreadLocalLog::dump(std::cerr);
+        std::cerr << "Dump complete!" << std::endl;
+      }
     }
-#endif
 
     inline SysLog& operator<<(const char* value)
     {
@@ -619,11 +620,11 @@ namespace Systematic
 
   inline ostream& endl(ostream& os)
   {
-      if constexpr (systematic || flight_recorder)
-      {
-        os << std::endl;
-      }
+    if constexpr (systematic || flight_recorder)
+    {
+      os << std::endl;
+    }
 
-      return os;
+    return os;
   }
 } // namespace Systematic

--- a/src/rt/test/systematic.h
+++ b/src/rt/test/systematic.h
@@ -56,6 +56,12 @@ namespace Systematic
   }
 #endif
 
+#ifdef USE_SYSTEMATIC_TESTING
+    static constexpr bool systematic = true;
+#else
+    static constexpr bool systematic = false;
+#endif
+
 #ifdef USE_FLIGHT_RECORDER
   static constexpr bool flight_recorder = true;
 #else
@@ -236,6 +242,7 @@ namespace Systematic
       return mine;
     }
 
+#ifdef USE_FLIGHT_RECORDER
     static void dump(std::ostream& o)
     {
       o << "Crash log begins with most recent events" << std::endl;
@@ -288,21 +295,16 @@ namespace Systematic
 
       o.flush();
     }
+  #endif
   };
 
   template<typename T>
-  std::ostream& pretty_printer(std::ostream& os, T const& e)
+  static std::ostream& pretty_printer(std::ostream& os, T const& e)
   {
     return os << e;
   }
   class SysLog
   {
-#ifdef USE_SYSTEMATIC_TESTING
-    static constexpr bool systematic = true;
-#else
-    static constexpr bool systematic = false;
-#endif
-
   private:
     std::ostream* o;
     bool first;
@@ -362,6 +364,7 @@ namespace Systematic
     }
 #endif
 
+#ifdef USE_FLIGHT_RECORDER
     static void dump_flight_recorder(size_t id = 0)
     {
       static std::atomic_flag dump_in_progress = ATOMIC_FLAG_INIT;
@@ -373,6 +376,7 @@ namespace Systematic
       ThreadLocalLog::dump(std::cerr);
       std::cerr << "Dump complete!" << std::endl;
     }
+#endif
 
     inline SysLog& operator<<(const char* value)
     {
@@ -611,5 +615,15 @@ namespace Systematic
   {
     static SysLog cout_log;
     return cout_log;
+  }
+
+  inline ostream& endl(ostream& os)
+  {
+      if constexpr (systematic || flight_recorder)
+      {
+        os << std::endl;
+      }
+
+      return os;
   }
 } // namespace Systematic


### PR DESCRIPTION
Systematic testing uses std::endl for printing, but it is otherwise not used.
Added Systematic::endl to avoid pulling in link-time dependencies towards <ostream> elements when not using systematic testing.
This allows using the Verona runtime in environments that don't support <ostream>.