### PR TITLE
[llvm-anybuild] Add PATH to the build environment

### DIFF
--- a/devops/llvm-anybuild.yml
+++ b/devops/llvm-anybuild.yml
@@ -180,6 +180,7 @@ jobs:
         env -i \
           llvmPassword=$(LLVMPrincipalPassword) \
           HOME="$HOME" \
+          PATH="$PATH" \
         timeout "$time_limit" time $(AbClientDirectory)/AnyBuild.sh \
           --RemoteExecServiceUri $(AnyBuildEnvironmentUri) \
           --NoCheckForUpdates \

--- a/devops/llvm-anybuild.yml
+++ b/devops/llvm-anybuild.yml
@@ -237,7 +237,7 @@ jobs:
   - bash: |
       set -euo pipefail
       rm -f $(PKG_NAME).tar
-      tar --sort=name -cf $(PKG_NAME).tar build/install
+      tar --sort=name --owner=root:0 --group=root:0 --mtime='UTC 2021-01-01' -cf $(PKG_NAME).tar build/install
       md5sum $(PKG_NAME).tar | awk '{print $1}' > $(PKG_NAME).tar.md5
       rm -rf "$(PKG_NAME)"
       mkdir $(PKG_NAME)

--- a/devops/llvm-anybuild.yml
+++ b/devops/llvm-anybuild.yml
@@ -238,7 +238,7 @@ jobs:
   - bash: |
       set -euo pipefail
       rm -f $(PKG_NAME).tar
-      tar --sort=name --owner=root:0 --group=root:0 --mtime='UTC 2021-01-01' -cf $(PKG_NAME).tar build/install
+      tar --sort=name -cf $(PKG_NAME).tar build/install
       md5sum $(PKG_NAME).tar | awk '{print $1}' > $(PKG_NAME).tar.md5
       rm -rf "$(PKG_NAME)"
       mkdir $(PKG_NAME)


### PR DESCRIPTION
Without passing PATH through, the build fails to find `git`(which it needs to determine version) and produces the following warning:
```
CMake Warning at /home/AnyBuild/azp-verona/_work/2/s/llvm/cmake/modules/VersionFromVCS.cmake:49 (message):
  Git not found.  Version cannot be determined.
Call Stack (most recent call first):
  /home/AnyBuild/azp-verona/_work/2/s/llvm/cmake/modules/GenerateVersionFromVCS.cmake:23 (get_source_info)
  /home/AnyBuild/azp-verona/_work/2/s/llvm/cmake/modules/GenerateVersionFromVCS.cmake:45 (append_info)
```