### PR TITLE
Move CI to Ubuntu 20 to fix ASAN build

### DIFF
--- a/devops/ci.yml
+++ b/devops/ci.yml
@@ -10,7 +10,7 @@ jobs:
 ############################################## Configure CI Run
 - job: ConfigureCIRun
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-20.04'
   steps:
   - script: |
       echo "Determine if any code has changed."
@@ -50,7 +50,7 @@ jobs:
   variables:
     RTTests: $[ dependencies.ConfigureCIRun.outputs['setVarStep.testRuntime'] ]
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-20.04'
   timeoutInMinutes: 120
   strategy:
     matrix:
@@ -257,7 +257,7 @@ jobs:
 - job: 
   displayName: Format
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-20.04'
   steps:
   - checkout: self
 

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -18,7 +18,7 @@ jobs:
 - job:
   displayName: Linux
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-20.04'
   timeoutInMinutes: 120
   strategy:
     matrix:


### PR DESCRIPTION
Seems the previous Ubuntu version (18.04) broken something with ASAN this week, and moving to 20.04 seems to fix it. It was about time to move anyway, so here it goes.

The problems we found were so far fetching (old `veronac`, new `verona-mlir` and `verona-interop`), that it's very unlikely they're from anything remotely similar. Problem in the system is more likely than in our code.

Both CI and nightly were fixed by this commit, with nightly back to the previous failures that we're still investigating (#436).
