### PR TITLE
Fix the Linux build with GCC and enable CI:

### DIFF
--- a/devops/ci.yml
+++ b/devops/ci.yml
@@ -32,9 +32,12 @@ jobs:
       fi
 
       echo "Determine if process-based sandbox changed."
-      if git diff --ignore-submodules=dirty --quiet origin/master -- experiments/process_sandbox; then
-        echo " - Process-based sandbox is unchanged!"
-        echo "##vso[task.setvariable variable=testProcSandbox;isOutput=true]Off" #set variable testProcSandbox to Off
+      # Check if the process sandbox code has changed, or snmalloc (which is
+      # tightly coupled to the process sandbox code) so that we can skip CI on
+      # the process sandbox code if it has not been modified.
+      if git diff --ignore-submodules=dirty --quiet origin/master -- experiments/process_sandbox external/snmalloc/; then
+       echo " - Process-based sandbox is unchanged!"
+       echo "##vso[task.setvariable variable=testProcSandbox;isOutput=true]Off" #set variable testProcSandbox to Off
       else
         echo " - Process-based sandbox has changed!"
         echo "##vso[task.setvariable variable=testProcSandbox;isOutput=true]On" #set variable testProcSandbox to On
@@ -111,6 +114,14 @@ jobs:
   timeoutInMinutes: 120
   strategy:
     matrix:
+      GCC Release:
+        CC: gcc-10
+        CXX: g++-10
+        BuildType: Release
+      GCC Debug:
+        CC: gcc-10
+        CXX: g++-10
+        BuildType: Debug
       Clang Release:
         CC: clang
         CXX: clang++
@@ -124,8 +135,9 @@ jobs:
 
   - script: |
       set -eo pipefail
-      git submodule init
-      git submodule update --depth 1 --recursive
+      # Skip two huge submodules that aren't needed.  This should save about a
+      # minute of CI time for each instance of this job.
+      git -c submodule."external/llvm-project".update=none -c submodule."external/CLI11".update=none submodule update --depth 1 --init --recursive
     displayName: 'Checkout submodules'
 
   - script: |

--- a/experiments/process_sandbox/CMakeLists.txt
+++ b/experiments/process_sandbox/CMakeLists.txt
@@ -72,6 +72,11 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	target_link_libraries(sandbox -ldl -lbsd -lrt)
 endif()
 
+if (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
+	target_link_libraries(library_runner -latomic)
+	target_link_libraries(sandbox -latomic)
+endif()
+
 if (${ENABLE_SECCOMP})
 	message(STATUS "Using seccomp-bpf for sandboxing")
 	target_link_libraries(library_runner -lseccomp)

--- a/experiments/process_sandbox/include/process_sandbox/helpers.h
+++ b/experiments/process_sandbox/include/process_sandbox/helpers.h
@@ -4,6 +4,37 @@
 #pragma once
 #include <memory>
 
+/**
+ * Helper macro to apply a pragma in a macro, concatenating arguments as a
+ * single string.
+ */
+#define SANDBOX_DO_PRAGMA(x) _Pragma(#x)
+
+#ifdef __clang__
+/**
+ * Macro to silence a clang warning until the next
+ * `SANDBOX_CLANG_DIAGNOSTIC_POP()`.  The argument is the name of the warning
+ * as a string.  For example, if the flag to enable the warning is
+ * `-Wwarning-with-false-positives` then the argument to this should be
+ * `"-Wwarning-with-false-positives"`.
+ *
+ * When compiling with a non-clang compiler, this macro does nothing.
+ */
+#  define SANDBOX_CLANG_DIAGNOSTIC_IGNORE(x) \
+    _Pragma("clang diagnostic push") \
+      SANDBOX_DO_PRAGMA(clang diagnostic ignored x)
+/**
+ * Restores the set of enabled clang warnings to the set before the most recent
+ * `SANDBOX_CLANG_DIAGNOSTIC_IGNORE()`.
+ *
+ * When compiling with a non-clang compiler, this macro does nothing.
+ */
+#  define SANDBOX_CLANG_DIAGNOSTIC_POP() _Pragma("clang diagnostic pop")
+#else
+#  define SANDBOX_CLANG_DIAGNOSTIC_IGNORE(x)
+#  define SANDBOX_CLANG_DIAGNOSTIC_POP()
+#endif
+
 #if __has_include(<experimental/source_location>)
 #  include <experimental/source_location>
 namespace sandbox

--- a/experiments/process_sandbox/include/process_sandbox/platform/README.md
+++ b/experiments/process_sandbox/include/process_sandbox/platform/README.md
@@ -9,4 +9,3 @@ or more sockets, it is not a generic event abstraction.
 
 Some of the code here may eventually be moved into generic Verona runtime
 platform abstractions and made more general.
-

--- a/experiments/process_sandbox/include/process_sandbox/platform/sandbox_seccomp-bpf.h
+++ b/experiments/process_sandbox/include/process_sandbox/platform/sandbox_seccomp-bpf.h
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
-#if __has_include(<seccomp.h>)
-#  pragma clang diagnostic push
-#  pragma clang diagnostic ignored "-Wmissing-field-initializers"
+#include "../helpers.h"
 
+#if __has_include(<seccomp.h>)
+SANDBOX_CLANG_DIAGNOSTIC_IGNORE("-Wmissing-field-initializers")
 #  include <seccomp.h>
-#  pragma clang diagnostic pop
+SANDBOX_CLANG_DIAGNOSTIC_POP()
 #  include <assert.h>
 
 namespace sandbox

--- a/experiments/process_sandbox/src/child_malloc.h
+++ b/experiments/process_sandbox/src/child_malloc.h
@@ -168,6 +168,8 @@ namespace sandbox
 }
 
 #define SNMALLOC_DEFAULT_CHUNKMAP sandbox::ProxyPageMap
-#define SNMALLOC_DEFAULT_MEMORY_PROVIDER struct sandbox::MemoryProviderProxy
-#define SNMALLOC_USE_THREAD_CLEANUP 1
+#define SNMALLOC_DEFAULT_MEMORY_PROVIDER sandbox::MemoryProviderProxy
+#ifdef __FreeBSD__
+#  define SNMALLOC_USE_THREAD_CLEANUP 1
+#endif
 #include "override/malloc.cc"

--- a/experiments/process_sandbox/src/library_runner.cc
+++ b/experiments/process_sandbox/src/library_runner.cc
@@ -55,7 +55,10 @@ namespace
   void* fdlopen(int fd, int flags)
   {
     char* str;
-    asprintf(&str, "/proc/%d/fd/%d", (int)getpid(), fd);
+    if (asprintf(&str, "/proc/%d/fd/%d", (int)getpid(), fd) < 0)
+    {
+      DefaultPal::error("asprintf failed in fdlopen.");
+    }
     void* ret = dlopen(str, flags);
     free(str);
     return ret;

--- a/experiments/process_sandbox/tests/poller.cc
+++ b/experiments/process_sandbox/tests/poller.cc
@@ -47,7 +47,8 @@ void test_poller()
     {
       auto sp = SocketPair::create();
       poller.add(sp.second.take());
-      write(sp.first.fd, &i, sizeof(i));
+      int ret = write(sp.first.fd, &i, sizeof(i));
+      SANDBOX_INVARIANT(ret == sizeof(i), "write failed {}", strerror(errno));
       socks.push_back(std::move(sp.first));
     }
     auto start = std::chrono::steady_clock::now();


### PR DESCRIPTION
 - GCC and libstdc++ requires libatomic for 64-bit compare and exchange,
   so link it when compiling with GCC.
 - Wrap the clang-specific pragmas for silencing warnings in macros so
   that they're only used when compiling with clang.
 - Don't use a FreeBSD-libc-specific snmalloc option on non-FreeBSD
   platforms.
 - Run the process-sandbox tests if snmalloc changes.  This should make
   it easier for Matthew to test new snmalloc imports.