### PR TITLE
Move some unit tests to Lambda

### DIFF
--- a/src/rt/cpp/lambdabehaviour.h
+++ b/src/rt/cpp/lambdabehaviour.h
@@ -66,7 +66,6 @@ namespace verona::rt
   static void scheduleLambda(T f)
   {
     Cown* c = new EmptyCown();
-    Cown::schedule<LambdaBehaviour<T>>(c, std::forward<T>(f));
-    Cown::release(ThreadAlloc::get(), c);
+    Cown::schedule<LambdaBehaviour<T>, YesTransfer>(c, std::forward<T>(f));
   }
 } // namespace verona::rt

--- a/src/rt/test/func/ext_ref/ext_ref_basic.h
+++ b/src/rt/test/func/ext_ref/ext_ref_basic.h
@@ -110,39 +110,6 @@ namespace ext_ref_basic
     }
   };
 
-  struct AMsg : public VBehaviour<AMsg>
-  {
-    A* a;
-    B* b;
-    ExternalRef* ext_node;
-
-    Node* get()
-    {
-      return (Node*)ext_node->get();
-    }
-
-    void f()
-    {
-      auto alloc = ThreadAlloc::get();
-
-      auto list = a->list;
-      check(ext_node->is_in(Region::get(g_list)));
-      auto node = get();
-
-      node->prev->next = node->next;
-      node->next->prev = node->prev;
-
-      node->element = nullptr;
-      RegionTrace::gc(alloc, list);
-
-      check(!ext_node->is_in(Region::get(g_list)));
-      Immutable::release(alloc, ext_node);
-    }
-
-    AMsg(A* a, B* b_, ExternalRef* ext_node_) : a(a), b{b_}, ext_node{ext_node_}
-    {}
-  };
-
   // Illustrating a scenario, where cown A holds a doubly-linked list, with
   // each node holds a ref to cown B. When cown B decides to remove itself
   // from this list, it could send an message to cown A. Upon receiving this
@@ -165,8 +132,24 @@ namespace ext_ref_basic
 
     // Aliasing ext_node in AMsg.
     Immutable::acquire(b->ext_node);
-    Cown::schedule<AMsg>(g_a, g_a, b, b->ext_node);
+    auto a = g_a;
+    auto ext_node = b->ext_node;
+    scheduleLambda(a, [a, ext_node]() {
+      auto alloc = ThreadAlloc::get();
 
+      auto list = a->list;
+      check(ext_node->is_in(Region::get(g_list)));
+      auto node = (Node*)ext_node->get();
+
+      node->prev->next = node->next;
+      node->next->prev = node->prev;
+
+      node->element = nullptr;
+      RegionTrace::gc(alloc, list);
+
+      check(!ext_node->is_in(Region::get(g_list)));
+      Immutable::release(alloc, ext_node);
+    });
     Cown::release(alloc, g_a);
     sched.run();
     snmalloc::current_alloc_pool()->debug_check_empty();

--- a/src/rt/test/func/notify/notify_basic.h
+++ b/src/rt/test/func/notify/notify_basic.h
@@ -2,11 +2,6 @@
 // SPDX-License-Identifier: MIT
 namespace notify_basic
 {
-  struct Ping : public VBehaviour<Ping>
-  {
-    void f() {}
-  };
-
   bool g_called = false;
 
   struct A : public VCown<A>
@@ -28,7 +23,7 @@ namespace notify_basic
     g_a = new A;
 
     g_a->mark_notify();
-    Cown::schedule<Ping>(g_a);
+    scheduleLambda(g_a, []() {});
 
     Cown::release(alloc, g_a);
   }


### PR DESCRIPTION
This moves a couple of the existing unit tests to use the new C++ Lambda API.  This generally is a good compression of the examples.  Gradually, we should move more across.  This PR was enough for me today ;-)