### PR TITLE
Use automatic cleanup for symbol stack pop

### DIFF
--- a/src/mlir/consumer.cc
+++ b/src/mlir/consumer.cc
@@ -258,12 +258,12 @@ namespace mlir::verona
     /// Closes the function, checking the return value
     void post(Function& node)
     {
+      // Automatically clean up
+      ScopeCleanup([&]() { symbolTable().popScope(); });
+
       // Check if needs to return a value at all
       if (gen.hasTerminator(builder().getBlock()))
-      {
-        symbolTable().popScope();
         return;
-      }
 
       // Fetch the current function
       auto loc = con.getLocation(node);
@@ -274,9 +274,6 @@ namespace mlir::verona
       // Lower return value
       auto val = takeOperand(/*last=*/true);
       gen.Return(loc, func, val);
-
-      // Pop function's variable scope
-      symbolTable().popScope();
     }
 
     /// Local declarations (including temps) reserve a place on the symbol table

--- a/src/mlir/consumer.cc
+++ b/src/mlir/consumer.cc
@@ -259,7 +259,7 @@ namespace mlir::verona
     void post(Function& node)
     {
       // Automatically clean up
-      ScopeCleanup([&]() { symbolTable().popScope(); });
+      ScopeCleanup pop([&]() { symbolTable().popScope(); });
 
       // Check if needs to return a value at all
       if (gen.hasTerminator(builder().getBlock()))

--- a/src/mlir/consumer.h
+++ b/src/mlir/consumer.h
@@ -86,4 +86,25 @@ namespace mlir::verona
     static llvm::Expected<OwningModuleRef>
     lower(MLIRContext* context, ::verona::parser::Ast ast);
   };
+
+  /*
+   * Scope Cleanup helper
+   *
+   * Automatically performs cleanup on destruction.
+   */
+  template<class T>
+  class ScopeCleanup
+  {
+    /// Action to perform on destruction
+    T cleanup;
+
+  public:
+    ScopeCleanup(T&& c) : cleanup(std::move(c)) {}
+
+    /// Automatically applies the cleanup
+    ~ScopeCleanup()
+    {
+      cleanup();
+    }
+  };
 }

--- a/src/mlir/consumer.h
+++ b/src/mlir/consumer.h
@@ -90,7 +90,13 @@ namespace mlir::verona
   /*
    * Scope Cleanup helper
    *
-   * Automatically performs cleanup on destruction.
+   * Automatically invokes the callable object passed to the constructor on
+   * destruction. This class is intended to provide lexically scoped cleanups,
+   * for example:
+   * ```c++
+   * ScopedCleanup defer([&] { cleanup code here });
+   * ```
+   * The code in the lambda will be invoked when `defer` goes out of scope.
    */
   template<class T>
   class ScopeCleanup


### PR DESCRIPTION
This allows us to return at any time from the post methods while making
sure we unwind the stack correctly on all cases.

For now there's only one case where this is beneficial, but it's a good pattern to keep.