### PR TITLE
Add AnyBuild pipeline

### DIFF
--- a/devops/llvm-anybuild.yml
+++ b/devops/llvm-anybuild.yml
@@ -11,7 +11,7 @@ parameters:
   - name: BuildOnMacOs
     type: boolean
     default: false
-  # whether to build Verona
+  # whether to upload LLVM installation tarballs to blob storage
   - name: UploadPackage
     type: boolean
     default: false
@@ -55,19 +55,16 @@ variables:
   value: https://anybuild$(AbEnvironmentName)neurope.blob.core.windows.net/clientreleases
 - name: AnyBuildRing
   value: Dogfood
-- name: VeronaRepoGitUri
-  value: https://github.com/microsoft/verona
 - name: LlvmRepoGitUri
   value: https://github.com/llvm/llvm-project
-# GOOD_HASH may be set in the pipeline in which case it overrides LLVM_COMMIT 
-# - name: GOOD_HASH
-#   value: ''
 
 jobs:
-### Configure: Determine commits to build
-###   - outputs VERONA_COMMIT and LLVM_COMMIT that correspond to the latest checked in change in verona@master
+### Configure: Determine LLVM commit to build.
+###
+### Outputs the LLVM_COMMIT variable to contain the commit hash of the LLVM submodule in latest verona@master.
+### Can be overridden by setting a pipeline variable named GOOD_HASH.
 - job: Configure
-  displayName: Configure LLVM/Verona commits to build
+  displayName: Configure LLVM commit to build
   pool:
     vmImage: ubuntu-18.04
   timeoutInMinutes: 5
@@ -77,7 +74,6 @@ jobs:
   - bash: |
       set -euo pipefail
 
-      VERONA_COMMIT=$(git rev-parse HEAD)
       if [[ -z "$(GOOD_HASH)" ]]; then
         LLVM_COMMIT=$(git submodule | grep llvm-project | cut -f1 -d\ | sed 's/^.//g')
       else
@@ -85,16 +81,14 @@ jobs:
       fi
 
       echo "Setting the following output variables:"
-      echo "  VERONA_COMMIT=$VERONA_COMMIT"
       echo "  LLVM_COMMIT=$LLVM_COMMIT"
-      echo "##vso[task.setvariable variable=VERONA_COMMIT;isOutput=true;]$VERONA_COMMIT"
       echo "##vso[task.setvariable variable=LLVM_COMMIT;isOutput=true;]$LLVM_COMMIT"
     displayName: SetCommits
     name: SetCommits
 
 ############################################# Windows Builds
 
-### Build LLVM with AnyBuild first
+### Build LLVM with AnyBuild
 - job: LLVM_Windows
   displayName: LLVM Windows
   condition: and(succeeded(), ${{ eq(parameters.BuildOnWindows, true) }})
@@ -128,14 +122,6 @@ jobs:
       CommitSha: $(LLVM_COMMIT)
 
   - powershell: |
-      Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
-    displayName: Install Choco
-
-  - powershell: |
-      C:\ProgramData\chocolatey\bin\choco install --accept-license -y ninja
-    displayName: Install Ninja
-
-  - powershell: |
       Set-ExecutionPolicy Bypass -Scope Process -Force
 
       Remove-Item -Force -Recurse "$env:LOCALAPPDATA\Microsoft\AnyBuild" -ea SilentlyContinue
@@ -164,7 +150,7 @@ jobs:
       set "USERDOMAIN_ROAMINGPROFILE="
 
       set ServicePrincipalPassword=$(LLVMPrincipalPassword)
-      call "%LOCALAPPDATA%\Microsoft\AnyBuild\AnyBuild.cmd" --EnableActionCache ${{ parameters.ExtraAnyBuildArgs }} --RemoteExecServiceUri $(AnyBuildEnvironmentUri) --ClientApplicationId $(LLVMPrincipalAppId) --ClientSecretEnvironmentVariable ServicePrincipalPassword --WaitForAgentForever --DoNotUseMachineUtilizationForScheduling -- "C:\ProgramData\chocolatey\lib\ninja\tools\ninja.exe" -j ${{ parameters.CmakeJobsWindows }} install
+      call "%LOCALAPPDATA%\Microsoft\AnyBuild\AnyBuild.cmd" --EnableActionCache ${{ parameters.ExtraAnyBuildArgs }} --RemoteExecServiceUri $(AnyBuildEnvironmentUri) --ClientApplicationId $(LLVMPrincipalAppId) --ClientSecretEnvironmentVariable ServicePrincipalPassword --WaitForAgentForever --DoNotUseMachineUtilizationForScheduling -- ninja.exe -j ${{ parameters.CmakeJobsWindows }} install
     displayName: Compile
 
   - template: ./steps/print-anybuild-stats.yml

--- a/devops/llvm-anybuild.yml
+++ b/devops/llvm-anybuild.yml
@@ -328,7 +328,7 @@ jobs:
       N=$(sysctl -n hw.ncpu)
       make -j $N install
     workingDirectory: build
-    displayName: 'Compile LLVM & MLIR'
+    displayName: Compile
 
   - ${{ if parameters.UploadPackage }}:
     - template: ./steps/tar-and-upload.yml

--- a/devops/llvm-anybuild.yml
+++ b/devops/llvm-anybuild.yml
@@ -31,10 +31,6 @@ parameters:
 resources:
   repositories:
   - repository: self
-  - repository: llvm
-    type: github
-    endpoint: LLVMServiceConnection
-    name: llvm/llvm-project
 
 schedules:
 - cron: "0 3 * * *" # this is 3am UTC
@@ -59,9 +55,9 @@ variables:
   value: https://github.com/llvm/llvm-project
 
 jobs:
-### Configure: Determine LLVM commit to build.
+### Determine LLVM commit to build.
 ###
-### Outputs the LLVM_COMMIT variable to contain the commit hash of the LLVM submodule in latest verona@master.
+### Output the LLVM_COMMIT variable to contain the commit hash of the LLVM submodule in latest verona@master.
 ### Can be overridden by setting a pipeline variable named GOOD_HASH.
 - job: Configure
   displayName: Configure LLVM commit to build
@@ -87,8 +83,6 @@ jobs:
     name: SetCommits
 
 ############################################# Windows Builds
-
-### Build LLVM with AnyBuild
 - job: LLVM_Windows
   displayName: LLVM Windows
   condition: and(succeeded(), ${{ eq(parameters.BuildOnWindows, true) }})
@@ -166,8 +160,6 @@ jobs:
         Md5Cmd: md5sum
 
 ############################################# Linux Builds
-
-### Build LLVM with AnyBuild first
 - job: LLVM_Linux
   displayName: LLVM Linux
   condition: and(succeeded(), ${{ eq(parameters.BuildOnLinux, true) }})
@@ -278,7 +270,7 @@ jobs:
         -- \
         cmake --build . -- -j ${{ parameters.CmakeJobsLinux }} install
     workingDirectory: $(LlvmBuildDir)
-    displayName: Build with AnyBuild
+    displayName: Compile
 
   - template: ./steps/print-anybuild-stats.yml
     parameters:

--- a/devops/llvm-anybuild.yml
+++ b/devops/llvm-anybuild.yml
@@ -1,0 +1,361 @@
+parameters:
+  # whether to build on Linux
+  - name: BuildOnLinux
+    type: boolean
+    default: true
+  # whether to build on Windows
+  - name: BuildOnWindows
+    type: boolean
+    default: true
+  # whether to build on MacOS
+  - name: BuildOnMacOs
+    type: boolean
+    default: false
+  # whether to build Verona
+  - name: UploadPackage
+    type: boolean
+    default: false
+  # extra command-line args to pass to AnyBuild
+  - name: ExtraAnyBuildArgs
+    type: string
+    default: --Verbose --WhyCacheMiss --WhyCacheMissOptions CacheDataStoreKey=LLVMVerona
+  # number of parallel cmake jobs when building LLVM on Linux
+  - name: CmakeJobsLinux
+    type: number
+    default: 48
+  # number of parallel cmake jobs when building LLVM on Windows
+  - name: CmakeJobsWindows
+    type: number
+    default: 24
+
+resources:
+  repositories:
+  - repository: self
+  - repository: llvm
+    type: github
+    endpoint: LLVMServiceConnection
+    name: llvm/llvm-project
+
+schedules:
+- cron: "0 3 * * *" # this is 3am UTC
+  displayName: Nightly AnyBuild LLVM Build
+  always: true
+  branches:
+    include:
+    - master
+
+variables:
+- name: AbEnvironmentName
+  value: LLVMVna
+- name: AbClusterId
+  value: 0310c9eb-18d0-4a58-bc85-bdc02a4d764a
+- name: AnyBuildEnvironmentUri
+  value: https://northeurope.anybuild-test.microsoft.com/api/clusters/$(AbClusterId)/agents
+- name: AnyBuildSource
+  value: https://anybuild$(AbEnvironmentName)neurope.blob.core.windows.net/clientreleases
+- name: AnyBuildRing
+  value: Dogfood
+- name: VeronaRepoGitUri
+  value: https://github.com/microsoft/verona
+- name: LlvmRepoGitUri
+  value: https://github.com/llvm/llvm-project
+# GOOD_HASH may be set in the pipeline in which case it overrides LLVM_COMMIT 
+# - name: GOOD_HASH
+#   value: ''
+
+jobs:
+### Configure: Determine commits to build
+###   - outputs VERONA_COMMIT and LLVM_COMMIT that correspond to the latest checked in change in verona@master
+- job: Configure
+  displayName: Configure LLVM/Verona commits to build
+  pool:
+    vmImage: ubuntu-18.04
+  timeoutInMinutes: 5
+  steps:
+  - checkout: self
+
+  - bash: |
+      set -euo pipefail
+
+      VERONA_COMMIT=$(git rev-parse HEAD)
+      if [[ -z "$(GOOD_HASH)" ]]; then
+        LLVM_COMMIT=$(git submodule | grep llvm-project | cut -f1 -d\ | sed 's/^.//g')
+      else
+        LLVM_COMMIT="$(GOOD_HASH)"
+      fi
+
+      echo "Setting the following output variables:"
+      echo "  VERONA_COMMIT=$VERONA_COMMIT"
+      echo "  LLVM_COMMIT=$LLVM_COMMIT"
+      echo "##vso[task.setvariable variable=VERONA_COMMIT;isOutput=true;]$VERONA_COMMIT"
+      echo "##vso[task.setvariable variable=LLVM_COMMIT;isOutput=true;]$LLVM_COMMIT"
+    displayName: SetCommits
+    name: SetCommits
+
+############################################# Windows Builds
+
+### Build LLVM with AnyBuild first
+- job: LLVM_Windows
+  displayName: LLVM Windows
+  condition: and(succeeded(), ${{ eq(parameters.BuildOnWindows, true) }})
+  dependsOn: [ Configure ]
+  pool:
+    vmImage: windows-2019
+  timeoutInMinutes: 120
+  strategy:
+    matrix:
+      Release:
+        BuildType: Release
+        BuildName: release
+  variables:
+  - name: AbLogsRootDir
+    value: $(Build.StagingDirectory)\ab_logs
+  - name: LlvmSourceDir
+    value: $(Agent.BuildDirectory)\s
+  - name: LlvmBuildDir
+    value: $(LlvmSourceDir)\build
+  - name: LLVM_COMMIT
+    value: $[ dependencies.Configure.outputs['SetCommits.LLVM_COMMIT'] ]
+  - name: PKG_NAME
+    value: verona-llvm-install-x86_64-windows-$(BuildName)-$(LLVM_COMMIT)
+
+  steps:
+  - checkout: none
+  - template: ./steps/git-shallow-clone.yml
+    parameters:
+      RepoUri: $(LlvmRepoGitUri)
+      TargetDir: $(LlvmSourceDir)
+      CommitSha: $(LLVM_COMMIT)
+
+  - powershell: |
+      Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+    displayName: Install Choco
+
+  - powershell: |
+      C:\ProgramData\chocolatey\bin\choco install --accept-license -y ninja
+    displayName: Install Ninja
+
+  - powershell: |
+      Set-ExecutionPolicy Bypass -Scope Process -Force
+
+      Remove-Item -Force -Recurse "$env:LOCALAPPDATA\Microsoft\AnyBuild" -ea SilentlyContinue
+
+      Invoke-Command -ScriptBlock ([scriptblock]::Create((New-Object System.Net.WebClient).DownloadString("$(AnyBuildSource)/bootstrapper.ps1"))) -ArgumentList ("$(AnyBuildSource)", "$(AnyBuildRing)")
+    displayName: Install AnyBuild
+
+  - script: |
+      rd /s /q build
+      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+      mkdir build
+      cd build
+      cmake ..\llvm -GNinja -DCMAKE_BUILD_TYPE=$(BuildType) -DLLVM_ENABLE_PROJECTS="clang;mlir" -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_ENABLE_EH=ON -DLLVM_ENABLE_RTTI=ON -DCMAKE_INSTALL_PREFIX=install -DMLIR_INCLUDE_TESTS=OFF -Wno-dev
+    displayName: CMake
+
+  - script: |
+      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+      cd build
+
+      set "COMPUTERNAME="
+      set "LOGONSERVER="
+      set "NUMBER_OF_PROCESSORS="
+      set "PROCESSOR_IDENTIFIER="
+      set "PROCESSOR_REVISION="
+      set "USERDOMAIN="
+      set "USERDOMAIN_ROAMINGPROFILE="
+
+      set ServicePrincipalPassword=$(LLVMPrincipalPassword)
+      call "%LOCALAPPDATA%\Microsoft\AnyBuild\AnyBuild.cmd" --EnableActionCache ${{ parameters.ExtraAnyBuildArgs }} --RemoteExecServiceUri $(AnyBuildEnvironmentUri) --ClientApplicationId $(LLVMPrincipalAppId) --ClientSecretEnvironmentVariable ServicePrincipalPassword --WaitForAgentForever --DoNotUseMachineUtilizationForScheduling -- "C:\ProgramData\chocolatey\lib\ninja\tools\ninja.exe" -j ${{ parameters.CmakeJobsWindows }} install
+    displayName: Compile
+
+  - template: ./steps/print-anybuild-stats.yml
+    parameters:
+      LogsDir: $(LlvmBuildDir)
+
+  - ${{ if parameters.UploadPackage }}:
+    - template: ./steps/tar-and-upload.yml
+      parameters:
+        WorkingDir: $(LlvmSourceDir)
+        InstallDirRelativePath: build/install
+        PackageName: $(PKG_NAME)
+        Md5Cmd: md5sum
+
+############################################# Linux Builds
+
+### Build LLVM with AnyBuild first
+- job: LLVM_Linux
+  displayName: LLVM Linux
+  condition: and(succeeded(), ${{ eq(parameters.BuildOnLinux, true) }})
+  dependsOn: [ Configure ]
+  pool:
+    vmImage: ubuntu-18.04
+  timeoutInMinutes: 120
+  strategy:
+    matrix:
+      Clang Release:
+        CC: clang
+        CXX: clang++
+        CXXFLAGS: -stdlib=libstdc++
+        BuildType: Release
+        BuildName: release
+        Sanitizer:
+
+  variables:
+  - name: AbClientDirectory
+    value: $HOME/.local/share/Microsoft/AnyBuild
+  - name: AbDeploymentJson
+    value: $HOME/.local/share/AnyBuildDeployment.json
+  - name: AbLogsRootDir
+    value: $(Build.StagingDirectory)/ab_logs
+  - name: LlvmSourceDir
+    value: $(Agent.BuildDirectory)/s
+  - name: LlvmBuildDir
+    value: $(LlvmSourceDir)/build
+  - name: LLVM_COMMIT
+    value: $[ dependencies.Configure.outputs['SetCommits.LLVM_COMMIT'] ]
+  - name: PKG_NAME
+    value: verona-llvm-install-x86_64-linux-$(BuildName)-$(LLVM_COMMIT)
+
+  steps:
+  - checkout: none
+  - template: ./steps/git-shallow-clone.yml
+    parameters:
+      RepoUri: $(LlvmRepoGitUri)
+      TargetDir: $(LlvmSourceDir)
+      CommitSha: $(LLVM_COMMIT)
+
+  - script: |
+      set -euo pipefail
+
+      sudo apt-get update
+      sudo apt-get install -y clang ninja-build lld jq tree
+
+      # Install latest CMake from snap (must first remove the pre-installed one)
+      sudo apt remove -y --purge cmake
+      sudo snap install cmake --classic
+    displayName: Install Prerequisites
+
+  - bash: |
+      set -euo pipefail
+
+      echo "=== Downloading AnyBuild from $(AnyBuildSource)"
+      wget -O- $(AnyBuildSource)/bootstrapper.sh | bash -s $(AnyBuildSource) $(AnyBuildRing)
+    displayName: Install AnyBuild Client
+
+  - bash: |
+      function log-and-run {
+        echo "Running "
+        echo "  CWD = $(pwd)"
+        echo "  CMD = $@"
+        "$@"
+      }
+
+      rm -rf "$(LlvmBuildDir)"
+      mkdir -p "$(LlvmBuildDir)"
+      cd "$(LlvmBuildDir)"
+      log-and-run cmake $(LlvmSourceDir)/llvm \
+        -GNinja                               \
+        -DCMAKE_BUILD_TYPE=$(BuildType)       \
+        -DCMAKE_C_COMPILER=$(CC)              \
+        -DCMAKE_CXX_COMPILER=$(CXX)           \
+        -DCMAKE_CXX_FLAGS=$(CXXFLAGS)         \
+        -DLLVM_USE_SANITIZER=$(Sanitizer)     \
+        -DLLVM_ENABLE_PROJECTS="clang;mlir"   \
+        -DLLVM_TARGETS_TO_BUILD="X86"         \
+        -DLLVM_ENABLE_ASSERTIONS=ON           \
+        -DLLVM_ENABLE_LLD=ON                  \
+        -DLLVM_ENABLE_EH=ON                   \
+        -DLLVM_ENABLE_RTTI=ON                 \
+        -DCMAKE_INSTALL_PREFIX=install        \
+        -DMLIR_INCLUDE_TESTS=OFF              \
+        -Wno-dev
+    workingDirectory: $(LlvmSourceDir)
+    displayName: CMake
+
+  - bash: |
+      declare time_limit="90m"
+
+      echo "===== Running build (${{ parameters.CmakeJobsLinux }} CMake jobs) up to ${time_limit} from $(pwd)"
+      echo
+
+      env -i                                                      \
+        llvmPassword=$(LLVMPrincipalPassword)                     \
+        HOME="$HOME"                                              \
+        PATH="$PATH"                                              \
+      timeout "$time_limit" time $(AbClientDirectory)/AnyBuild.sh \
+        --RemoteExecServiceUri $(AnyBuildEnvironmentUri)          \
+        --NoCheckForUpdates                                       \
+        --WaitForAgentForever                                     \
+        --DoNotUseMachineUtilizationForScheduling                 \
+        --ClientApplicationId $(LLVMPrincipalAppId)               \
+        --ClientSecretEnvironmentVariable llvmPassword            \
+        ${{ parameters.ExtraAnyBuildArgs }}                       \
+        -- \
+        cmake --build . -- -j ${{ parameters.CmakeJobsLinux }} install
+    workingDirectory: $(LlvmBuildDir)
+    displayName: Build with AnyBuild
+
+  - template: ./steps/print-anybuild-stats.yml
+    parameters:
+      LogsDir: $(LlvmBuildDir)
+
+  - bash: |
+      ninja clean
+    workingDirectory: $(LlvmBuildDir)
+    displayName: Delete Build Outputs (to free up space for 'Create package')
+
+  - ${{ if parameters.UploadPackage }}:
+    - template: ./steps/tar-and-upload.yml
+      parameters:
+        WorkingDir: $(LlvmSourceDir)
+        InstallDirRelativePath: build/install
+        PackageName: $(PKG_NAME)
+        Md5Cmd: md5sum
+
+############################################## MacOS Builds
+- job: LLVM_MacOs
+  displayName: LLVM MacOS Build
+  condition: and(succeeded(), ${{ eq(parameters.BuildOnMacOs, true) }})
+  dependsOn: [ Configure ]
+  pool:
+    vmImage: 'macOS-10.14'
+  timeoutInMinutes: 240
+  strategy:
+    matrix:
+      Release:
+        BuildType: Release
+        BuildName: release
+  variables:
+  - name: LlvmSourceDir
+    value: $(Agent.BuildDirectory)/s
+  - name: LLVM_COMMIT
+    value: $[ dependencies.Configure.outputs['SetCommits.LLVM_COMMIT'] ]
+  - name: PKG_NAME
+    value: verona-llvm-install-x86_64-darwin-$(BuildName)-$(LLVM_COMMIT)
+  steps:
+  - checkout: none
+  - template: ./steps/git-shallow-clone.yml
+    parameters:
+      RepoUri: $(LlvmRepoGitUri)
+      TargetDir: $(LlvmSourceDir)
+      CommitSha: $(LLVM_COMMIT)
+
+  - task: CMake@1
+    displayName: 'CMake'
+    inputs:
+      cmakeArgs: |
+        ../llvm -DCMAKE_BUILD_TYPE=$(BuildType) -DLLVM_ENABLE_PROJECTS="clang;mlir" -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_ENABLE_EH=ON -DLLVM_ENABLE_RTTI=ON -DCMAKE_INSTALL_PREFIX=install -DMLIR_INCLUDE_TESTS=OFF -Wno-dev
+
+  - script: |
+      set -eo pipefail
+      N=$(sysctl -n hw.ncpu)
+      make -j $N install
+    workingDirectory: build
+    displayName: 'Compile LLVM & MLIR'
+
+  - ${{ if parameters.UploadPackage }}:
+    - template: ./steps/tar-and-upload.yml
+      parameters:
+        WorkingDir: $(LlvmSourceDir)
+        InstallDirRelativePath: build/install
+        PackageName: $(PKG_NAME)
+        Md5Cmd: md5 -r

--- a/devops/steps/git-shallow-clone.yml
+++ b/devops/steps/git-shallow-clone.yml
@@ -1,0 +1,35 @@
+###
+### Performs a shallow git clone at a given commit
+###
+
+parameters:
+# git url
+- name: RepoUri
+  type: string
+# directory where to clone
+- name: TargetDir
+  type: string
+# git commit to clone
+- name: CommitSha
+  type: string
+
+steps:
+- bash: |
+    set -euo pipefail
+
+    mkdir -p "${{ parameters.TargetDir }}"
+    cd "${{ parameters.TargetDir }}"
+    git init
+
+    echo "=== Initializing origin"
+    git remote add origin ${{ parameters.RepoUri }}
+    git fetch --depth 1 origin ${{ parameters.CommitSha }}
+    git checkout FETCH_HEAD
+
+    echo "=== Initializing submodules"
+    git submodule init
+    git submodule update --depth 1 --recursive
+
+    echo "=== Last commit"
+    git log -1
+  displayName: Checkout ${{ parameters.RepoUri}} @ ${{ parameters.CommitSha }}

--- a/devops/steps/git-shallow-clone.yml
+++ b/devops/steps/git-shallow-clone.yml
@@ -21,8 +21,10 @@ steps:
     cd "${{ parameters.TargetDir }}"
     git init
 
-    echo "=== Initializing origin"
+    echo "=== Setting origin to ${{ parameters.RepoUri }}"
     git remote add origin ${{ parameters.RepoUri }}
+
+    echo "=== Checking out commit ${{ parameters.CommitSha }}"
     git fetch --depth 1 origin ${{ parameters.CommitSha }}
     git checkout FETCH_HEAD
 
@@ -32,4 +34,4 @@ steps:
 
     echo "=== Last commit"
     git log -1
-  displayName: Checkout ${{ parameters.RepoUri}} @ ${{ parameters.CommitSha }}
+  displayName: Shallow Checkout 

--- a/devops/steps/print-anybuild-stats.yml
+++ b/devops/steps/print-anybuild-stats.yml
@@ -1,0 +1,16 @@
+parameters:
+- name: LogsDir
+  type: string
+
+steps:
+- bash: |
+    set -euo pipefail
+
+    readonly logFile="${{ parameters.LogsDir }}/AnyBuild.log"
+    if [[ -f "$logFile" ]]; then
+      echo "=== AnyBuild stats ==="
+      sed -n '/Session telemetry: Finished/,$ p' "$logFile"
+    fi
+  continueOnError: true
+  condition: always()
+  displayName: Print AnyBuild Stats

--- a/devops/steps/tar-and-upload.yml
+++ b/devops/steps/tar-and-upload.yml
@@ -13,15 +13,24 @@ steps:
       set -euo pipefail
       readonly PKG_NAME="${{ parameters.PackageName }}"
       rm -f $PKG_NAME.tar.gz
+
+      echo "=== Creating a tarball from $(pwd)/${{ parameters.InstallDirRelativePath }}"
       tar zcf $PKG_NAME.tar.gz ${{ parameters.InstallDirRelativePath }}
+      echo "=== $PKG_NAME.tar.gz created"
+
+      echo "=== Computing md5 checksum"
       ${{ parameters.Md5Cmd }} $PKG_NAME.tar.gz | awk '{print $1}' > $PKG_NAME.tar.gz.md5
+      cat $PKG_NAME.tar.gz.md5
     workingDirectory: ${{ parameters.WorkingDir }}
     displayName: Create Package
 
   - bash: |
       set -eo pipefail
       readonly PKG_NAME="${{ parameters.PackageName }}"
+      echo "=== Uploading $(pwd)/$PKG_NAME.tar.gz"
       az storage blob upload --container-name llvmbuild --file $PKG_NAME.tar.gz --name $PKG_NAME --connection-string "$(BLOB_CONNECTION_STRING)"
+
+      echo "=== Uploading $(pwd)/$PKG_NAME.tar.gz.md5"
       az storage blob upload --container-name llvmbuild --file $PKG_NAME.tar.gz.md5 --name $PKG_NAME.md5 --connection-string "$(BLOB_CONNECTION_STRING)"
     workingDirectory: ${{ parameters.WorkingDir }}
     displayName: Upload Package

--- a/devops/steps/tar-and-upload.yml
+++ b/devops/steps/tar-and-upload.yml
@@ -1,0 +1,27 @@
+parameters:
+- name: WorkingDir
+  type: string
+- name: InstallDirRelativePath
+  type: string
+- name: PackageName
+  type: string
+- name: Md5Cmd
+  type: string
+
+steps:
+  - bash: |
+      set -euo pipefail
+      readonly PKG_NAME="${{ parameters.PackageName }}"
+      rm -f $PKG_NAME.tar.gz
+      tar zcf $PKG_NAME.tar.gz ${{ parameters.InstallDirRelativePath }}
+      ${{ parameters.Md5Cmd }} $PKG_NAME.tar.gz | awk '{print $1}' > $PKG_NAME.tar.gz.md5
+    workingDirectory: ${{ parameters.WorkingDir }}
+    displayName: Create Package
+
+  - bash: |
+      set -eo pipefail
+      readonly PKG_NAME="${{ parameters.PackageName }}"
+      az storage blob upload --container-name llvmbuild --file $PKG_NAME.tar.gz --name $PKG_NAME --connection-string "$(BLOB_CONNECTION_STRING)"
+      az storage blob upload --container-name llvmbuild --file $PKG_NAME.tar.gz.md5 --name $PKG_NAME.md5 --connection-string "$(BLOB_CONNECTION_STRING)"
+    workingDirectory: ${{ parameters.WorkingDir }}
+    displayName: Upload Package


### PR DESCRIPTION
The pipeline has the following job dependencies:
```
Configure
├── LLVM-linux
├── LLVM-macOS
└── LLVM-windows
```
The `Configure` job sets an output variable named `LLVM_COMMIT` to either to the value of the `$(GOOD_HASH)` pipeline variable (if set) or the commit hash of the llvm-project submodule currently checked into this repo.

The subsequent jobs build the `LLVM_COMMIT` commit of the `llvm-project` repo on Linux, Windows, and macOS.   They all produce an installation tarball and optionally upload it to blob storage.

On Linux and Windows, the build is wrapped with AnyBuild to provide distribution and caching on top of the native build.