### PR TITLE
Supporting signed/unsigned types, no auto-cast

### DIFF
--- a/src/mlir/generator.h
+++ b/src/mlir/generator.h
@@ -122,16 +122,6 @@ namespace mlir::verona
 
     // ==================================================== Low level generators
 
-    /// Convert (promote/demote) the value to the specified type. This
-    /// automatically chooses promotion / demotion based on the types involved.
-    Value Convert(Value val, Type ty);
-
-    /// Promote the smallest (compatible) type and return the values to be used
-    /// for arithmetic operations. If types are same, just return them, if not,
-    /// return the cast operations that make them the same. If types are
-    /// incompatible, assert.
-    std::pair<Value, Value> Promote(Value lhs, Value rhs);
-
     /// Generates an alloca (stack variable)
     Value Alloca(Location loc, Type ty);
 
@@ -166,6 +156,6 @@ namespace mlir::verona
     Value ConstantString(StringRef str, StringRef name = "");
 
     /// Generate an arithmetic call (known operation or intrinsic)
-    Value Arithmetic(Location loc, StringRef name, Value ops);
+    Value Arithmetic(Location loc, StringRef name, Value ops, Type retTy);
   };
 }

--- a/testsuite/verona-mlir/arithmetic.out/stdout.txt
+++ b/testsuite/verona-mlir/arithmetic.out/stdout.txt
@@ -95,6 +95,59 @@ module  {
     %14 = llvm.load %13 : !llvm.ptr<i32>
     return %14 : i32
   }
+  llvm.mlir.global private constant @std.sexti("std.sexti")
+  func @"$module-0__I32__ext"(%arg0: i32) -> i64 {
+    %c1_i32 = constant 1 : i32
+    %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
+    %1 = llvm.mlir.addressof @std.sexti : !llvm.ptr<array<9 x i8>>
+    %2 = sexti %arg0 : i32 to i64
+    %c0_i32 = constant 0 : i32
+    %3 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %4 = llvm.load %3 : !llvm.ptr<i64>
+    %5 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    llvm.store %2, %5 : !llvm.ptr<i64>
+    %6 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %7 = llvm.load %6 : !llvm.ptr<i64>
+    return %7 : i64
+  }
+  func @"$module-0__U32__+"(%arg0: i32, %arg1: i32) -> i32 {
+    %c1_i32 = constant 1 : i32
+    %0 = llvm.alloca %c1_i32 x i32 : (i32) -> !llvm.ptr<i32>
+    %1 = llvm.mlir.addressof @std.addi : !llvm.ptr<array<8 x i8>>
+    %2 = llvm.alloca %c1_i32 x !llvm.struct<(i32, i32)> : (i32) -> !llvm.ptr<struct<(i32, i32)>>
+    %c0_i32 = constant 0 : i32
+    %3 = llvm.getelementptr %2[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(i32, i32)>>, i32, i32) -> !llvm.ptr<i32>
+    llvm.store %arg0, %3 : !llvm.ptr<i32>
+    %4 = llvm.getelementptr %2[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(i32, i32)>>, i32, i32) -> !llvm.ptr<i32>
+    llvm.store %arg1, %4 : !llvm.ptr<i32>
+    %5 = llvm.getelementptr %2[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(i32, i32)>>, i32, i32) -> !llvm.ptr<i32>
+    %6 = llvm.load %5 : !llvm.ptr<i32>
+    %7 = llvm.getelementptr %2[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(i32, i32)>>, i32, i32) -> !llvm.ptr<i32>
+    %8 = llvm.load %7 : !llvm.ptr<i32>
+    %9 = addi %6, %8 : i32
+    %10 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
+    %11 = llvm.load %10 : !llvm.ptr<i32>
+    %12 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
+    llvm.store %9, %12 : !llvm.ptr<i32>
+    %13 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
+    %14 = llvm.load %13 : !llvm.ptr<i32>
+    return %14 : i32
+  }
+  llvm.mlir.global private constant @std.zexti("std.zexti")
+  func @"$module-0__U32__ext"(%arg0: i32) -> i64 {
+    %c1_i32 = constant 1 : i32
+    %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
+    %1 = llvm.mlir.addressof @std.zexti : !llvm.ptr<array<9 x i8>>
+    %2 = zexti %arg0 : i32 to i64
+    %c0_i32 = constant 0 : i32
+    %3 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %4 = llvm.load %3 : !llvm.ptr<i64>
+    %5 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    llvm.store %2, %5 : !llvm.ptr<i64>
+    %6 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %7 = llvm.load %6 : !llvm.ptr<i64>
+    return %7 : i64
+  }
   func @"$module-0__I64__+"(%arg0: i64, %arg1: i64) -> i64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
@@ -118,10 +171,54 @@ module  {
     %14 = llvm.load %13 : !llvm.ptr<i64>
     return %14 : i64
   }
-  func @"$module-0__I64__-"(%arg0: i64, %arg1: i64) -> i64 {
+  llvm.mlir.global private constant @std.trunci("std.trunci")
+  func @"$module-0__I64__trunc"(%arg0: i64) -> i32 {
+    %c1_i32 = constant 1 : i32
+    %0 = llvm.alloca %c1_i32 x i32 : (i32) -> !llvm.ptr<i32>
+    %1 = llvm.mlir.addressof @std.trunci : !llvm.ptr<array<10 x i8>>
+    %2 = trunci %arg0 : i64 to i32
+    %c0_i32 = constant 0 : i32
+    %3 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
+    %4 = llvm.load %3 : !llvm.ptr<i32>
+    %5 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
+    llvm.store %2, %5 : !llvm.ptr<i32>
+    %6 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
+    %7 = llvm.load %6 : !llvm.ptr<i32>
+    return %7 : i32
+  }
+  llvm.mlir.global private constant @std.sitofp("std.sitofp")
+  func @"$module-0__I64__toFloat"(%arg0: i64) -> f32 {
+    %c1_i32 = constant 1 : i32
+    %0 = llvm.alloca %c1_i32 x f32 : (i32) -> !llvm.ptr<f32>
+    %1 = llvm.mlir.addressof @std.sitofp : !llvm.ptr<array<10 x i8>>
+    %2 = sitofp %arg0 : i64 to f32
+    %c0_i32 = constant 0 : i32
+    %3 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f32>, i32) -> !llvm.ptr<f32>
+    %4 = llvm.load %3 : !llvm.ptr<f32>
+    %5 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f32>, i32) -> !llvm.ptr<f32>
+    llvm.store %2, %5 : !llvm.ptr<f32>
+    %6 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f32>, i32) -> !llvm.ptr<f32>
+    %7 = llvm.load %6 : !llvm.ptr<f32>
+    return %7 : f32
+  }
+  func @"$module-0__I64__toDouble"(%arg0: i64) -> f64 {
+    %c1_i32 = constant 1 : i32
+    %0 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
+    %1 = llvm.mlir.addressof @std.sitofp : !llvm.ptr<array<10 x i8>>
+    %2 = sitofp %arg0 : i64 to f64
+    %c0_i32 = constant 0 : i32
+    %3 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    %4 = llvm.load %3 : !llvm.ptr<f64>
+    %5 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    llvm.store %2, %5 : !llvm.ptr<f64>
+    %6 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    %7 = llvm.load %6 : !llvm.ptr<f64>
+    return %7 : f64
+  }
+  func @"$module-0__U64__+"(%arg0: i64, %arg1: i64) -> i64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
-    %1 = llvm.mlir.addressof @std.subi : !llvm.ptr<array<8 x i8>>
+    %1 = llvm.mlir.addressof @std.addi : !llvm.ptr<array<8 x i8>>
     %2 = llvm.alloca %c1_i32 x !llvm.struct<(i64, i64)> : (i32) -> !llvm.ptr<struct<(i64, i64)>>
     %c0_i32 = constant 0 : i32
     %3 = llvm.getelementptr %2[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(i64, i64)>>, i32, i32) -> !llvm.ptr<i64>
@@ -132,7 +229,7 @@ module  {
     %6 = llvm.load %5 : !llvm.ptr<i64>
     %7 = llvm.getelementptr %2[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(i64, i64)>>, i32, i32) -> !llvm.ptr<i64>
     %8 = llvm.load %7 : !llvm.ptr<i64>
-    %9 = subi %6, %8 : i64
+    %9 = addi %6, %8 : i64
     %10 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
     %11 = llvm.load %10 : !llvm.ptr<i64>
     %12 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
@@ -141,51 +238,48 @@ module  {
     %14 = llvm.load %13 : !llvm.ptr<i64>
     return %14 : i64
   }
-  func @"$module-0__I64__*"(%arg0: i64, %arg1: i64) -> i64 {
+  func @"$module-0__U64__trunc"(%arg0: i64) -> i32 {
     %c1_i32 = constant 1 : i32
-    %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
-    %1 = llvm.mlir.addressof @std.muli : !llvm.ptr<array<8 x i8>>
-    %2 = llvm.alloca %c1_i32 x !llvm.struct<(i64, i64)> : (i32) -> !llvm.ptr<struct<(i64, i64)>>
+    %0 = llvm.alloca %c1_i32 x i32 : (i32) -> !llvm.ptr<i32>
+    %1 = llvm.mlir.addressof @std.trunci : !llvm.ptr<array<10 x i8>>
+    %2 = trunci %arg0 : i64 to i32
     %c0_i32 = constant 0 : i32
-    %3 = llvm.getelementptr %2[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(i64, i64)>>, i32, i32) -> !llvm.ptr<i64>
-    llvm.store %arg0, %3 : !llvm.ptr<i64>
-    %4 = llvm.getelementptr %2[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(i64, i64)>>, i32, i32) -> !llvm.ptr<i64>
-    llvm.store %arg1, %4 : !llvm.ptr<i64>
-    %5 = llvm.getelementptr %2[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(i64, i64)>>, i32, i32) -> !llvm.ptr<i64>
-    %6 = llvm.load %5 : !llvm.ptr<i64>
-    %7 = llvm.getelementptr %2[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(i64, i64)>>, i32, i32) -> !llvm.ptr<i64>
-    %8 = llvm.load %7 : !llvm.ptr<i64>
-    %9 = muli %6, %8 : i64
-    %10 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
-    %11 = llvm.load %10 : !llvm.ptr<i64>
-    %12 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
-    llvm.store %9, %12 : !llvm.ptr<i64>
-    %13 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
-    %14 = llvm.load %13 : !llvm.ptr<i64>
-    return %14 : i64
+    %3 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
+    %4 = llvm.load %3 : !llvm.ptr<i32>
+    %5 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
+    llvm.store %2, %5 : !llvm.ptr<i32>
+    %6 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
+    %7 = llvm.load %6 : !llvm.ptr<i32>
+    return %7 : i32
   }
-  func @"$module-0__I64__/"(%arg0: i64, %arg1: i64) -> i64 {
+  llvm.mlir.global private constant @std.uitofp("std.uitofp")
+  func @"$module-0__U64__toFloat"(%arg0: i64) -> f32 {
     %c1_i32 = constant 1 : i32
-    %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
-    %1 = llvm.mlir.addressof @std.divi_signed : !llvm.ptr<array<15 x i8>>
-    %2 = llvm.alloca %c1_i32 x !llvm.struct<(i64, i64)> : (i32) -> !llvm.ptr<struct<(i64, i64)>>
+    %0 = llvm.alloca %c1_i32 x f32 : (i32) -> !llvm.ptr<f32>
+    %1 = llvm.mlir.addressof @std.uitofp : !llvm.ptr<array<10 x i8>>
+    %2 = uitofp %arg0 : i64 to f32
     %c0_i32 = constant 0 : i32
-    %3 = llvm.getelementptr %2[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(i64, i64)>>, i32, i32) -> !llvm.ptr<i64>
-    llvm.store %arg0, %3 : !llvm.ptr<i64>
-    %4 = llvm.getelementptr %2[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(i64, i64)>>, i32, i32) -> !llvm.ptr<i64>
-    llvm.store %arg1, %4 : !llvm.ptr<i64>
-    %5 = llvm.getelementptr %2[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(i64, i64)>>, i32, i32) -> !llvm.ptr<i64>
-    %6 = llvm.load %5 : !llvm.ptr<i64>
-    %7 = llvm.getelementptr %2[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(i64, i64)>>, i32, i32) -> !llvm.ptr<i64>
-    %8 = llvm.load %7 : !llvm.ptr<i64>
-    %9 = divi_signed %6, %8 : i64
-    %10 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
-    %11 = llvm.load %10 : !llvm.ptr<i64>
-    %12 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
-    llvm.store %9, %12 : !llvm.ptr<i64>
-    %13 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
-    %14 = llvm.load %13 : !llvm.ptr<i64>
-    return %14 : i64
+    %3 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f32>, i32) -> !llvm.ptr<f32>
+    %4 = llvm.load %3 : !llvm.ptr<f32>
+    %5 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f32>, i32) -> !llvm.ptr<f32>
+    llvm.store %2, %5 : !llvm.ptr<f32>
+    %6 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f32>, i32) -> !llvm.ptr<f32>
+    %7 = llvm.load %6 : !llvm.ptr<f32>
+    return %7 : f32
+  }
+  func @"$module-0__U64__toDouble"(%arg0: i64) -> f64 {
+    %c1_i32 = constant 1 : i32
+    %0 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
+    %1 = llvm.mlir.addressof @std.uitofp : !llvm.ptr<array<10 x i8>>
+    %2 = uitofp %arg0 : i64 to f64
+    %c0_i32 = constant 0 : i32
+    %3 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    %4 = llvm.load %3 : !llvm.ptr<f64>
+    %5 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    llvm.store %2, %5 : !llvm.ptr<f64>
+    %6 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    %7 = llvm.load %6 : !llvm.ptr<f64>
+    return %7 : f64
   }
   llvm.mlir.global private constant @std.addf("std.addf")
   func @"$module-0__F32__+"(%arg0: f32, %arg1: f32) -> f32 {
@@ -283,6 +377,21 @@ module  {
     %14 = llvm.load %13 : !llvm.ptr<f32>
     return %14 : f32
   }
+  llvm.mlir.global private constant @std.fpext("std.fpext")
+  func @"$module-0__F32__ext"(%arg0: f32) -> f64 {
+    %c1_i32 = constant 1 : i32
+    %0 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
+    %1 = llvm.mlir.addressof @std.fpext : !llvm.ptr<array<9 x i8>>
+    %2 = fpext %arg0 : f32 to f64
+    %c0_i32 = constant 0 : i32
+    %3 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    %4 = llvm.load %3 : !llvm.ptr<f64>
+    %5 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    llvm.store %2, %5 : !llvm.ptr<f64>
+    %6 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    %7 = llvm.load %6 : !llvm.ptr<f64>
+    return %7 : f64
+  }
   func @"$module-0__F64__+"(%arg0: f64, %arg1: f64) -> f64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
@@ -306,74 +415,65 @@ module  {
     %14 = llvm.load %13 : !llvm.ptr<f64>
     return %14 : f64
   }
-  func @"$module-0__F64__-"(%arg0: f64, %arg1: f64) -> f64 {
+  llvm.mlir.global private constant @std.fptrunc("std.fptrunc")
+  func @"$module-0__F64__trunc"(%arg0: f64) -> f32 {
     %c1_i32 = constant 1 : i32
-    %0 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
-    %1 = llvm.mlir.addressof @std.subf : !llvm.ptr<array<8 x i8>>
-    %2 = llvm.alloca %c1_i32 x !llvm.struct<(f64, f64)> : (i32) -> !llvm.ptr<struct<(f64, f64)>>
+    %0 = llvm.alloca %c1_i32 x f32 : (i32) -> !llvm.ptr<f32>
+    %1 = llvm.mlir.addressof @std.fptrunc : !llvm.ptr<array<11 x i8>>
+    %2 = fptrunc %arg0 : f64 to f32
     %c0_i32 = constant 0 : i32
-    %3 = llvm.getelementptr %2[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(f64, f64)>>, i32, i32) -> !llvm.ptr<f64>
-    llvm.store %arg0, %3 : !llvm.ptr<f64>
-    %4 = llvm.getelementptr %2[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(f64, f64)>>, i32, i32) -> !llvm.ptr<f64>
-    llvm.store %arg1, %4 : !llvm.ptr<f64>
-    %5 = llvm.getelementptr %2[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(f64, f64)>>, i32, i32) -> !llvm.ptr<f64>
-    %6 = llvm.load %5 : !llvm.ptr<f64>
-    %7 = llvm.getelementptr %2[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(f64, f64)>>, i32, i32) -> !llvm.ptr<f64>
-    %8 = llvm.load %7 : !llvm.ptr<f64>
-    %9 = subf %6, %8 : f64
-    %10 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
-    %11 = llvm.load %10 : !llvm.ptr<f64>
-    %12 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
-    llvm.store %9, %12 : !llvm.ptr<f64>
-    %13 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
-    %14 = llvm.load %13 : !llvm.ptr<f64>
-    return %14 : f64
+    %3 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f32>, i32) -> !llvm.ptr<f32>
+    %4 = llvm.load %3 : !llvm.ptr<f32>
+    %5 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f32>, i32) -> !llvm.ptr<f32>
+    llvm.store %2, %5 : !llvm.ptr<f32>
+    %6 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f32>, i32) -> !llvm.ptr<f32>
+    %7 = llvm.load %6 : !llvm.ptr<f32>
+    return %7 : f32
   }
-  func @"$module-0__F64__*"(%arg0: f64, %arg1: f64) -> f64 {
+  llvm.mlir.global private constant @std.fptosi("std.fptosi")
+  func @"$module-0__F64__toInt"(%arg0: f64) -> i64 {
     %c1_i32 = constant 1 : i32
-    %0 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
-    %1 = llvm.mlir.addressof @std.mulf : !llvm.ptr<array<8 x i8>>
-    %2 = llvm.alloca %c1_i32 x !llvm.struct<(f64, f64)> : (i32) -> !llvm.ptr<struct<(f64, f64)>>
+    %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
+    %1 = llvm.mlir.addressof @std.fptosi : !llvm.ptr<array<10 x i8>>
+    %2 = fptosi %arg0 : f64 to i64
     %c0_i32 = constant 0 : i32
-    %3 = llvm.getelementptr %2[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(f64, f64)>>, i32, i32) -> !llvm.ptr<f64>
-    llvm.store %arg0, %3 : !llvm.ptr<f64>
-    %4 = llvm.getelementptr %2[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(f64, f64)>>, i32, i32) -> !llvm.ptr<f64>
-    llvm.store %arg1, %4 : !llvm.ptr<f64>
-    %5 = llvm.getelementptr %2[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(f64, f64)>>, i32, i32) -> !llvm.ptr<f64>
-    %6 = llvm.load %5 : !llvm.ptr<f64>
-    %7 = llvm.getelementptr %2[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(f64, f64)>>, i32, i32) -> !llvm.ptr<f64>
-    %8 = llvm.load %7 : !llvm.ptr<f64>
-    %9 = mulf %6, %8 : f64
-    %10 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
-    %11 = llvm.load %10 : !llvm.ptr<f64>
-    %12 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
-    llvm.store %9, %12 : !llvm.ptr<f64>
-    %13 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
-    %14 = llvm.load %13 : !llvm.ptr<f64>
-    return %14 : f64
+    %3 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %4 = llvm.load %3 : !llvm.ptr<i64>
+    %5 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    llvm.store %2, %5 : !llvm.ptr<i64>
+    %6 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %7 = llvm.load %6 : !llvm.ptr<i64>
+    return %7 : i64
   }
-  func @"$module-0__F64__/"(%arg0: f64, %arg1: f64) -> f64 {
+  llvm.mlir.global private constant @std.fptoui("std.fptoui")
+  func @"$module-0__F64__toUInt"(%arg0: f64) -> i64 {
+    %c1_i32 = constant 1 : i32
+    %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
+    %1 = llvm.mlir.addressof @std.fptoui : !llvm.ptr<array<10 x i8>>
+    %2 = fptoui %arg0 : f64 to i64
+    %c0_i32 = constant 0 : i32
+    %3 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %4 = llvm.load %3 : !llvm.ptr<i64>
+    %5 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    llvm.store %2, %5 : !llvm.ptr<i64>
+    %6 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %7 = llvm.load %6 : !llvm.ptr<i64>
+    return %7 : i64
+  }
+  llvm.mlir.global private constant @std.negf("std.negf")
+  func @"$module-0__F64__neg"(%arg0: f64) -> f64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
-    %1 = llvm.mlir.addressof @std.divf : !llvm.ptr<array<8 x i8>>
-    %2 = llvm.alloca %c1_i32 x !llvm.struct<(f64, f64)> : (i32) -> !llvm.ptr<struct<(f64, f64)>>
+    %1 = llvm.mlir.addressof @std.negf : !llvm.ptr<array<8 x i8>>
+    %2 = negf %arg0 : f64
     %c0_i32 = constant 0 : i32
-    %3 = llvm.getelementptr %2[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(f64, f64)>>, i32, i32) -> !llvm.ptr<f64>
-    llvm.store %arg0, %3 : !llvm.ptr<f64>
-    %4 = llvm.getelementptr %2[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(f64, f64)>>, i32, i32) -> !llvm.ptr<f64>
-    llvm.store %arg1, %4 : !llvm.ptr<f64>
-    %5 = llvm.getelementptr %2[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(f64, f64)>>, i32, i32) -> !llvm.ptr<f64>
-    %6 = llvm.load %5 : !llvm.ptr<f64>
-    %7 = llvm.getelementptr %2[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(f64, f64)>>, i32, i32) -> !llvm.ptr<f64>
-    %8 = llvm.load %7 : !llvm.ptr<f64>
-    %9 = divf %6, %8 : f64
-    %10 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
-    %11 = llvm.load %10 : !llvm.ptr<f64>
-    %12 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
-    llvm.store %9, %12 : !llvm.ptr<f64>
-    %13 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
-    %14 = llvm.load %13 : !llvm.ptr<f64>
-    return %14 : f64
+    %3 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    %4 = llvm.load %3 : !llvm.ptr<f64>
+    %5 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    llvm.store %2, %5 : !llvm.ptr<f64>
+    %6 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    %7 = llvm.load %6 : !llvm.ptr<f64>
+    return %7 : f64
   }
   func @"$module-0__simple_int"(%arg0: i32, %arg1: i32) -> i32 {
     %c1_i32 = constant 1 : i32
@@ -506,115 +606,237 @@ module  {
   func @"$module-0__int_upcast"(%arg0: i32, %arg1: i64) -> i64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
-    %1 = llvm.mlir.addressof @std.addi : !llvm.ptr<array<8 x i8>>
-    %2 = llvm.alloca %c1_i32 x !llvm.struct<(i32, i64)> : (i32) -> !llvm.ptr<struct<(i32, i64)>>
+    %1 = call @"$module-0__I32__ext"(%arg0) : (i32) -> i64
     %c0_i32 = constant 0 : i32
-    %3 = llvm.getelementptr %2[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(i32, i64)>>, i32, i32) -> !llvm.ptr<i32>
-    llvm.store %arg0, %3 : !llvm.ptr<i32>
-    %4 = llvm.getelementptr %2[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(i32, i64)>>, i32, i32) -> !llvm.ptr<i64>
-    llvm.store %arg1, %4 : !llvm.ptr<i64>
-    %5 = llvm.getelementptr %2[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(i32, i64)>>, i32, i32) -> !llvm.ptr<i32>
-    %6 = llvm.load %5 : !llvm.ptr<i32>
-    %7 = llvm.getelementptr %2[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(i32, i64)>>, i32, i32) -> !llvm.ptr<i64>
-    %8 = llvm.load %7 : !llvm.ptr<i64>
-    %9 = sexti %6 : i32 to i64
-    %10 = addi %9, %8 : i64
-    %11 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %2 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %3 = llvm.load %2 : !llvm.ptr<i64>
+    %4 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    llvm.store %1, %4 : !llvm.ptr<i64>
+    %5 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
+    %6 = llvm.alloca %c1_i32 x !llvm.struct<(i64, i64)> : (i32) -> !llvm.ptr<struct<(i64, i64)>>
+    %7 = llvm.getelementptr %6[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(i64, i64)>>, i32, i32) -> !llvm.ptr<i64>
+    %8 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %9 = llvm.load %8 : !llvm.ptr<i64>
+    llvm.store %9, %7 : !llvm.ptr<i64>
+    %10 = llvm.getelementptr %6[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(i64, i64)>>, i32, i32) -> !llvm.ptr<i64>
+    llvm.store %arg1, %10 : !llvm.ptr<i64>
+    %11 = llvm.getelementptr %6[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(i64, i64)>>, i32, i32) -> !llvm.ptr<i64>
     %12 = llvm.load %11 : !llvm.ptr<i64>
-    %13 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
-    llvm.store %10, %13 : !llvm.ptr<i64>
-    %14 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
-    %15 = llvm.load %14 : !llvm.ptr<i64>
-    return %15 : i64
+    %13 = llvm.getelementptr %6[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(i64, i64)>>, i32, i32) -> !llvm.ptr<i64>
+    %14 = llvm.load %13 : !llvm.ptr<i64>
+    %15 = call @"$module-0__I64__+"(%12, %14) : (i64, i64) -> i64
+    %16 = llvm.getelementptr %5[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %17 = llvm.load %16 : !llvm.ptr<i64>
+    %18 = llvm.getelementptr %5[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    llvm.store %15, %18 : !llvm.ptr<i64>
+    %19 = llvm.getelementptr %5[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %20 = llvm.load %19 : !llvm.ptr<i64>
+    return %20 : i64
   }
   func @"$module-0__fp_upcast"(%arg0: f64, %arg1: f32) -> f64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
-    %1 = llvm.mlir.addressof @std.addf : !llvm.ptr<array<8 x i8>>
-    %2 = llvm.alloca %c1_i32 x !llvm.struct<(f64, f32)> : (i32) -> !llvm.ptr<struct<(f64, f32)>>
+    %1 = call @"$module-0__F32__ext"(%arg1) : (f32) -> f64
     %c0_i32 = constant 0 : i32
-    %3 = llvm.getelementptr %2[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(f64, f32)>>, i32, i32) -> !llvm.ptr<f64>
-    llvm.store %arg0, %3 : !llvm.ptr<f64>
-    %4 = llvm.getelementptr %2[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(f64, f32)>>, i32, i32) -> !llvm.ptr<f32>
-    llvm.store %arg1, %4 : !llvm.ptr<f32>
-    %5 = llvm.getelementptr %2[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(f64, f32)>>, i32, i32) -> !llvm.ptr<f64>
-    %6 = llvm.load %5 : !llvm.ptr<f64>
-    %7 = llvm.getelementptr %2[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(f64, f32)>>, i32, i32) -> !llvm.ptr<f32>
-    %8 = llvm.load %7 : !llvm.ptr<f32>
-    %9 = fpext %8 : f32 to f64
-    %10 = addf %6, %9 : f64
-    %11 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    %2 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    %3 = llvm.load %2 : !llvm.ptr<f64>
+    %4 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    llvm.store %1, %4 : !llvm.ptr<f64>
+    %5 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
+    %6 = llvm.alloca %c1_i32 x !llvm.struct<(f64, f64)> : (i32) -> !llvm.ptr<struct<(f64, f64)>>
+    %7 = llvm.getelementptr %6[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(f64, f64)>>, i32, i32) -> !llvm.ptr<f64>
+    llvm.store %arg0, %7 : !llvm.ptr<f64>
+    %8 = llvm.getelementptr %6[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(f64, f64)>>, i32, i32) -> !llvm.ptr<f64>
+    %9 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    %10 = llvm.load %9 : !llvm.ptr<f64>
+    llvm.store %10, %8 : !llvm.ptr<f64>
+    %11 = llvm.getelementptr %6[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(f64, f64)>>, i32, i32) -> !llvm.ptr<f64>
     %12 = llvm.load %11 : !llvm.ptr<f64>
-    %13 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
-    llvm.store %10, %13 : !llvm.ptr<f64>
-    %14 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
-    %15 = llvm.load %14 : !llvm.ptr<f64>
-    return %15 : f64
+    %13 = llvm.getelementptr %6[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(f64, f64)>>, i32, i32) -> !llvm.ptr<f64>
+    %14 = llvm.load %13 : !llvm.ptr<f64>
+    %15 = call @"$module-0__F64__+"(%12, %14) : (f64, f64) -> f64
+    %16 = llvm.getelementptr %5[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    %17 = llvm.load %16 : !llvm.ptr<f64>
+    %18 = llvm.getelementptr %5[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    llvm.store %15, %18 : !llvm.ptr<f64>
+    %19 = llvm.getelementptr %5[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    %20 = llvm.load %19 : !llvm.ptr<f64>
+    return %20 : f64
+  }
+  func @"$module-0__simple_unsigned"(%arg0: i32, %arg1: i32) {
+    %c1_i32 = constant 1 : i32
+    %0 = llvm.alloca %c1_i32 x i32 : (i32) -> !llvm.ptr<i32>
+    %1 = llvm.alloca %c1_i32 x !llvm.struct<(i32, i32)> : (i32) -> !llvm.ptr<struct<(i32, i32)>>
+    %c0_i32 = constant 0 : i32
+    %2 = llvm.getelementptr %1[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(i32, i32)>>, i32, i32) -> !llvm.ptr<i32>
+    llvm.store %arg0, %2 : !llvm.ptr<i32>
+    %3 = llvm.getelementptr %1[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(i32, i32)>>, i32, i32) -> !llvm.ptr<i32>
+    llvm.store %arg1, %3 : !llvm.ptr<i32>
+    %4 = llvm.getelementptr %1[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(i32, i32)>>, i32, i32) -> !llvm.ptr<i32>
+    %5 = llvm.load %4 : !llvm.ptr<i32>
+    %6 = llvm.getelementptr %1[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(i32, i32)>>, i32, i32) -> !llvm.ptr<i32>
+    %7 = llvm.load %6 : !llvm.ptr<i32>
+    %8 = call @"$module-0__U32__+"(%5, %7) : (i32, i32) -> i32
+    %9 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
+    %10 = llvm.load %9 : !llvm.ptr<i32>
+    %11 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
+    llvm.store %8, %11 : !llvm.ptr<i32>
+    return
+  }
+  func @"$module-0__unsigned_upcast"(%arg0: i32, %arg1: i64) -> i64 {
+    %c1_i32 = constant 1 : i32
+    %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
+    %1 = call @"$module-0__U32__ext"(%arg0) : (i32) -> i64
+    %c0_i32 = constant 0 : i32
+    %2 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %3 = llvm.load %2 : !llvm.ptr<i64>
+    %4 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    llvm.store %1, %4 : !llvm.ptr<i64>
+    %5 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
+    %6 = llvm.alloca %c1_i32 x !llvm.struct<(i64, i64)> : (i32) -> !llvm.ptr<struct<(i64, i64)>>
+    %7 = llvm.getelementptr %6[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(i64, i64)>>, i32, i32) -> !llvm.ptr<i64>
+    %8 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %9 = llvm.load %8 : !llvm.ptr<i64>
+    llvm.store %9, %7 : !llvm.ptr<i64>
+    %10 = llvm.getelementptr %6[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(i64, i64)>>, i32, i32) -> !llvm.ptr<i64>
+    llvm.store %arg1, %10 : !llvm.ptr<i64>
+    %11 = llvm.getelementptr %6[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(i64, i64)>>, i32, i32) -> !llvm.ptr<i64>
+    %12 = llvm.load %11 : !llvm.ptr<i64>
+    %13 = llvm.getelementptr %6[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(i64, i64)>>, i32, i32) -> !llvm.ptr<i64>
+    %14 = llvm.load %13 : !llvm.ptr<i64>
+    %15 = call @"$module-0__U64__+"(%12, %14) : (i64, i64) -> i64
+    %16 = llvm.getelementptr %5[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %17 = llvm.load %16 : !llvm.ptr<i64>
+    %18 = llvm.getelementptr %5[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    llvm.store %15, %18 : !llvm.ptr<i64>
+    %19 = llvm.getelementptr %5[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %20 = llvm.load %19 : !llvm.ptr<i64>
+    return %20 : i64
   }
   func @"$module-0__literals"() -> f64 {
     %c1_i32 = constant 1 : i32
-    %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
+    %0 = llvm.alloca %c1_i32 x i32 : (i32) -> !llvm.ptr<i32>
     %c21_i64 = constant 21 : i64
+    %1 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
     %c0_i32 = constant 0 : i32
-    %1 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
-    %2 = llvm.load %1 : !llvm.ptr<i64>
-    %3 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
-    llvm.store %c21_i64, %3 : !llvm.ptr<i64>
-    %4 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
+    %2 = llvm.getelementptr %1[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    llvm.store %c21_i64, %2 : !llvm.ptr<i64>
+    %3 = llvm.getelementptr %1[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %4 = llvm.load %3 : !llvm.ptr<i64>
+    %5 = call @"$module-0__I64__trunc"(%4) : (i64) -> i32
+    %6 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
+    %7 = llvm.load %6 : !llvm.ptr<i32>
+    %8 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
+    llvm.store %5, %8 : !llvm.ptr<i32>
+    %9 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
+    %10 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
+    %11 = llvm.load %10 : !llvm.ptr<i32>
+    %12 = call @"$module-0__I32__ext"(%11) : (i32) -> i64
+    %13 = llvm.getelementptr %9[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %14 = llvm.load %13 : !llvm.ptr<i64>
+    %15 = llvm.getelementptr %9[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    llvm.store %12, %15 : !llvm.ptr<i64>
     %c21_i64_0 = constant 21 : i64
-    %5 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
-    %6 = llvm.getelementptr %5[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
-    llvm.store %c21_i64_0, %6 : !llvm.ptr<i64>
-    %7 = llvm.alloca %c1_i32 x !llvm.struct<(i64, i64)> : (i32) -> !llvm.ptr<struct<(i64, i64)>>
-    %8 = llvm.getelementptr %7[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(i64, i64)>>, i32, i32) -> !llvm.ptr<i64>
-    %9 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
-    %10 = llvm.load %9 : !llvm.ptr<i64>
-    llvm.store %10, %8 : !llvm.ptr<i64>
-    %11 = llvm.getelementptr %7[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(i64, i64)>>, i32, i32) -> !llvm.ptr<i64>
-    %12 = llvm.getelementptr %5[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
-    %13 = llvm.load %12 : !llvm.ptr<i64>
-    llvm.store %13, %11 : !llvm.ptr<i64>
-    %14 = llvm.getelementptr %7[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(i64, i64)>>, i32, i32) -> !llvm.ptr<i64>
-    %15 = llvm.load %14 : !llvm.ptr<i64>
-    %16 = llvm.getelementptr %7[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(i64, i64)>>, i32, i32) -> !llvm.ptr<i64>
-    %17 = llvm.load %16 : !llvm.ptr<i64>
-    %18 = call @"$module-0__I64__+"(%15, %17) : (i64, i64) -> i64
-    %19 = llvm.getelementptr %4[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
-    %20 = llvm.load %19 : !llvm.ptr<i64>
-    %21 = llvm.getelementptr %4[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
-    llvm.store %18, %21 : !llvm.ptr<i64>
-    %22 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
+    %16 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
+    %17 = llvm.getelementptr %16[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    llvm.store %c21_i64_0, %17 : !llvm.ptr<i64>
+    %18 = llvm.alloca %c1_i32 x !llvm.struct<(i64, i64)> : (i32) -> !llvm.ptr<struct<(i64, i64)>>
+    %19 = llvm.getelementptr %18[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(i64, i64)>>, i32, i32) -> !llvm.ptr<i64>
+    %20 = llvm.getelementptr %9[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %21 = llvm.load %20 : !llvm.ptr<i64>
+    llvm.store %21, %19 : !llvm.ptr<i64>
+    %22 = llvm.getelementptr %18[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(i64, i64)>>, i32, i32) -> !llvm.ptr<i64>
+    %23 = llvm.getelementptr %16[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %24 = llvm.load %23 : !llvm.ptr<i64>
+    llvm.store %24, %22 : !llvm.ptr<i64>
+    %25 = llvm.getelementptr %18[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(i64, i64)>>, i32, i32) -> !llvm.ptr<i64>
+    %26 = llvm.load %25 : !llvm.ptr<i64>
+    %27 = llvm.getelementptr %18[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(i64, i64)>>, i32, i32) -> !llvm.ptr<i64>
+    %28 = llvm.load %27 : !llvm.ptr<i64>
+    %29 = call @"$module-0__I64__+"(%26, %28) : (i64, i64) -> i64
+    %30 = llvm.getelementptr %9[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %31 = llvm.load %30 : !llvm.ptr<i64>
+    %32 = llvm.getelementptr %9[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    llvm.store %29, %32 : !llvm.ptr<i64>
+    %33 = llvm.alloca %c1_i32 x f32 : (i32) -> !llvm.ptr<f32>
     %cst = constant 3.140000e+00 : f64
-    %23 = llvm.getelementptr %22[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
-    %24 = llvm.load %23 : !llvm.ptr<f64>
-    %25 = llvm.getelementptr %22[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
-    llvm.store %cst, %25 : !llvm.ptr<f64>
-    %26 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
-    %cst_1 = constant 1.500000e-03 : f64
-    %27 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
-    %28 = llvm.getelementptr %27[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
-    llvm.store %cst_1, %28 : !llvm.ptr<f64>
-    %29 = llvm.alloca %c1_i32 x !llvm.struct<(f64, f64)> : (i32) -> !llvm.ptr<struct<(f64, f64)>>
-    %30 = llvm.getelementptr %29[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(f64, f64)>>, i32, i32) -> !llvm.ptr<f64>
-    %31 = llvm.getelementptr %22[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
-    %32 = llvm.load %31 : !llvm.ptr<f64>
-    llvm.store %32, %30 : !llvm.ptr<f64>
-    %33 = llvm.getelementptr %29[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(f64, f64)>>, i32, i32) -> !llvm.ptr<f64>
-    %34 = llvm.getelementptr %27[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
-    %35 = llvm.load %34 : !llvm.ptr<f64>
-    llvm.store %35, %33 : !llvm.ptr<f64>
-    %36 = llvm.getelementptr %29[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(f64, f64)>>, i32, i32) -> !llvm.ptr<f64>
+    %34 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
+    %35 = llvm.getelementptr %34[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    llvm.store %cst, %35 : !llvm.ptr<f64>
+    %36 = llvm.getelementptr %34[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
     %37 = llvm.load %36 : !llvm.ptr<f64>
-    %38 = llvm.getelementptr %29[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(f64, f64)>>, i32, i32) -> !llvm.ptr<f64>
-    %39 = llvm.load %38 : !llvm.ptr<f64>
-    %40 = call @"$module-0__F64__+"(%37, %39) : (f64, f64) -> f64
-    %41 = llvm.getelementptr %26[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
-    %42 = llvm.load %41 : !llvm.ptr<f64>
-    %43 = llvm.getelementptr %26[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
-    llvm.store %40, %43 : !llvm.ptr<f64>
-    %44 = llvm.getelementptr %26[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
-    %45 = llvm.load %44 : !llvm.ptr<f64>
-    return %45 : f64
+    %38 = call @"$module-0__F64__trunc"(%37) : (f64) -> f32
+    %39 = llvm.getelementptr %33[%c0_i32] : (!llvm.ptr<f32>, i32) -> !llvm.ptr<f32>
+    %40 = llvm.load %39 : !llvm.ptr<f32>
+    %41 = llvm.getelementptr %33[%c0_i32] : (!llvm.ptr<f32>, i32) -> !llvm.ptr<f32>
+    llvm.store %38, %41 : !llvm.ptr<f32>
+    %42 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
+    %43 = llvm.getelementptr %33[%c0_i32] : (!llvm.ptr<f32>, i32) -> !llvm.ptr<f32>
+    %44 = llvm.load %43 : !llvm.ptr<f32>
+    %45 = call @"$module-0__F32__ext"(%44) : (f32) -> f64
+    %46 = llvm.getelementptr %42[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    %47 = llvm.load %46 : !llvm.ptr<f64>
+    %48 = llvm.getelementptr %42[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    llvm.store %45, %48 : !llvm.ptr<f64>
+    %cst_1 = constant 1.500000e-03 : f64
+    %49 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
+    %50 = llvm.getelementptr %49[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    llvm.store %cst_1, %50 : !llvm.ptr<f64>
+    %51 = llvm.alloca %c1_i32 x !llvm.struct<(f64, f64)> : (i32) -> !llvm.ptr<struct<(f64, f64)>>
+    %52 = llvm.getelementptr %51[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(f64, f64)>>, i32, i32) -> !llvm.ptr<f64>
+    %53 = llvm.getelementptr %42[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    %54 = llvm.load %53 : !llvm.ptr<f64>
+    llvm.store %54, %52 : !llvm.ptr<f64>
+    %55 = llvm.getelementptr %51[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(f64, f64)>>, i32, i32) -> !llvm.ptr<f64>
+    %56 = llvm.getelementptr %49[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    %57 = llvm.load %56 : !llvm.ptr<f64>
+    llvm.store %57, %55 : !llvm.ptr<f64>
+    %58 = llvm.getelementptr %51[%c0_i32, %c0_i32] : (!llvm.ptr<struct<(f64, f64)>>, i32, i32) -> !llvm.ptr<f64>
+    %59 = llvm.load %58 : !llvm.ptr<f64>
+    %60 = llvm.getelementptr %51[%c0_i32, %c1_i32] : (!llvm.ptr<struct<(f64, f64)>>, i32, i32) -> !llvm.ptr<f64>
+    %61 = llvm.load %60 : !llvm.ptr<f64>
+    %62 = call @"$module-0__F64__+"(%59, %61) : (f64, f64) -> f64
+    %63 = llvm.getelementptr %42[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    %64 = llvm.load %63 : !llvm.ptr<f64>
+    %65 = llvm.getelementptr %42[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    llvm.store %62, %65 : !llvm.ptr<f64>
+    %66 = llvm.getelementptr %42[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    %67 = llvm.load %66 : !llvm.ptr<f64>
+    return %67 : f64
+  }
+  func @"$module-0__conversions"() -> i64 {
+    %c1_i32 = constant 1 : i32
+    %0 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
+    %c42_i64 = constant 42 : i64
+    %1 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
+    %c0_i32 = constant 0 : i32
+    %2 = llvm.getelementptr %1[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    llvm.store %c42_i64, %2 : !llvm.ptr<i64>
+    %3 = llvm.getelementptr %1[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %4 = llvm.load %3 : !llvm.ptr<i64>
+    %5 = call @"$module-0__I64__toDouble"(%4) : (i64) -> f64
+    %6 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    %7 = llvm.load %6 : !llvm.ptr<f64>
+    %8 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    llvm.store %5, %8 : !llvm.ptr<f64>
+    %9 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    %10 = llvm.load %9 : !llvm.ptr<f64>
+    %11 = call @"$module-0__F64__neg"(%10) : (f64) -> f64
+    %12 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    %13 = llvm.load %12 : !llvm.ptr<f64>
+    %14 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    llvm.store %11, %14 : !llvm.ptr<f64>
+    %15 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
+    %16 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    %17 = llvm.load %16 : !llvm.ptr<f64>
+    %18 = call @"$module-0__F64__toInt"(%17) : (f64) -> i64
+    %19 = llvm.getelementptr %15[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %20 = llvm.load %19 : !llvm.ptr<i64>
+    %21 = llvm.getelementptr %15[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    llvm.store %18, %21 : !llvm.ptr<i64>
+    %22 = llvm.getelementptr %15[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %23 = llvm.load %22 : !llvm.ptr<i64>
+    return %23 : i64
   }
   func @"$module-0__update_value"() -> i64 {
     %c1_i32 = constant 1 : i32

--- a/testsuite/verona-mlir/arithmetic.verona
+++ b/testsuite/verona-mlir/arithmetic.verona
@@ -23,6 +23,24 @@ class I32
     let res : I32 = "std.divi_signed"(lhs, rhs);
     return res;
   }
+  ext(arg: I32) : I64
+  {
+    let res : I64 = "std.sexti"(arg);
+    return res;
+  }
+}
+class U32
+{
+  +(lhs: U32, rhs: U32) : U32
+  {
+    let res : U32 = "std.addi"(lhs, rhs);
+    return res;
+  }
+  ext(arg: U32) : U64
+  {
+    let res : U64 = "std.zexti"(arg);
+    return res;
+  }
 }
 class I64
 {
@@ -31,19 +49,42 @@ class I64
     let res : I64 = "std.addi"(lhs, rhs);
     return res;
   }
-  -(lhs: I64, rhs: I64) : I64
+  trunc(arg: I64) : I32
   {
-    let res : I64 = "std.subi"(lhs, rhs);
+    let res : I32 = "std.trunci"(arg);
     return res;
   }
-  *(lhs: I64, rhs: I64) : I64
+  toFloat(arg: U64) : F32
   {
-    let res : I64 = "std.muli"(lhs, rhs);
+    let res : F32 = "std.sitofp"(arg);
     return res;
   }
-  /(lhs: I64, rhs: I64) : I64
+  toDouble(arg: U64) : F64
   {
-    let res : I64 = "std.divi_signed"(lhs, rhs);
+    let res : F64 = "std.sitofp"(arg);
+    return res;
+  }
+}
+class U64
+{
+  +(lhs: U64, rhs: U64) : U64
+  {
+    let res : U64 = "std.addi"(lhs, rhs);
+    return res;
+  }
+  trunc(arg: U64) : U32
+  {
+    let res : U32 = "std.trunci"(arg);
+    return res;
+  }
+  toFloat(arg: U64) : F32
+  {
+    let res : F32 = "std.uitofp"(arg);
+    return res;
+  }
+  toDouble(arg: U64) : F64
+  {
+    let res : F64 = "std.uitofp"(arg);
     return res;
   }
 }
@@ -69,6 +110,11 @@ class F32
     let res : F32 = "std.divf"(lhs, rhs);
     return res;
   }
+  ext(arg: F32) : F64
+  {
+    let res : F64 = "std.fpext"(arg);
+    return res;
+  }
 }
 class F64
 {
@@ -77,19 +123,24 @@ class F64
     let res : F64 = "std.addf"(lhs, rhs);
     return res;
   }
-  -(lhs: F64, rhs: F64) : F64
+  trunc(arg: F64) : F32
   {
-    let res : F64 = "std.subf"(lhs, rhs);
+    let res : F32 = "std.fptrunc"(arg);
     return res;
   }
-  *(lhs: F64, rhs: F64) : F64
+  toInt(arg: F64) : I64
   {
-    let res : F64 = "std.mulf"(lhs, rhs);
+    let res : I64 = "std.fptosi"(arg);
     return res;
   }
-  /(lhs: F64, rhs: F64) : F64
+  toUInt(arg: F64) : U64
   {
-    let res : F64 = "std.divf"(lhs, rhs);
+    let res : U64 = "std.fptoui"(arg);
+    return res;
+  }
+  neg(arg: F64) : F64
+  {
+    let res : F64 = "std.negf"(arg);
     return res;
   }
 }
@@ -116,25 +167,56 @@ simple_fp(a: F32, b: F32): F32
 
 int_upcast(a: I32, b: I64): I64
 {
-  // a will be automatically promoted to I64
-  let x : I64 = "std.addi"(a, b);
+  // This is what a + b will be lowered to
+  let a64 : I64 = I32::ext(a);
+  let x : I64 = I64::+(a64, b);
   return x;
 }
 
 fp_upcast(a: F64, b: F32): F64
 {
-  // b will be automatically promoted to F64
-  let x : F64 = "std.addf"(a, b);
+  // This is what a + b will be lowered to
+  let b64 : F64 = F32::ext(b);
+  let x : F64 = F64::+(a, b64);
+  return x;
+}
+
+simple_unsigned(a: U32, b: U32)
+{
+  // This is what a + b will be lowered to
+  var x : U32 = U32::+(a, b);
+  return x;
+}
+
+unsigned_upcast(a: U32, b: U64): U64
+{
+  // This is what a + b will be lowered to
+  let a64 : U64 = U32::ext(a);
+  var x : U64 = U64::+(a64, b);
   return x;
 }
 
 literals(): F64
 {
-  let x : I64 = 21;
-  let y : I64 = I64::+(x, 21);
-  let f : F64 = 3.14;
-  let d : F64 = F64::+(f, 0.0015);
-  return d;
+  // This is x:I32 = 21; x + 21;
+  let x32 : I32 = I64::trunc(21);
+  var x : I64 = I32::ext(x32);
+  x = I64::+(x, 21);
+
+  // This is y:F32 = 3.14; y + 0.0015;
+  let y32 : F32 = F64::trunc(3.14);
+  var y : F64 = F32::ext(y32);
+  y = F64::+(y, 0.0015);
+
+  return y;
+}
+
+conversions(): I64
+{
+  var x : F64 = I64::toDouble(42);
+  x = F64::neg(x);
+  var y : I64 = F64::toInt(x);
+  return y;
 }
 
 update_value(): I64

--- a/testsuite/verona-mlir/struct.out/stdout.txt
+++ b/testsuite/verona-mlir/struct.out/stdout.txt
@@ -1,4 +1,19 @@
 module  {
+  llvm.mlir.global private constant @std.trunci("std.trunci")
+  func @"$module-0__I64__trunc"(%arg0: i64) -> i32 {
+    %c1_i32 = constant 1 : i32
+    %0 = llvm.alloca %c1_i32 x i32 : (i32) -> !llvm.ptr<i32>
+    %1 = llvm.mlir.addressof @std.trunci : !llvm.ptr<array<10 x i8>>
+    %2 = trunci %arg0 : i64 to i32
+    %c0_i32 = constant 0 : i32
+    %3 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
+    %4 = llvm.load %3 : !llvm.ptr<i32>
+    %5 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
+    llvm.store %2, %5 : !llvm.ptr<i32>
+    %6 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
+    %7 = llvm.load %6 : !llvm.ptr<i32>
+    return %7 : i32
+  }
   func @"$module-0__Boop__getPI"() -> f64 {
     %cst = constant 3.141500e+00 : f64
     %c1_i32 = constant 1 : i32
@@ -30,37 +45,42 @@ module  {
     llvm.store %11, %9 : !llvm.ptr<f64>
     %13 = llvm.getelementptr %0[%c0_i32, %c0_i32] : (!llvm.ptr<struct<"Foo", (i32, i64)>>, i32, i32) -> !llvm.ptr<i32>
     %c12_i64 = constant 12 : i64
-    %14 = trunci %c12_i64 : i64 to i32
-    %15 = llvm.load %13 : !llvm.ptr<i32>
-    llvm.store %14, %13 : !llvm.ptr<i32>
-    %16 = llvm.getelementptr %1[%c0_i32, %c0_i32] : (!llvm.ptr<struct<"Bar", (i32, i64)>>, i32, i32) -> !llvm.ptr<i32>
-    %17 = llvm.getelementptr %0[%c0_i32, %c0_i32] : (!llvm.ptr<struct<"Foo", (i32, i64)>>, i32, i32) -> !llvm.ptr<i32>
-    %18 = llvm.load %17 : !llvm.ptr<i32>
-    %19 = llvm.load %16 : !llvm.ptr<i32>
-    llvm.store %18, %16 : !llvm.ptr<i32>
-    %20 = llvm.getelementptr %1[%c0_i32, %c1_i32] : (!llvm.ptr<struct<"Bar", (i32, i64)>>, i32, i32) -> !llvm.ptr<i64>
+    %14 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
+    %15 = llvm.getelementptr %14[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    llvm.store %c12_i64, %15 : !llvm.ptr<i64>
+    %16 = llvm.getelementptr %14[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %17 = llvm.load %16 : !llvm.ptr<i64>
+    %18 = call @"$module-0__I64__trunc"(%17) : (i64) -> i32
+    %19 = llvm.load %13 : !llvm.ptr<i32>
+    llvm.store %18, %13 : !llvm.ptr<i32>
+    %20 = llvm.getelementptr %1[%c0_i32, %c0_i32] : (!llvm.ptr<struct<"Bar", (i32, i64)>>, i32, i32) -> !llvm.ptr<i32>
+    %21 = llvm.getelementptr %0[%c0_i32, %c0_i32] : (!llvm.ptr<struct<"Foo", (i32, i64)>>, i32, i32) -> !llvm.ptr<i32>
+    %22 = llvm.load %21 : !llvm.ptr<i32>
+    %23 = llvm.load %20 : !llvm.ptr<i32>
+    llvm.store %22, %20 : !llvm.ptr<i32>
+    %24 = llvm.getelementptr %1[%c0_i32, %c1_i32] : (!llvm.ptr<struct<"Bar", (i32, i64)>>, i32, i32) -> !llvm.ptr<i64>
     %c12_i64_0 = constant 12 : i64
-    %21 = llvm.load %20 : !llvm.ptr<i64>
-    llvm.store %c12_i64_0, %20 : !llvm.ptr<i64>
-    %22 = llvm.alloca %c1_i32 x !llvm.struct<"Two", (struct<"One", (struct<"Foo", (i32, i64)>)>)> : (i32) -> !llvm.ptr<struct<"Two", (struct<"One", (struct<"Foo", (i32, i64)>)>)>>
-    %23 = llvm.alloca %c1_i32 x i32 : (i32) -> !llvm.ptr<i32>
-    %24 = llvm.getelementptr %22[%c0_i32, %c0_i32] : (!llvm.ptr<struct<"Two", (struct<"One", (struct<"Foo", (i32, i64)>)>)>>, i32, i32) -> !llvm.ptr<struct<"One", (struct<"Foo", (i32, i64)>)>>
-    %25 = llvm.getelementptr %24[%c0_i32, %c0_i32] : (!llvm.ptr<struct<"One", (struct<"Foo", (i32, i64)>)>>, i32, i32) -> !llvm.ptr<struct<"Foo", (i32, i64)>>
-    %26 = llvm.getelementptr %25[%c0_i32, %c0_i32] : (!llvm.ptr<struct<"Foo", (i32, i64)>>, i32, i32) -> !llvm.ptr<i32>
-    %27 = llvm.load %26 : !llvm.ptr<i32>
-    %28 = llvm.getelementptr %23[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
-    %29 = llvm.load %28 : !llvm.ptr<i32>
-    %30 = llvm.getelementptr %23[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
-    llvm.store %27, %30 : !llvm.ptr<i32>
-    %31 = llvm.getelementptr %22[%c0_i32, %c0_i32] : (!llvm.ptr<struct<"Two", (struct<"One", (struct<"Foo", (i32, i64)>)>)>>, i32, i32) -> !llvm.ptr<struct<"One", (struct<"Foo", (i32, i64)>)>>
-    %32 = llvm.getelementptr %31[%c0_i32, %c0_i32] : (!llvm.ptr<struct<"One", (struct<"Foo", (i32, i64)>)>>, i32, i32) -> !llvm.ptr<struct<"Foo", (i32, i64)>>
-    %33 = llvm.getelementptr %32[%c0_i32, %c1_i32] : (!llvm.ptr<struct<"Foo", (i32, i64)>>, i32, i32) -> !llvm.ptr<i64>
+    %25 = llvm.load %24 : !llvm.ptr<i64>
+    llvm.store %c12_i64_0, %24 : !llvm.ptr<i64>
+    %26 = llvm.alloca %c1_i32 x !llvm.struct<"Two", (struct<"One", (struct<"Foo", (i32, i64)>)>)> : (i32) -> !llvm.ptr<struct<"Two", (struct<"One", (struct<"Foo", (i32, i64)>)>)>>
+    %27 = llvm.alloca %c1_i32 x i32 : (i32) -> !llvm.ptr<i32>
+    %28 = llvm.getelementptr %26[%c0_i32, %c0_i32] : (!llvm.ptr<struct<"Two", (struct<"One", (struct<"Foo", (i32, i64)>)>)>>, i32, i32) -> !llvm.ptr<struct<"One", (struct<"Foo", (i32, i64)>)>>
+    %29 = llvm.getelementptr %28[%c0_i32, %c0_i32] : (!llvm.ptr<struct<"One", (struct<"Foo", (i32, i64)>)>>, i32, i32) -> !llvm.ptr<struct<"Foo", (i32, i64)>>
+    %30 = llvm.getelementptr %29[%c0_i32, %c0_i32] : (!llvm.ptr<struct<"Foo", (i32, i64)>>, i32, i32) -> !llvm.ptr<i32>
+    %31 = llvm.load %30 : !llvm.ptr<i32>
+    %32 = llvm.getelementptr %27[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
+    %33 = llvm.load %32 : !llvm.ptr<i32>
+    %34 = llvm.getelementptr %27[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
+    llvm.store %31, %34 : !llvm.ptr<i32>
+    %35 = llvm.getelementptr %26[%c0_i32, %c0_i32] : (!llvm.ptr<struct<"Two", (struct<"One", (struct<"Foo", (i32, i64)>)>)>>, i32, i32) -> !llvm.ptr<struct<"One", (struct<"Foo", (i32, i64)>)>>
+    %36 = llvm.getelementptr %35[%c0_i32, %c0_i32] : (!llvm.ptr<struct<"One", (struct<"Foo", (i32, i64)>)>>, i32, i32) -> !llvm.ptr<struct<"Foo", (i32, i64)>>
+    %37 = llvm.getelementptr %36[%c0_i32, %c1_i32] : (!llvm.ptr<struct<"Foo", (i32, i64)>>, i32, i32) -> !llvm.ptr<i64>
     %c42_i64 = constant 42 : i64
-    %34 = llvm.load %33 : !llvm.ptr<i64>
-    llvm.store %c42_i64, %33 : !llvm.ptr<i64>
-    %35 = llvm.getelementptr %1[%c0_i32, %c0_i32] : (!llvm.ptr<struct<"Bar", (i32, i64)>>, i32, i32) -> !llvm.ptr<i32>
-    %36 = llvm.load %35 : !llvm.ptr<i32>
-    return %36 : i32
+    %38 = llvm.load %37 : !llvm.ptr<i64>
+    llvm.store %c42_i64, %37 : !llvm.ptr<i64>
+    %39 = llvm.getelementptr %1[%c0_i32, %c0_i32] : (!llvm.ptr<struct<"Bar", (i32, i64)>>, i32, i32) -> !llvm.ptr<i32>
+    %40 = llvm.load %39 : !llvm.ptr<i32>
+    return %40 : i32
   }
   func @"$module-0__bar"() -> f64 {
     %c1_i32 = constant 1 : i32

--- a/testsuite/verona-mlir/struct.verona
+++ b/testsuite/verona-mlir/struct.verona
@@ -2,7 +2,14 @@
 // SPDX-License-Identifier: MIT
 
 class I32 {}
-class I64 {}
+class I64
+{
+  trunc(arg: I64) : I32
+  {
+    let res : I32 = "std.trunci"(arg);
+    return res;
+  }
+}
 class F32 {}
 class F64 {}
 
@@ -50,7 +57,7 @@ foo() : I32
   boop.d = PI;
 
   // Test reading / writing to fields
-  foo.a = 12;
+  foo.a = I64::trunc(12);
   bar.a = foo.a;
   bar.b = 12;
 

--- a/testsuite/verona-mlir/using.out/stdout.txt
+++ b/testsuite/verona-mlir/using.out/stdout.txt
@@ -1,54 +1,152 @@
 module  {
+  llvm.mlir.global private constant @std.trunci("std.trunci")
+  func @"$module-0__trunc_64_8"(%arg0: i64) -> i8 {
+    %c1_i32 = constant 1 : i32
+    %0 = llvm.alloca %c1_i32 x i8 : (i32) -> !llvm.ptr<i8>
+    %1 = llvm.mlir.addressof @std.trunci : !llvm.ptr<array<10 x i8>>
+    %2 = trunci %arg0 : i64 to i8
+    %c0_i32 = constant 0 : i32
+    %3 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i8>, i32) -> !llvm.ptr<i8>
+    %4 = llvm.load %3 : !llvm.ptr<i8>
+    %5 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i8>, i32) -> !llvm.ptr<i8>
+    llvm.store %2, %5 : !llvm.ptr<i8>
+    %6 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i8>, i32) -> !llvm.ptr<i8>
+    %7 = llvm.load %6 : !llvm.ptr<i8>
+    return %7 : i8
+  }
+  func @"$module-0__trunc_64_16"(%arg0: i64) -> i16 {
+    %c1_i32 = constant 1 : i32
+    %0 = llvm.alloca %c1_i32 x i16 : (i32) -> !llvm.ptr<i16>
+    %1 = llvm.mlir.addressof @std.trunci : !llvm.ptr<array<10 x i8>>
+    %2 = trunci %arg0 : i64 to i16
+    %c0_i32 = constant 0 : i32
+    %3 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i16>, i32) -> !llvm.ptr<i16>
+    %4 = llvm.load %3 : !llvm.ptr<i16>
+    %5 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i16>, i32) -> !llvm.ptr<i16>
+    llvm.store %2, %5 : !llvm.ptr<i16>
+    %6 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i16>, i32) -> !llvm.ptr<i16>
+    %7 = llvm.load %6 : !llvm.ptr<i16>
+    return %7 : i16
+  }
+  func @"$module-0__trunc_64_32"(%arg0: i64) -> i32 {
+    %c1_i32 = constant 1 : i32
+    %0 = llvm.alloca %c1_i32 x i32 : (i32) -> !llvm.ptr<i32>
+    %1 = llvm.mlir.addressof @std.trunci : !llvm.ptr<array<10 x i8>>
+    %2 = trunci %arg0 : i64 to i32
+    %c0_i32 = constant 0 : i32
+    %3 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
+    %4 = llvm.load %3 : !llvm.ptr<i32>
+    %5 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
+    llvm.store %2, %5 : !llvm.ptr<i32>
+    %6 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
+    %7 = llvm.load %6 : !llvm.ptr<i32>
+    return %7 : i32
+  }
+  llvm.mlir.global private constant @std.sexti("std.sexti")
+  func @"$module-0__ext_64_128"(%arg0: i64) -> i128 {
+    %c1_i32 = constant 1 : i32
+    %0 = llvm.alloca %c1_i32 x i128 : (i32) -> !llvm.ptr<i128>
+    %1 = llvm.mlir.addressof @std.sexti : !llvm.ptr<array<9 x i8>>
+    %2 = sexti %arg0 : i64 to i128
+    %c0_i32 = constant 0 : i32
+    %3 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i128>, i32) -> !llvm.ptr<i128>
+    %4 = llvm.load %3 : !llvm.ptr<i128>
+    %5 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i128>, i32) -> !llvm.ptr<i128>
+    llvm.store %2, %5 : !llvm.ptr<i128>
+    %6 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i128>, i32) -> !llvm.ptr<i128>
+    %7 = llvm.load %6 : !llvm.ptr<i128>
+    return %7 : i128
+  }
+  llvm.mlir.global private constant @std.fptrunc("std.fptrunc")
+  func @"$module-0__truncf_64_32"(%arg0: f64) -> f32 {
+    %c1_i32 = constant 1 : i32
+    %0 = llvm.alloca %c1_i32 x f32 : (i32) -> !llvm.ptr<f32>
+    %1 = llvm.mlir.addressof @std.fptrunc : !llvm.ptr<array<11 x i8>>
+    %2 = fptrunc %arg0 : f64 to f32
+    %c0_i32 = constant 0 : i32
+    %3 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f32>, i32) -> !llvm.ptr<f32>
+    %4 = llvm.load %3 : !llvm.ptr<f32>
+    %5 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f32>, i32) -> !llvm.ptr<f32>
+    llvm.store %2, %5 : !llvm.ptr<f32>
+    %6 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<f32>, i32) -> !llvm.ptr<f32>
+    %7 = llvm.load %6 : !llvm.ptr<f32>
+    return %7 : f32
+  }
   func @"$module-0__foo"() {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i8 : (i32) -> !llvm.ptr<i8>
     %c10_i64 = constant 10 : i64
-    %1 = trunci %c10_i64 : i64 to i8
+    %1 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
     %c0_i32 = constant 0 : i32
-    %2 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i8>, i32) -> !llvm.ptr<i8>
-    %3 = llvm.load %2 : !llvm.ptr<i8>
-    %4 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i8>, i32) -> !llvm.ptr<i8>
-    llvm.store %1, %4 : !llvm.ptr<i8>
-    %5 = llvm.alloca %c1_i32 x i16 : (i32) -> !llvm.ptr<i16>
+    %2 = llvm.getelementptr %1[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    llvm.store %c10_i64, %2 : !llvm.ptr<i64>
+    %3 = llvm.getelementptr %1[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %4 = llvm.load %3 : !llvm.ptr<i64>
+    %5 = call @"$module-0__trunc_64_8"(%4) : (i64) -> i8
+    %6 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i8>, i32) -> !llvm.ptr<i8>
+    %7 = llvm.load %6 : !llvm.ptr<i8>
+    %8 = llvm.getelementptr %0[%c0_i32] : (!llvm.ptr<i8>, i32) -> !llvm.ptr<i8>
+    llvm.store %5, %8 : !llvm.ptr<i8>
+    %9 = llvm.alloca %c1_i32 x i16 : (i32) -> !llvm.ptr<i16>
     %c123123_i64 = constant 123123 : i64
-    %6 = trunci %c123123_i64 : i64 to i16
-    %7 = llvm.getelementptr %5[%c0_i32] : (!llvm.ptr<i16>, i32) -> !llvm.ptr<i16>
-    %8 = llvm.load %7 : !llvm.ptr<i16>
-    %9 = llvm.getelementptr %5[%c0_i32] : (!llvm.ptr<i16>, i32) -> !llvm.ptr<i16>
-    llvm.store %6, %9 : !llvm.ptr<i16>
-    %10 = llvm.alloca %c1_i32 x i32 : (i32) -> !llvm.ptr<i32>
+    %10 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
+    %11 = llvm.getelementptr %10[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    llvm.store %c123123_i64, %11 : !llvm.ptr<i64>
+    %12 = llvm.getelementptr %10[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %13 = llvm.load %12 : !llvm.ptr<i64>
+    %14 = call @"$module-0__trunc_64_16"(%13) : (i64) -> i16
+    %15 = llvm.getelementptr %9[%c0_i32] : (!llvm.ptr<i16>, i32) -> !llvm.ptr<i16>
+    %16 = llvm.load %15 : !llvm.ptr<i16>
+    %17 = llvm.getelementptr %9[%c0_i32] : (!llvm.ptr<i16>, i32) -> !llvm.ptr<i16>
+    llvm.store %14, %17 : !llvm.ptr<i16>
+    %18 = llvm.alloca %c1_i32 x i32 : (i32) -> !llvm.ptr<i32>
     %c1000000000_i64 = constant 1000000000 : i64
-    %11 = trunci %c1000000000_i64 : i64 to i32
-    %12 = llvm.getelementptr %10[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
-    %13 = llvm.load %12 : !llvm.ptr<i32>
-    %14 = llvm.getelementptr %10[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
-    llvm.store %11, %14 : !llvm.ptr<i32>
-    %15 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
+    %19 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
+    %20 = llvm.getelementptr %19[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    llvm.store %c1000000000_i64, %20 : !llvm.ptr<i64>
+    %21 = llvm.getelementptr %19[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %22 = llvm.load %21 : !llvm.ptr<i64>
+    %23 = call @"$module-0__trunc_64_32"(%22) : (i64) -> i32
+    %24 = llvm.getelementptr %18[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
+    %25 = llvm.load %24 : !llvm.ptr<i32>
+    %26 = llvm.getelementptr %18[%c0_i32] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
+    llvm.store %23, %26 : !llvm.ptr<i32>
+    %27 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
     %c2000000000_i64 = constant 2000000000 : i64
-    %16 = llvm.getelementptr %15[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
-    %17 = llvm.load %16 : !llvm.ptr<i64>
-    %18 = llvm.getelementptr %15[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
-    llvm.store %c2000000000_i64, %18 : !llvm.ptr<i64>
-    %19 = llvm.alloca %c1_i32 x i128 : (i32) -> !llvm.ptr<i128>
+    %28 = llvm.getelementptr %27[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %29 = llvm.load %28 : !llvm.ptr<i64>
+    %30 = llvm.getelementptr %27[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    llvm.store %c2000000000_i64, %30 : !llvm.ptr<i64>
+    %31 = llvm.alloca %c1_i32 x i128 : (i32) -> !llvm.ptr<i128>
     %c1234567890_i64 = constant 1234567890 : i64
-    %20 = sexti %c1234567890_i64 : i64 to i128
-    %21 = llvm.getelementptr %19[%c0_i32] : (!llvm.ptr<i128>, i32) -> !llvm.ptr<i128>
-    %22 = llvm.load %21 : !llvm.ptr<i128>
-    %23 = llvm.getelementptr %19[%c0_i32] : (!llvm.ptr<i128>, i32) -> !llvm.ptr<i128>
-    llvm.store %20, %23 : !llvm.ptr<i128>
-    %24 = llvm.alloca %c1_i32 x f32 : (i32) -> !llvm.ptr<f32>
+    %32 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
+    %33 = llvm.getelementptr %32[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    llvm.store %c1234567890_i64, %33 : !llvm.ptr<i64>
+    %34 = llvm.getelementptr %32[%c0_i32] : (!llvm.ptr<i64>, i32) -> !llvm.ptr<i64>
+    %35 = llvm.load %34 : !llvm.ptr<i64>
+    %36 = call @"$module-0__ext_64_128"(%35) : (i64) -> i128
+    %37 = llvm.getelementptr %31[%c0_i32] : (!llvm.ptr<i128>, i32) -> !llvm.ptr<i128>
+    %38 = llvm.load %37 : !llvm.ptr<i128>
+    %39 = llvm.getelementptr %31[%c0_i32] : (!llvm.ptr<i128>, i32) -> !llvm.ptr<i128>
+    llvm.store %36, %39 : !llvm.ptr<i128>
+    %40 = llvm.alloca %c1_i32 x f32 : (i32) -> !llvm.ptr<f32>
     %cst = constant 3.141500e+20 : f64
-    %25 = fptrunc %cst : f64 to f32
-    %26 = llvm.getelementptr %24[%c0_i32] : (!llvm.ptr<f32>, i32) -> !llvm.ptr<f32>
-    %27 = llvm.load %26 : !llvm.ptr<f32>
-    %28 = llvm.getelementptr %24[%c0_i32] : (!llvm.ptr<f32>, i32) -> !llvm.ptr<f32>
-    llvm.store %25, %28 : !llvm.ptr<f32>
-    %29 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
+    %41 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
+    %42 = llvm.getelementptr %41[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    llvm.store %cst, %42 : !llvm.ptr<f64>
+    %43 = llvm.getelementptr %41[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    %44 = llvm.load %43 : !llvm.ptr<f64>
+    %45 = call @"$module-0__truncf_64_32"(%44) : (f64) -> f32
+    %46 = llvm.getelementptr %40[%c0_i32] : (!llvm.ptr<f32>, i32) -> !llvm.ptr<f32>
+    %47 = llvm.load %46 : !llvm.ptr<f32>
+    %48 = llvm.getelementptr %40[%c0_i32] : (!llvm.ptr<f32>, i32) -> !llvm.ptr<f32>
+    llvm.store %45, %48 : !llvm.ptr<f32>
+    %49 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
     %cst_0 = constant 3.141500e+123 : f64
-    %30 = llvm.getelementptr %29[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
-    %31 = llvm.load %30 : !llvm.ptr<f64>
-    %32 = llvm.getelementptr %29[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
-    llvm.store %cst_0, %32 : !llvm.ptr<f64>
+    %50 = llvm.getelementptr %49[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    %51 = llvm.load %50 : !llvm.ptr<f64>
+    %52 = llvm.getelementptr %49[%c0_i32] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
+    llvm.store %cst_0, %52 : !llvm.ptr<f64>
     return
   }
 }

--- a/testsuite/verona-mlir/using.verona
+++ b/testsuite/verona-mlir/using.verona
@@ -3,15 +3,42 @@
 
 using "numbers";
 
+// This needs to be here until "numbers" implement it
+trunc_64_8(arg: I64) : I8
+{
+  let res : I8 = "std.trunci"(arg);
+  return res;
+}
+trunc_64_16(arg: I64) : I16
+{
+  let res : I16 = "std.trunci"(arg);
+  return res;
+}
+trunc_64_32(arg: I64) : I32
+{
+  let res : I32 = "std.trunci"(arg);
+  return res;
+}
+ext_64_128(arg: I64) : I128
+{
+  let res : I128 = "std.sexti"(arg);
+  return res;
+}
+truncf_64_32(arg: F64) : F32
+{
+  let res : F32 = "std.fptrunc"(arg);
+  return res;
+}
+
 foo()
 {
-  let i8 : I8 = 10;
-  let i16 : I16 = 123123;
-  let i32 : I32 = 1000000000;
+  let i8 : I8 = trunc_64_8(10);
+  let i16 : I16 = trunc_64_16(123123);
+  let i32 : I32 = trunc_64_32(1000000000);
   let i64 : I64 = 2000000000;
-  let i128 : I128 = 1234567890;
+  let i128 : I128 = ext_64_128(1234567890);
   // Testing ISize is platform dependent.
   // let iSize : ISize = 12345;
-  let f32 : F32 = 3.1415e20;
+  let f32 : F32 = truncf_64_32(3.1415e20);
   let f64 : F64 = 3.1415e123;
 }


### PR DESCRIPTION
This commit adds signed/unsigned integer types and moves all cast
operations to the standard library implementation. For now, it's
implemented on the tests themselves, but that implementation should move
to `stdlib` and the tests should include that.

From now on, we assume that all casts and type promotions will happen at
the AST level and we'll get the correct types for all arithmetic
operations, so this commit also adds a few asserts  to make sure that's
true.

See `testsuite/verona-mlir/arithmetic.verona` for an idea how arithmetic
functions will look like. Soon, inline MLIR calls will change syntax
(probably something like @std.addi instead of "std.addi") and we can
move the implementation to the standard library.