### PR TITLE
Move class initialisation into a single struct

### DIFF
--- a/src/mlir/consumer.cc
+++ b/src/mlir/consumer.cc
@@ -102,7 +102,8 @@ namespace mlir::verona
       info.finalize();
 
       // Update the map between class types and their field names
-      con.classInfo.emplace(info.key(), std::move(info));
+      auto key = info.key();
+      con.classInfo.emplace(key, std::move(info));
 
       // Pop the function scope for name mangling and current class
       if (!functionScope.empty())


### PR DESCRIPTION
This commit implements class initialisation (fields, types, etc) to a
single class that inhabits a stack during declaration, then moves to an
unordered map to be used during the definition phase.

Both declaration stack and definition map are on the same type, so it's
a simple move once the object is finalised. With this, we reduce the
number of shared state between declaraiton and definition and also
simplify the field access logic considerably.

No tests changed, which is a good sign.