### PR TITLE
Fix the build with GCC:

### DIFF
--- a/experiments/process_sandbox/CMakeLists.txt
+++ b/experiments/process_sandbox/CMakeLists.txt
@@ -14,6 +14,10 @@ set(CMAKE_CXX_STANDARD 17)
 if (MSVC)
 else ()
 	add_compile_options(-mcx16 -Wall -Wextra -Werror "$<$<CONFIG:DEBUG>:-fno-inline>")
+	# Disable GCC warnings that give a large number of false positives.
+	if (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
+		add_compile_options(-Wno-attributes -Wno-cast-function-type)
+	endif()
 endif()
 
 set(DEFAULT_KQUEUE true)

--- a/experiments/process_sandbox/include/process_sandbox/helpers.h
+++ b/experiments/process_sandbox/include/process_sandbox/helpers.h
@@ -4,17 +4,17 @@
 #pragma once
 #include <memory>
 
-#if __has_include(<source_location>)
-#  include <source_location>
-namespace sandbox
-{
-  using source_location = std::source_location;
-}
-#elif __has_include(<experimental/source_location>)
+#if __has_include(<experimental/source_location>)
 #  include <experimental/source_location>
 namespace sandbox
 {
   using source_location = std::experimental::source_location;
+}
+#elif __has_include(<source_location>)
+#  include <source_location>
+namespace sandbox
+{
+  using source_location = std::source_location;
 }
 #else
 // If we don't have a vaguely recent standard library then we don't get useful

--- a/experiments/process_sandbox/src/library_runner.cc
+++ b/experiments/process_sandbox/src/library_runner.cc
@@ -604,7 +604,7 @@ namespace
       auto syscall_callback = [&](int number, auto&& fn) {
         if ((number != -1) && (number == syscall))
         {
-          uintptr_t result = call(fn);
+          intptr_t result = call(fn);
           if (result < 0)
           {
             c.set_error_return(-result);

--- a/experiments/process_sandbox/src/libsandbox.cc
+++ b/experiments/process_sandbox/src/libsandbox.cc
@@ -446,7 +446,7 @@ namespace sandbox
       if (fd >= 0)
       {
         platform::Handle h(fd);
-        return std::move(h);
+        return h;
       }
       return -errno;
     };


### PR DESCRIPTION
 - Remove a std::move that is redundant with RVO (GCC warning)
 - Fix an tautological compare (uintptr_t < 0)
 - Prefer std::experimental::source_location to std::source_location
   (the latter is only enabled for C++20 or later with libstdc++)
 - Disable two GCC warnings that produce false positives
   (always-inline may not be inlined - it probably is, function-pointer
   cast may be invalid - triggered by any use of dlfunc)