### PR TITLE
[nightly.yml] Add a new stage for building Verona+LLVM at once on Linux

### DIFF
--- a/devops/llvm-anybuild.yml
+++ b/devops/llvm-anybuild.yml
@@ -95,8 +95,8 @@ jobs:
     value: $(LlvmSourceDir)\build
   - name: LLVM_COMMIT
     value: $[ dependencies.Configure.outputs['SetCommits.LLVM_COMMIT'] ]
-  - name: PKG_NAME
-    value: verona-llvm-install-x86_64-windows-$(BuildName)-$(LLVM_COMMIT)
+  - name: PKG_NAME_PREFIX
+    value: verona-llvm-install-x86_64-windows-$(BuildName)
 
   steps:
   - checkout: none
@@ -147,7 +147,8 @@ jobs:
       parameters:
         WorkingDir: $(LlvmSourceDir)
         InstallDirRelativePath: build/install
-        PackageName: $(PKG_NAME)
+        PackageName: $(PKG_NAME_PREFIX)
+        PackageCommit: $(LLVM_COMMIT)
         Md5Cmd: md5sum
 
 ############################################# Linux Builds
@@ -181,8 +182,8 @@ jobs:
     value: $(LlvmSourceDir)/build
   - name: LLVM_COMMIT
     value: $[ dependencies.Configure.outputs['SetCommits.LLVM_COMMIT'] ]
-  - name: PKG_NAME
-    value: verona-llvm-install-x86_64-linux-$(BuildName)-$(LLVM_COMMIT)
+  - name: PKG_NAME_PREFIX
+    value: verona-llvm-install-x86_64-linux-$(BuildName)
 
   steps:
   - checkout: none
@@ -250,7 +251,8 @@ jobs:
       parameters:
         WorkingDir: $(LlvmSourceDir)
         InstallDirRelativePath: build/install
-        PackageName: $(PKG_NAME)
+        PackageName: $(PKG_NAME_PREFIX)
+        PackageCommit: $(LLVM_COMMIT)
         Md5Cmd: md5sum
 
 ############################################## MacOS Builds
@@ -271,8 +273,8 @@ jobs:
     value: $(Agent.BuildDirectory)/s
   - name: LLVM_COMMIT
     value: $[ dependencies.Configure.outputs['SetCommits.LLVM_COMMIT'] ]
-  - name: PKG_NAME
-    value: verona-llvm-install-x86_64-darwin-$(BuildName)-$(LLVM_COMMIT)
+  - name: PKG_NAME_PREFIX
+    value: verona-llvm-install-x86_64-darwin-$(BuildName)
   steps:
   - checkout: none
   - template: ./steps/git-shallow-clone.yml
@@ -299,5 +301,6 @@ jobs:
       parameters:
         WorkingDir: $(LlvmSourceDir)
         InstallDirRelativePath: build/install
-        PackageName: $(PKG_NAME)
+        PackageName: $(PKG_NAME_PREFIX)
+        PackageCommit: $(LLVM_COMMIT)
         Md5Cmd: md5 -r

--- a/devops/llvm-anybuild.yml
+++ b/devops/llvm-anybuild.yml
@@ -18,7 +18,7 @@ parameters:
   # extra command-line args to pass to AnyBuild
   - name: ExtraAnyBuildArgs
     type: string
-    default: --Verbose --WhyCacheMiss --WhyCacheMissOptions CacheDataStoreKey=LLVMVerona
+    default: ''
   # number of parallel cmake jobs when building LLVM on Linux
   - name: CmakeJobsLinux
     type: number
@@ -41,16 +41,7 @@ schedules:
     - master
 
 variables:
-- name: AbEnvironmentName
-  value: LLVMVna
-- name: AbClusterId
-  value: 0310c9eb-18d0-4a58-bc85-bdc02a4d764a
-- name: AnyBuildEnvironmentUri
-  value: https://northeurope.anybuild-test.microsoft.com/api/clusters/$(AbClusterId)/agents
-- name: AnyBuildSource
-  value: https://anybuild$(AbEnvironmentName)neurope.blob.core.windows.net/clientreleases
-- name: AnyBuildRing
-  value: Dogfood
+- template: ./vars/anybuild-vars.yml
 - name: LlvmRepoGitUri
   value: https://github.com/llvm/llvm-project
 
@@ -144,7 +135,7 @@ jobs:
       set "USERDOMAIN_ROAMINGPROFILE="
 
       set ServicePrincipalPassword=$(LLVMPrincipalPassword)
-      call "%LOCALAPPDATA%\Microsoft\AnyBuild\AnyBuild.cmd" --EnableActionCache ${{ parameters.ExtraAnyBuildArgs }} --RemoteExecServiceUri $(AnyBuildEnvironmentUri) --ClientApplicationId $(LLVMPrincipalAppId) --ClientSecretEnvironmentVariable ServicePrincipalPassword --WaitForAgentForever --DoNotUseMachineUtilizationForScheduling -- ninja.exe -j ${{ parameters.CmakeJobsWindows }} install
+      call "%LOCALAPPDATA%\Microsoft\AnyBuild\AnyBuild.cmd" --EnableActionCache --WhyCacheMiss --WhyCacheMissOptions CacheDataStoreKey=LLVMVerona ${{ parameters.ExtraAnyBuildArgs }} --RemoteExecServiceUri $(AnyBuildEnvironmentUri) --ClientApplicationId $(LLVMPrincipalAppId) --ClientSecretEnvironmentVariable ServicePrincipalPassword --WaitForAgentForever --DoNotUseMachineUtilizationForScheduling -- ninja.exe -j ${{ parameters.CmakeJobsWindows }} install
     displayName: Compile
 
   - template: ./steps/print-anybuild-stats.yml
@@ -213,13 +204,6 @@ jobs:
     displayName: Install Prerequisites
 
   - bash: |
-      set -euo pipefail
-
-      echo "=== Downloading AnyBuild from $(AnyBuildSource)"
-      wget -O- $(AnyBuildSource)/bootstrapper.sh | bash -s $(AnyBuildSource) $(AnyBuildRing)
-    displayName: Install AnyBuild Client
-
-  - bash: |
       function log-and-run {
         echo "Running "
         echo "  CWD = $(pwd)"
@@ -249,32 +233,12 @@ jobs:
     workingDirectory: $(LlvmSourceDir)
     displayName: CMake
 
-  - bash: |
-      declare time_limit="90m"
-
-      echo "===== Running build (${{ parameters.CmakeJobsLinux }} CMake jobs) up to ${time_limit} from $(pwd)"
-      echo
-
-      env -i                                                      \
-        llvmPassword=$(LLVMPrincipalPassword)                     \
-        HOME="$HOME"                                              \
-        PATH="$PATH"                                              \
-      timeout "$time_limit" time $(AbClientDirectory)/AnyBuild.sh \
-        --RemoteExecServiceUri $(AnyBuildEnvironmentUri)          \
-        --NoCheckForUpdates                                       \
-        --WaitForAgentForever                                     \
-        --DoNotUseMachineUtilizationForScheduling                 \
-        --ClientApplicationId $(LLVMPrincipalAppId)               \
-        --ClientSecretEnvironmentVariable llvmPassword            \
-        ${{ parameters.ExtraAnyBuildArgs }}                       \
-        -- \
-        cmake --build . -- -j ${{ parameters.CmakeJobsLinux }} install
-    workingDirectory: $(LlvmBuildDir)
-    displayName: Compile
-
-  - template: ./steps/print-anybuild-stats.yml
+  - template: ./steps/linux/anybuild.yml
     parameters:
-      LogsDir: $(LlvmBuildDir)
+      BuildName: LLVM-$(BuildType)-$(CC)-Asan$(Asan)-AnyBuild
+      BuildCommandLine: cmake --build . -- -j ${{ parameters.CmakeJobsLinux }} install
+      WorkingDirectory: $(LlvmBuildDir)
+      ExtraAnyBuildArgs: ${{ parameters.ExtraAnyBuildArgs }}
 
   - bash: |
       ninja clean

--- a/devops/llvm-anybuild.yml
+++ b/devops/llvm-anybuild.yml
@@ -18,7 +18,7 @@ parameters:
   # extra command-line args to pass to AnyBuild
   - name: ExtraAnyBuildArgs
     type: string
-    default: ''
+    default: --Epoch 0
   # number of parallel cmake jobs when building LLVM on Linux
   - name: CmakeJobsLinux
     type: number

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -137,11 +137,6 @@ stages:
     - bash: |
         set -euo pipefail
 
-        # drop an AnyBuild.json config file and use it to
-        #   - ignore the CMAKE_BUILD_PARALLEL_LEVEL variable
-        #   - limit the number of concurrent cache lookups
-        echo '{"ActionCache": { "MaxParallelLookups": 10, "IgnoredEnvVars": [ "CMAKE_BUILD_PARALLEL_LEVEL" ] }}' | tee AnyBuild.json
-
         # remove '-march=native' which is incompatible with remote execution
         sed -i 's/ -march=native//g' src/rt/CMakeLists.txt
 

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -137,19 +137,6 @@ stages:
     - bash: |
         set -euo pipefail
 
-        # remove '-march=native' which is incompatible with remote execution
-        sed -i 's/ -march=native//g' src/rt/CMakeLists.txt
-
-        echo "=============="
-        echo "Patch applied:"
-        echo "=============="
-        echo
-        git diff
-      displayName: Configure AnyBuild
-
-    - bash: |
-        set -euo pipefail
-
         mkdir -p build
         cd build
         cmake                                      \

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -1,5 +1,5 @@
 parameters:
-  # number of parallel cmake jobs when building LLVM on Linux
+  # number of parallel cmake jobs when building with AnyBuild
   - name: AnyBuildParallelism
     type: number
     default: 48

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -1,3 +1,9 @@
+parameters:
+  # number of parallel cmake jobs when building LLVM on Linux
+  - name: AnyBuildParallelism
+    type: number
+    default: 48
+
 resources:
 - repo: self
 
@@ -13,182 +19,275 @@ schedules:
     include:
     - master
 
-jobs:
 ############################################## Linux Builds
-- job:
-  displayName: Linux
-  pool:
-    vmImage: 'ubuntu-20.04'
-  timeoutInMinutes: 120
-  strategy:
-    matrix:
-      GCC Debug:
-        CC: gcc
-        CXX: g++
-        CXXFLAGS:
-        BuildType: Debug
-        Asan: Off
-      GCC Release:
-        CC: gcc
-        CXX: g++
-        CXXFLAGS:
-        Asan: Off
-        BuildType: Release
-      Clang Debug:
-        CC: clang
-        CXX: clang++
-        CXXFLAGS: -stdlib=libstdc++
-        BuildType: Debug
-        Asan: Off
-      Clang Release:
-        CC: clang
-        CXX: clang++
-        CXXFLAGS: -stdlib=libstdc++
-        Asan: Off
-        BuildType: Release
-      Clang Debug (ASAN):
-        CC: clang
-        CXX: clang++
-        CXXFLAGS: -stdlib=libstdc++
-        BuildType: Debug
-        Asan: On
-      Clang Release (ASAN):
-        CC: clang
-        CXX: clang++
-        CXXFLAGS: -stdlib=libstdc++
-        BuildType: Release
-        Asan: On
-  steps:
-  - checkout: self
+stages:
+- stage: Linux
+  displayName: Linux (Verona)
+  dependsOn: []
+  jobs:
+  - job:
+    displayName: Linux
+    pool:
+      vmImage: 'ubuntu-20.04'
+    timeoutInMinutes: 120
+    strategy:
+      matrix:
+        GCC Debug:
+          CC: gcc
+          CXX: g++
+          CXXFLAGS:
+          BuildType: Debug
+          Asan: Off
+        GCC Release:
+          CC: gcc
+          CXX: g++
+          CXXFLAGS:
+          Asan: Off
+          BuildType: Release
+        Clang Debug:
+          CC: clang
+          CXX: clang++
+          CXXFLAGS: -stdlib=libstdc++
+          BuildType: Debug
+          Asan: Off
+        Clang Release:
+          CC: clang
+          CXX: clang++
+          CXXFLAGS: -stdlib=libstdc++
+          Asan: Off
+          BuildType: Release
+        Clang Debug (ASAN):
+          CC: clang
+          CXX: clang++
+          CXXFLAGS: -stdlib=libstdc++
+          BuildType: Debug
+          Asan: On
+        Clang Release (ASAN):
+          CC: clang
+          CXX: clang++
+          CXXFLAGS: -stdlib=libstdc++
+          BuildType: Release
+          Asan: On
+    steps:
+    - checkout: self
 
-  - script: |
-      set -eo pipefail
-      git submodule init
-      git submodule update --depth 1 --recursive
-    displayName: 'Checkout submodules'
+    - script: |
+        set -eo pipefail
+        git submodule init
+        git submodule update --depth 1 --recursive
+      displayName: 'Checkout submodules'
 
-  - script: |
-      set -eo pipefail
-      sudo apt-get update
-      sudo apt-get install -y ninja-build
-      sudo apt-get remove --purge cmake
-      sudo snap install cmake --classic
-      sudo pip install wheel OutputCheck
-    displayName: 'Dependencies'
+    - template: ./steps/linux/dependencies.yml
 
-  - task: CMake@1
-    displayName: 'CMake'
-    inputs:
-      cmakeArgs: |
-        .. -GNinja -DCMAKE_BUILD_TYPE=$(BuildType) -DCMAKE_CXX_FLAGS=$(CXXFLAGS) -DENABLE_ASSERTS=ON -DUSE_ASAN=$(Asan) -DVERONA_CI_BUILD=On -DRT_TESTS=ON
+    - task: CMake@1
+      displayName: 'CMake'
+      inputs:
+        cmakeArgs: |
+          .. -GNinja -DCMAKE_BUILD_TYPE=$(BuildType) -DCMAKE_CXX_FLAGS=$(CXXFLAGS) -DENABLE_ASSERTS=ON -DUSE_ASAN=$(Asan) -DVERONA_CI_BUILD=On -DRT_TESTS=ON
 
-  - script: |
-      set -eo pipefail
-      ninja
-    workingDirectory: build
-    displayName: 'Compile'
+    - script: |
+        set -eo pipefail
+        ninja
+      workingDirectory: build
+      displayName: 'Compile'
 
-  - script: |
-      set -eo pipefail
-      export ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer
-      export ASAN_OPTIONS="alloc_dealloc_mismatch=0 symbolize=1"
-      ninja check
-    workingDirectory: build
-    displayName: 'Tests'
+    - template: ./steps/linux/test.yml
+      parameters:
+        WorkingDirectory: build
+
+- stage: LinuxFull
+  displayName: Linux (Verona + LLVM)
+  dependsOn: []
+  jobs:
+  - job:
+    displayName: Linux
+    pool:
+      vmImage: 'ubuntu-20.04'
+    timeoutInMinutes: 120
+    strategy:
+      matrix:
+        GCC Release:
+          CC: gcc
+          CXX: g++
+          CXXFLAGS:
+          Asan: Off
+          BuildType: Release
+        Clang Debug (ASAN):
+          CC: clang
+          CXX: clang++
+          CXXFLAGS: -stdlib=libstdc++
+          BuildType: Debug
+          Asan: On
+
+    variables:
+      - template: ./vars/anybuild-vars.yml
+      - template: ./vars/llvm-vars.yml
+
+    steps:
+    - checkout: self
+
+    - script: |
+        set -eo pipefail
+        git submodule init
+        git submodule update --depth 1 --recursive
+      displayName: 'Checkout submodules'
+
+    - template: ./steps/linux/dependencies.yml
+
+    - bash: |
+        set -euo pipefail
+
+        # drop an AnyBuild.json config file and use it to
+        #   - ignore the CMAKE_BUILD_PARALLEL_LEVEL variable
+        #   - limit the number of concurrent cache lookups
+        echo '{"ActionCache": { "MaxParallelLookups": 10, "IgnoredEnvVars": [ "CMAKE_BUILD_PARALLEL_LEVEL" ] }}' | tee AnyBuild.json
+
+        # remove '-march=native' which is incompatible with remote execution
+        sed -i 's/ -march=native//g' src/rt/CMakeLists.txt
+
+        echo "=============="
+        echo "Patch applied:"
+        echo "=============="
+        echo
+        git diff
+      displayName: Configure AnyBuild
+
+    - bash: |
+        set -euo pipefail
+
+        mkdir -p build
+        cd build
+        cmake                                      \
+          ..                                       \
+          -GNinja                                  \
+          -DCMAKE_BUILD_TYPE=$(BuildType)          \
+          -DCMAKE_CXX_FLAGS=$(CXXFLAGS)            \
+          -DENABLE_ASSERTS=ON                      \
+          -DUSE_ASAN=$(Asan)                       \
+          -DVERONA_CI_BUILD=On                     \
+          -DRT_TESTS=ON                            \
+          -DVERONA_DOWNLOAD_LLVM=OFF               \
+          -DLLVM_EXTRA_CMAKE_ARGS="                \
+            -Wno-dev                               \
+            -DCMAKE_C_COMPILER=$(LLVM_CC)          \
+            -DCMAKE_CXX_COMPILER=$(LLVM_CXX)       \
+            -DCMAKE_BUILD_TYPE=$(LLVM_BuildType)   \
+            -DCMAKE_CXX_FLAGS=$(LLVM_CXXFLAGS)     \
+            -DLLVM_USE_SANITIZER=$(LLVM_Sanitizer) \
+            -DMLIR_INCLUDE_TESTS=OFF"
+      displayName: CMake
+
+    - template: ./steps/linux/anybuild.yml
+      parameters:
+        BuildName: Verona-$(BuildType)-$(CC)-Asan$(Asan)-AnyBuild
+        BuildCommandLine: env CMAKE_BUILD_PARALLEL_LEVEL=${{ parameters.AnyBuildParallelism }} cmake --build .
+        WorkingDirectory: build
+
+    - template: ./steps/linux/test.yml
+      parameters:
+        WorkingDirectory: build
 
 ############################################## Windows Builds
-- job:
-  displayName: Windows
-  pool:
-    vmImage: 'windows-2019'
-  timeoutInMinutes: 120
-  strategy:
-    matrix:
-      RelWithDebInfo:
-        CXXFLAGS: '/EHsc /D _SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING=1'
-        BuildType: RelWithDebInfo
-      Release:
-        CXXFLAGS: '/EHsc /D _SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING=1'
-        BuildType: Release
+- stage: Windows
+  displayName: Windows (Verona)
+  dependsOn: []
+  jobs:
+  - job:
+    displayName: Windows
+    pool:
+      vmImage: 'windows-2019'
+    timeoutInMinutes: 120
+    strategy:
+      matrix:
+        RelWithDebInfo:
+          CXXFLAGS: '/EHsc /D _SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING=1'
+          BuildType: RelWithDebInfo
+        Release:
+          CXXFLAGS: '/EHsc /D _SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING=1'
+          BuildType: Release
 
-  steps:
-  - checkout: self
+    steps:
+    - checkout: self
 
-  - script: |
-      git submodule init
-      git submodule update --depth 1 --recursive
-    displayName: 'Checkout submodules'
+    - script: |
+        git submodule init
+        git submodule update --depth 1 --recursive
+      displayName: 'Checkout submodules'
 
-  - script:
-      pip install OutputCheck
-    displayName: 'Dependencies'
+    - script:
+        pip install OutputCheck
+      displayName: 'Dependencies'
 
 
-  - script: |
-      mkdir build
-      cd build
-      cmake .. -G"Visual Studio 16 2019" -DENABLE_ASSERTS=ON -DVERONA_CI_BUILD=On -DRT_TESTS=ON -DCMAKE_CXX_FLAGS="$(CXXFLAGS)"
-    displayName: 'CMake'
+    - script: |
+        mkdir build
+        cd build
+        cmake .. -G"Visual Studio 16 2019" -DENABLE_ASSERTS=ON -DVERONA_CI_BUILD=On -DRT_TESTS=ON -DCMAKE_CXX_FLAGS="$(CXXFLAGS)"
+      displayName: 'CMake'
 
-  - task: MSBuild@1
-    displayName: 'Compile'
-    inputs:
-      solution: build/verona.sln
-      msbuildArguments: '/m /p:Configuration=$(BuildType)'
+    - task: MSBuild@1
+      displayName: 'Compile'
+      inputs:
+        solution: build/verona.sln
+        msbuildArguments: '/m /p:Configuration=$(BuildType)'
 
-  - task: MSBuild@1
-    displayName: 'Test'
-    inputs:
-      solution: build/check.vcxproj
-      msbuildArguments: '/m /p:Configuration=$(BuildType)'
+    - task: MSBuild@1
+      displayName: 'Test'
+      inputs:
+        solution: build/check.vcxproj
+        msbuildArguments: '/m /p:Configuration=$(BuildType)'
 
-  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-    displayName: 'Component Detection'
-    inputs:
-      failOnAlert: true
+    - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+      displayName: 'Component Detection'
+      inputs:
+        failOnAlert: true
 
 ############################################## MacOS Builds
-- job:
-  displayName: macOS
-  pool:
-    vmImage: 'macOS-10.14'
-  timeoutInMinutes: 120
-  strategy:
-    matrix:
-      Debug:
-        BuildType: Debug
-      Release:
-        BuildType: Release
+- stage: MacOS
+  displayName: macOS (Verona)
+  dependsOn: []
+  jobs:
+  - job:
+    displayName: macOS
+    pool:
+      vmImage: 'macOS-10.14'
+    timeoutInMinutes: 120
+    strategy:
+      matrix:
+        Debug:
+          BuildType: Debug
+        Release:
+          BuildType: Release
 
-  steps:
-  - checkout: self
+    steps:
+    - checkout: self
 
-  - script: |
-      set -eo pipefail
-      git submodule init
-      git submodule update --depth 1 --recursive
-    displayName: 'Checkout submodules'
+    - script: |
+        set -eo pipefail
+        git submodule init
+        git submodule update --depth 1 --recursive
+      displayName: 'Checkout submodules'
 
-  - script: |
-      set -eo pipefail
-      sudo pip3 install wheel OutputCheck
-    displayName:  'Dependencies'
+    - script: |
+        set -eo pipefail
+        sudo pip3 install wheel OutputCheck
+      displayName:  'Dependencies'
 
-  - task: CMake@1
-    displayName: 'CMake'
-    inputs:
-      cmakeArgs: |
-        .. -DCMAKE_BUILD_TYPE=$(BuildType) -DENABLE_ASSERTS=ON -DVERONA_CI_BUILD=On -DRT_TESTS=ON
+    - task: CMake@1
+      displayName: 'CMake'
+      inputs:
+        cmakeArgs: |
+          .. -DCMAKE_BUILD_TYPE=$(BuildType) -DENABLE_ASSERTS=ON -DVERONA_CI_BUILD=On -DRT_TESTS=ON
 
-  - script: |
-      set -eo pipefail
-      N=$(sysctl -n hw.ncpu)
-      make -j $N
-    workingDirectory: build
-    displayName: 'Compile'
+    - script: |
+        set -eo pipefail
+        N=$(sysctl -n hw.ncpu)
+        make -j $N
+      workingDirectory: build
+      displayName: 'Compile'
 
-  - script: |
-      set -eo pipefail
-      make check
-    workingDirectory: build/
-    displayName: 'Tests'
+    - script: |
+        set -eo pipefail
+        make check
+      workingDirectory: build/
+      displayName: 'Tests'

--- a/devops/steps/linux/anybuild.yml
+++ b/devops/steps/linux/anybuild.yml
@@ -1,0 +1,68 @@
+parameters:
+  - name: BuildName
+    type: string
+  - name: BuildCommandLine
+    type: string
+  - name: WorkingDirectory
+    type: string
+  - name: Condition
+    type: string
+    default: succeeded()
+  - name: ExtraAnyBuildArgs
+    type: string
+    default: ''
+
+steps:
+- bash: |
+    set -euo pipefail
+
+    echo "=== Downloading AnyBuild from $(AnyBuildSource)"
+    wget -O- $(AnyBuildSource)/bootstrapper.sh | bash -s $(AnyBuildSource) $(AnyBuildRing)
+  displayName: Install AnyBuild Client
+
+- bash: |
+    set -euo pipefail
+
+    echo "===== Running '${{ parameters.BuildCommandLine }}' from $(pwd)"
+    echo
+
+    readonly abClientExe="$HOME/.local/share/Microsoft/AnyBuild/AnyBuild.sh"
+
+    env -i                                                                \
+      SECRET=$(LLVMPrincipalPassword)                                     \
+      HOME="$HOME"                                                        \
+      PATH="$PATH"                                                        \
+    "$abClientExe"                                                        \
+      --RemoteExecServiceUri $(AnyBuildEnvironmentUri)                    \
+      --NoCheckForUpdates                                                 \
+      --WaitForAgentForever                                               \
+      --DoNotUseMachineUtilizationForScheduling                           \
+      --ClientApplicationId $(LLVMPrincipalAppId)                         \
+      --ClientSecretEnvironmentVariable SECRET                            \
+      --ExperimentName "${{ parameters.BuildName }}"                      \
+      --WhyCacheMiss                                                      \
+      --WhyCacheMissOptions CacheDataStoreKey=${{ parameters.BuildName }} \
+      ${{ parameters.ExtraAnyBuildArgs }}                                 \
+      --                                                                  \
+      ${{ parameters.BuildCommandLine }}
+  workingDirectory: ${{ parameters.WorkingDirectory }}
+  displayName: AnyBuild ${{ parameters.BuildName }}
+
+- template: ../print-anybuild-stats.yml
+  parameters:
+    LogsDir: ${{ parameters.WorkingDirectory }}
+
+- bash: |
+    rm -rf AnyBuildLogs
+    mkdir AnyBuildLogs
+    mv -v AnyBuild*.log AnyBuildLogs/
+  workingDirectory: ${{ parameters.WorkingDirectory }}
+  continueOnError: true
+  condition: not(canceled())
+  displayName: Extract AnyBuild Logs
+
+- publish: ${{ parameters.WorkingDirectory }}/AnyBuildLogs
+  artifact: AnyBuildLogs-${{ parameters.BuildName }}-linux.$(Build.BuildId)
+  continueOnError: true
+  condition: not(canceled())
+  displayName: Publish AnyBuild Logs

--- a/devops/steps/linux/anybuild.yml
+++ b/devops/steps/linux/anybuild.yml
@@ -23,6 +23,12 @@ steps:
 - bash: |
     set -euo pipefail
 
+    # drop an AnyBuild.json config file and use it to
+    #   - ignore the CMAKE_BUILD_PARALLEL_LEVEL variable
+    #   - limit the number of concurrent cache lookups
+    echo "===== Writing AnyBuild.json"
+    echo '{"ActionCache": { "MaxParallelLookups": 10, "IgnoredEnvVars": [ "CMAKE_BUILD_PARALLEL_LEVEL", "SNAP" ] }}' | tee AnyBuild.json
+
     echo "===== Running '${{ parameters.BuildCommandLine }}' from $(pwd)"
     echo
 
@@ -58,11 +64,11 @@ steps:
     mv -v AnyBuild*.log AnyBuildLogs/
   workingDirectory: ${{ parameters.WorkingDirectory }}
   continueOnError: true
-  condition: not(canceled())
+  condition: and(failed(), not(canceled()))
   displayName: Extract AnyBuild Logs
 
 - publish: ${{ parameters.WorkingDirectory }}/AnyBuildLogs
   artifact: AnyBuildLogs-${{ parameters.BuildName }}-linux.$(Build.BuildId)
   continueOnError: true
-  condition: not(canceled())
+  condition: and(failed(), not(canceled()))
   displayName: Publish AnyBuild Logs

--- a/devops/steps/linux/dependencies.yml
+++ b/devops/steps/linux/dependencies.yml
@@ -1,0 +1,9 @@
+steps:
+- script: |
+    set -eo pipefail
+    sudo apt-get update
+    sudo apt-get install -y ninja-build
+    sudo apt-get remove --purge cmake
+    sudo snap install cmake --classic
+    sudo pip install wheel OutputCheck
+  displayName: 'Dependencies'

--- a/devops/steps/linux/test.yml
+++ b/devops/steps/linux/test.yml
@@ -1,0 +1,12 @@
+parameters:
+  - name: WorkingDirectory
+    type: string
+  
+steps:
+- script: |
+    set -eo pipefail
+    export ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer
+    export ASAN_OPTIONS="alloc_dealloc_mismatch=0 symbolize=1"
+    ninja check
+  workingDirectory: ${{ parameters.WorkingDirectory }}
+  displayName: Tests

--- a/devops/steps/linux/test.yml
+++ b/devops/steps/linux/test.yml
@@ -1,7 +1,7 @@
 parameters:
   - name: WorkingDirectory
     type: string
-  
+
 steps:
 - script: |
     set -eo pipefail

--- a/devops/steps/tar-and-upload.yml
+++ b/devops/steps/tar-and-upload.yml
@@ -5,13 +5,18 @@ parameters:
   type: string
 - name: PackageName
   type: string
+- name: PackageCommit
+  type: string
 - name: Md5Cmd
   type: string
 
 steps:
   - bash: |
       set -euo pipefail
-      readonly PKG_NAME="${{ parameters.PackageName }}"
+
+      readonly CommitLong="${{ parameters.PackageCommit }}"
+
+      PKG_NAME="${{ parameters.PackageName }}-${CommitLong:0:11}"
       rm -f $PKG_NAME.tar.gz
 
       echo "=== Creating a tarball from $(pwd)/${{ parameters.InstallDirRelativePath }}"
@@ -21,16 +26,11 @@ steps:
       echo "=== Computing md5 checksum"
       ${{ parameters.Md5Cmd }} $PKG_NAME.tar.gz | awk '{print $1}' > $PKG_NAME.tar.gz.md5
       cat $PKG_NAME.tar.gz.md5
-    workingDirectory: ${{ parameters.WorkingDir }}
-    displayName: Create Package
 
-  - bash: |
-      set -eo pipefail
-      readonly PKG_NAME="${{ parameters.PackageName }}"
       echo "=== Uploading $(pwd)/$PKG_NAME.tar.gz"
       az storage blob upload --container-name llvmbuild --file $PKG_NAME.tar.gz --name $PKG_NAME --connection-string "$(BLOB_CONNECTION_STRING)"
 
       echo "=== Uploading $(pwd)/$PKG_NAME.tar.gz.md5"
       az storage blob upload --container-name llvmbuild --file $PKG_NAME.tar.gz.md5 --name $PKG_NAME.md5 --connection-string "$(BLOB_CONNECTION_STRING)"
     workingDirectory: ${{ parameters.WorkingDir }}
-    displayName: Upload Package
+    displayName: Create and Upload Package

--- a/devops/vars/anybuild-vars.yml
+++ b/devops/vars/anybuild-vars.yml
@@ -1,0 +1,11 @@
+variables:
+- name: AbEnvironmentName
+  value: LLVMVna
+- name: AbClusterId
+  value: 0310c9eb-18d0-4a58-bc85-bdc02a4d764a
+- name: AnyBuildEnvironmentUri
+  value: https://northeurope.anybuild-test.microsoft.com/api/clusters/$(AbClusterId)/agents
+- name: AnyBuildSource
+  value: https://anybuild$(AbEnvironmentName)neurope.blob.core.windows.net/clientreleases
+- name: AnyBuildRing
+  value: Dogfood

--- a/devops/vars/llvm-vars.yml
+++ b/devops/vars/llvm-vars.yml
@@ -1,0 +1,6 @@
+variables:
+  LLVM_CC: clang
+  LLVM_CXX: clang++
+  LLVM_CXXFLAGS: -stdlib=libstdc++
+  LLVM_BuildType: Release
+  LLVM_Sanitizer:

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -63,6 +63,7 @@ if (VERONA_DOWNLOAD_LLVM)
     USES_TERMINAL_DOWNLOAD true
   )
 else()
+  separate_arguments(LLVM_EXTRA_CMAKE_ARGS UNIX_COMMAND ${LLVM_EXTRA_CMAKE_ARGS})
   list (APPEND LLVM_EXTRA_CMAKE_ARGS
     -DCMAKE_INSTALL_PREFIX=${MLIR_INSTALL}/install  # Add install as tar has install prefix. Outer project knows about this.
     # Note: We must use the SEMICOLON generator expression here because CMake

--- a/src/rt/CMakeLists.txt
+++ b/src/rt/CMakeLists.txt
@@ -68,7 +68,7 @@ if(MSVC)
   set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /DEBUG")
 else()
   find_package(Threads REQUIRED)
-  target_compile_options(verona_rt INTERFACE -mcx16 -march=native)
+  target_compile_options(verona_rt INTERFACE -mcx16)
 endif()
 
 if(USE_SCHED_STATS)


### PR DESCRIPTION
The only functional change should be the addition of the new stage.

This PR also includes a syntactic change which breaks up the nightly pipeline into the following stages
  - Linux (Verona)
  - Linux (Verona+LLVM)
  - Windows (Verona)
  - macOS (Verona)

Having stages is convenient because the ADO GUI allows for selecting which stages to execute when enqueuing a new build (and so, it becomes easy to run partial validations).