### PR TITLE
Added .devcontainers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.188.0/containers/cpp/.devcontainer/base.Dockerfile
+
+ARG VARIANT="buster"
+FROM mcr.microsoft.com/vscode/devcontainers/cpp:0-${VARIANT}
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends cmake \
+    ninja-build python3 clang-8 clang-format clang-tools \
+    clang-format-9

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,5 +5,5 @@ FROM mcr.microsoft.com/vscode/devcontainers/cpp:0-${VARIANT}
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends cmake \
-    ninja-build python3 clang-8 clang-format clang-tools \
+    ninja-build python3 clang clang-format clang-tools \
     clang-format-9

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.188.0/containers/cpp
+{
+	"name": "C++",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick an Debian / Ubuntu OS version: debian-10, debian-9, ubuntu-20.04, ubuntu-18.04
+		"args": { "VARIANT": "ubuntu-20.04" }
+	},
+	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-vscode.cpptools",
+		"ms-vscode.cpptools-extension-pack"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "gcc -v",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}


### PR DESCRIPTION
As mentioned in #463 

A devcontainer in the directory .devcontainer allows VSCode to launch and mount a docker container which you can work from.

This comes with all dependencies pre-installed, you'll just have to build the container once, the first time you open it (and every time it changes).

I've tested compilation, verona compiles in it.

```
[main] Building folder: verona verona
[build] Starting build
[proc] Executing command: /usr/bin/cmake --build /workspaces/verona/build --config Debug --target verona -j 18 --
[build] [1/2   0% :: 0.000] Re-checking globbed directories...
[build] [1/17   5% :: 0.120] Creating directories for 'external'
[build] [2/17  11% :: 0.159] No download step for 'external'
[build] [4/17  17% :: 0.200] No update step for 'external'
[build] [4/17  23% :: 0.205] No patch step for 'external'
[build] [5/17  23% :: 0.212] Performing configure step for 'external'
[build] -- The CXX compiler identification is GNU 9.3.0
[build] -- Check for working CXX compiler: /usr/bin/c++
[build] -- Check for working CXX compiler: /usr/bin/c++ -- works
[build] -- Detecting CXX compiler ABI info
[build] -- Detecting CXX compiler ABI info - done
[build] -- Detecting CXX compile features
[build] -- Detecting CXX compile features - done
[build] -- Install MLIR to /workspaces/verona/build/Debug/mlir
[build] -- Found Git: /usr/bin/git (found version "2.25.1") 
[build] -- Detected GIT commit: 9f33943ee01
[build] -- Configuring done
[build] -- Generating done
[build] -- Build files have been written to: /workspaces/verona/build/external-prefix/src/external-build
[build] [6/17  29% :: 3.854] Performing build step for 'external'
[build] [1/9  11% :: 0.126] Creating directories for 'mlir'
[build] [2/9  11% :: 0.131] Performing download step (download, verify and extract) for 'mlir'
[build] -- Downloading...
[build]    dst='/workspaces/verona/build/external-prefix/src/external-build/mlir-release/src/archive.tar'
[build]    timeout='none'
[build] -- Using src='https://verona.blob.core.windows.net/llvmbuild/verona-llvm-install-x86_64-linux-release-9f33943ee01'
[build] -- verifying file...
[build]        file='/workspaces/verona/build/external-prefix/src/external-build/mlir-release/src/archive.tar'
[build] -- Downloading... done
[build] -- extracting...
[build]      src='/workspaces/verona/build/external-prefix/src/external-build/mlir-release/src/archive.tar'
[build]      dst='/workspaces/verona/build/Debug/mlir'
[build] -- extracting... [tar xf]
[build] -- extracting... [analysis]
[build] -- extracting... [rename]
[build] -- extracting... [clean up]
[build] -- extracting... done
[build] [4/9  33% :: 274.393] No patch step for 'mlir'
[build] [4/9  44% :: 274.397] No update step for 'mlir'
[build] [5/9  55% :: 274.418] No configure step for 'mlir'
[build] [6/9  66% :: 274.437] No build step for 'mlir'
[build] [7/9  77% :: 274.459] No install step for 'mlir'
[build] [8/9  88% :: 274.479] No test step for 'mlir'
[build] [9/9 100% :: 274.508] Completed 'mlir'
[build] [7/17  41% :: 278.492] No install step for 'external'
[build] [8/17  47% :: 278.510] No test step for 'external'
[build] [9/17  52% :: 278.536] Completed 'external'
[build] [10/17  58% :: 278.602] Creating directories for 'verona'
[build] [11/17  64% :: 278.622] No download step for 'verona'
[build] [13/17  70% :: 278.639] No patch step for 'verona'
[build] [13/17  76% :: 278.641] No update step for 'verona'
[build] [14/17  76% :: 278.642] Performing configure step for 'verona'
[build] -- The CXX compiler identification is Clang 10.0.0
[build] -- Check for working CXX compiler: /bin/clang++-10
[build] -- Check for working CXX compiler: /bin/clang++-10 -- works
[build] -- Detecting CXX compiler ABI info
[build] -- Detecting CXX compiler ABI info - done
[build] -- Detecting CXX compile features
[build] -- Detecting CXX compile features - done
[build] -- Build Type for Verona Debug
[build] -- Build types Release;Debug;RelWithDebInfo
[build] -- Version: 6.2.0
[build] -- Build type: Debug
[build] -- CXX_STANDARD: 17
[build] -- Performing Test has_std_17_flag
[build] -- Performing Test has_std_17_flag - Success
[build] -- Performing Test has_std_1z_flag
[build] -- Performing Test has_std_1z_flag - Success
[build] -- Performing Test SUPPORTS_USER_DEFINED_LITERALS
[build] -- Performing Test SUPPORTS_USER_DEFINED_LITERALS - Success
[build] -- Performing Test FMT_HAS_VARIANT
[build] -- Performing Test FMT_HAS_VARIANT - Success
[build] -- Required features: cxx_variadic_templates
[build] -- Performing Test HAS_NULLPTR_WARNING
[build] -- Performing Test HAS_NULLPTR_WARNING - Success
[build] -- Looking for strtod_l
[build] -- Looking for strtod_l - found
[build] -- The C compiler identification is Clang 10.0.0
[build] -- Check for working C compiler: /bin/clang-10
[build] -- Check for working C compiler: /bin/clang-10 -- works
[build] -- Detecting C compiler ABI info
[build] -- Detecting C compiler ABI info - done
[build] -- Detecting C compile features
[build] -- Detecting C compile features - done
[build] -- Performing Test CONST_QUALIFIED_MALLOC_USABLE_SIZE
[build] -- Performing Test CONST_QUALIFIED_MALLOC_USABLE_SIZE - Failed
[build] -- Looking for pthread.h
[build] -- Looking for pthread.h - found
[build] -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
[build] -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
[build] -- Looking for pthread_create in pthreads
[build] -- Looking for pthread_create in pthreads - not found
[build] -- Looking for pthread_create in pthread
[build] -- Looking for pthread_create in pthread - found
[build] -- Found Threads: TRUE  
[build] -- Performing Test CXX_FILESYSTEM
[build] -- Performing Test CXX_FILESYSTEM - Success
[build] -- Looking for _LIBCPP_VERSION
[build] -- Looking for _LIBCPP_VERSION - not found
[build] -- Setting LLVM_DIR as /workspaces/verona/build/Debug/mlir/install/lib/cmake/llvm
[build] -- Setting MLIR_DIR as /workspaces/verona/build/Debug/mlir/install/lib/cmake/mlir
[build] -- Setting LLVM_EXTERNAL_LIT as /workspaces/verona/build/Debug/mlir/install/bin/llvm-lit
[build] -- Using MLIRConfig.cmake in: /workspaces/verona/build/Debug/mlir/install/lib/cmake/mlir
[build] -- Using LLVMConfig.cmake in: /workspaces/verona/build/Debug/mlir/install/lib/cmake/llvm
[build] -- Linker detection: GNU ld
[build] -- Performing Test LLVM_LIBSTDCXX_MIN
[build] -- Performing Test LLVM_LIBSTDCXX_MIN - Success
[build] -- Performing Test LLVM_LIBSTDCXX_SOFT_ERROR
[build] -- Performing Test LLVM_LIBSTDCXX_SOFT_ERROR - Success
[build] -- Performing Test C_SUPPORTS_FPIC
[build] -- Performing Test C_SUPPORTS_FPIC - Success
[build] -- Performing Test CXX_SUPPORTS_FPIC
[build] -- Performing Test CXX_SUPPORTS_FPIC - Success
[build] -- Building with -fPIC
[build] -- Performing Test SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG
[build] -- Performing Test SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG - Success
[build] -- Performing Test C_SUPPORTS_WERROR_DATE_TIME
[build] -- Performing Test C_SUPPORTS_WERROR_DATE_TIME - Success
[build] -- Performing Test CXX_SUPPORTS_WERROR_DATE_TIME
[build] -- Performing Test CXX_SUPPORTS_WERROR_DATE_TIME - Success
[build] -- Performing Test C_SUPPORTS_WERROR_UNGUARDED_AVAILABILITY_NEW
[build] -- Performing Test C_SUPPORTS_WERROR_UNGUARDED_AVAILABILITY_NEW - Success
[build] -- Performing Test CXX_SUPPORTS_WERROR_UNGUARDED_AVAILABILITY_NEW
[build] -- Performing Test CXX_SUPPORTS_WERROR_UNGUARDED_AVAILABILITY_NEW - Success
[build] -- Performing Test CXX_SUPPORTS_MISSING_FIELD_INITIALIZERS_FLAG
[build] -- Performing Test CXX_SUPPORTS_MISSING_FIELD_INITIALIZERS_FLAG - Success
[build] -- Performing Test C_SUPPORTS_IMPLICIT_FALLTHROUGH_FLAG
[build] -- Performing Test C_SUPPORTS_IMPLICIT_FALLTHROUGH_FLAG - Success
[build] -- Performing Test CXX_SUPPORTS_IMPLICIT_FALLTHROUGH_FLAG
[build] -- Performing Test CXX_SUPPORTS_IMPLICIT_FALLTHROUGH_FLAG - Success
[build] -- Performing Test C_SUPPORTS_COVERED_SWITCH_DEFAULT_FLAG
[build] -- Performing Test C_SUPPORTS_COVERED_SWITCH_DEFAULT_FLAG - Success
[build] -- Performing Test CXX_SUPPORTS_COVERED_SWITCH_DEFAULT_FLAG
[build] -- Performing Test CXX_SUPPORTS_COVERED_SWITCH_DEFAULT_FLAG - Success
[build] -- Performing Test CXX_SUPPORTS_CLASS_MEMACCESS_FLAG
[build] -- Performing Test CXX_SUPPORTS_CLASS_MEMACCESS_FLAG - Failed
[build] -- Performing Test CXX_SUPPORTS_NOEXCEPT_TYPE_FLAG
[build] -- Performing Test CXX_SUPPORTS_NOEXCEPT_TYPE_FLAG - Success
[build] -- Performing Test CXX_WONT_WARN_ON_FINAL_NONVIRTUALDTOR
[build] -- Performing Test CXX_WONT_WARN_ON_FINAL_NONVIRTUALDTOR - Success
[build] -- Performing Test C_SUPPORTS_DELETE_NON_VIRTUAL_DTOR_FLAG
[build] -- Performing Test C_SUPPORTS_DELETE_NON_VIRTUAL_DTOR_FLAG - Success
[build] -- Performing Test CXX_SUPPORTS_DELETE_NON_VIRTUAL_DTOR_FLAG
[build] -- Performing Test CXX_SUPPORTS_DELETE_NON_VIRTUAL_DTOR_FLAG - Success
[build] -- Performing Test CXX_SUPPORTS_SUGGEST_OVERRIDE_FLAG
[build] -- Performing Test CXX_SUPPORTS_SUGGEST_OVERRIDE_FLAG - Failed
[build] -- Performing Test C_WCOMMENT_ALLOWS_LINE_WRAP
[build] -- Performing Test C_WCOMMENT_ALLOWS_LINE_WRAP - Success
[build] -- Performing Test C_SUPPORTS_STRING_CONVERSION_FLAG
[build] -- Performing Test C_SUPPORTS_STRING_CONVERSION_FLAG - Success
[build] -- Performing Test CXX_SUPPORTS_STRING_CONVERSION_FLAG
[build] -- Performing Test CXX_SUPPORTS_STRING_CONVERSION_FLAG - Success
[build] -- Performing Test LINKER_SUPPORTS_COLOR_DIAGNOSTICS
[build] -- Performing Test LINKER_SUPPORTS_COLOR_DIAGNOSTICS - Failed
[build] -- Looking for os_signpost_interval_begin
[build] -- Looking for os_signpost_interval_begin - not found
[build] -- Setting Clang_DIR as /workspaces/verona/build/Debug/mlir/install/lib/cmake/clang
[build] -- Configuring done
[build] -- Generating done
[build] -- Build files have been written to: /workspaces/verona/build/verona-prefix/src/verona-build
[build] [15/17  82% :: 293.414] Performing build step for 'verona'
[build] [18/88   1% :: 0.686] Building CXX object parser/CMakeFiles/verona-parser-lib.dir/escaping.cc.o
[build] [19/88   2% :: 0.803] Building CXX object parser/CMakeFiles/verona-parser-lib.dir/lexer.cc.o
[build] [20/88   3% :: 0.846] Building CXX object parser/CMakeFiles/verona-parser-lib.dir/ast.cc.o
[build] [21/88   4% :: 1.028] Building CXX object parser/CMakeFiles/verona-parser-lib.dir/path.cc.o
[build] [22/88   5% :: 1.142] Building CXX object parser/CMakeFiles/verona-parser-lib.dir/source.cc.o
[build] [23/88   6% :: 1.237] Building CXX object external/fmt/CMakeFiles/fmt.dir/src/os.cc.o
[build] [24/88   7% :: 1.386] Building CXX object external/pegmatite/CMakeFiles/pegmatite-static.dir/ast.cc.o
[build] [25/88   9% :: 1.404] Building CXX object parser/CMakeFiles/verona-parser-lib.dir/lookup.cc.o
[build] [26/88  10% :: 1.572] Building CXX object parser/CMakeFiles/verona-parser-lib.dir/pretty.cc.o
[build] [27/88  11% :: 1.598] Building CXX object parser/CMakeFiles/verona-parser-lib.dir/rewrite.cc.o
[build] [28/88  12% :: 1.631] Building CXX object parser/CMakeFiles/verona-parser-lib.dir/print.cc.o
[build] [29/88  13% :: 1.837] Building CXX object parser/CMakeFiles/verona-parser-lib.dir/dnf.cc.o
[build] [30/88  14% :: 2.126] Building CXX object parser/CMakeFiles/verona-parser-lib.dir/resolve.cc.o
[build] [31/88  15% :: 2.404] Building CXX object parser/CMakeFiles/verona-parser-lib.dir/anf.cc.o
[build] [32/88  17% :: 3.342] Building CXX object compiler/CMakeFiles/veronac-lib.dir/codegen/generator.cc.o
[build] [33/88  18% :: 3.978] Building CXX object external/fmt/CMakeFiles/fmt.dir/src/format.cc.o
[build] [34/88  19% :: 4.893] Building CXX object parser/CMakeFiles/verona-parser.dir/main.cc.o
[build] [35/88  20% :: 5.199] Building CXX object compiler/CMakeFiles/veronac-lib.dir/codegen/descriptor.cc.o
[build] [36/88  21% :: 5.295] Building CXX object compiler/CMakeFiles/veronac-lib.dir/codegen/selector.cc.o
[build] [37/88  22% :: 5.516] Building CXX object parser/CMakeFiles/verona-parser-lib.dir/parser.cc.o
[build] [38/88  23% :: 6.595] Building CXX object compiler/CMakeFiles/veronac-lib.dir/codegen/builtins.cc.o
[build] [39/88  25% :: 6.701] Building CXX object compiler/CMakeFiles/veronac-lib.dir/ast.cc.o
[build] [40/88  26% :: 7.281] Building CXX object compiler/CMakeFiles/veronac-lib.dir/dataflow/liveness.cc.o
[build] [41/88  27% :: 7.465] Building CXX object external/pegmatite/CMakeFiles/pegmatite-static.dir/parser.cc.o
[build] /workspaces/verona/external/pegmatite/parser.cc:1657:9: warning: parameter 'r' not found in the function declaration [-Wdocumentation]
[build]         @param r rule.
[build]                ^
[build] /workspaces/verona/external/pegmatite/parser.cc:1657:9: note: did you mean 's'?
[build]         @param r rule.
[build]                ^
[build]                s
[build] /workspaces/verona/external/pegmatite/parser.cc:1785:9: warning: parameter 'el' not found in the function declaration [-Wdocumentation]
[build]         @param el list of errors.
[build]                ^~
[build] 2 warnings generated.
[build] [42/88  28% :: 7.769] Linking CXX static library external/fmt/libfmtd.a
[build] [43/88  29% :: 7.919] Building CXX object compiler/CMakeFiles/veronac-lib.dir/fixpoint.cc.o
[build] [44/88  30% :: 8.300] Building CXX object compiler/CMakeFiles/veronac-lib.dir/context.cc.o
[build] [45/88  31% :: 8.830] Building CXX object compiler/CMakeFiles/veronac-lib.dir/elaboration.cc.o
[build] [46/88  32% :: 8.938] Building CXX object compiler/CMakeFiles/veronac-lib.dir/codegen/codegen.cc.o
[build] [47/88  34% :: 9.779] Building CXX object compiler/CMakeFiles/veronac-lib.dir/ir/dominance.cc.o
[build] [48/88  35% :: 9.866] Building CXX object compiler/CMakeFiles/veronac-lib.dir/instantiation.cc.o
[build] [49/88  36% :: 11.222] Building CXX object compiler/CMakeFiles/veronac-lib.dir/codegen/function.cc.o
[build] [50/88  37% :: 11.739] Building CXX object compiler/CMakeFiles/veronac-lib.dir/ir/ir.cc.o
[build] [51/88  38% :: 12.386] Building CXX object compiler/CMakeFiles/veronac-lib.dir/analysis.cc.o
[build] [52/88  39% :: 12.552] Building CXX object compiler/CMakeFiles/veronac-lib.dir/ir/point.cc.o
[build] [53/88  40% :: 12.672] Building CXX object compiler/CMakeFiles/veronac-lib.dir/codegen/reachability.cc.o
[build] [54/88  42% :: 13.569] Building CXX object compiler/CMakeFiles/veronac-lib.dir/mapper.cc.o
[build] [55/88  43% :: 13.908] Building CXX object compiler/CMakeFiles/veronac-lib.dir/ir/variable_renaming.cc.o
[build] [56/88  44% :: 14.573] Building CXX object compiler/CMakeFiles/veronac-lib.dir/type.cc.o
[build] [57/88  45% :: 16.414] Building CXX object compiler/CMakeFiles/veronac-lib.dir/polarize.cc.o
[build] [58/88  46% :: 16.564] Building CXX object compiler/CMakeFiles/veronac-lib.dir/ir/print.cc.o
[build] [59/88  47% :: 16.992] Linking CXX static library external/pegmatite/libpegmatite.a
[build] [60/88  48% :: 17.473] Building CXX object compiler/CMakeFiles/veronac-lib.dir/typecheck/capability_predicate.cc.o
[build] [61/88  50% :: 17.581] Building CXX object compiler/CMakeFiles/veronac-lib.dir/ir/builder.cc.o
[build] [62/88  51% :: 17.731] Building CXX object compiler/CMakeFiles/veronac-lib.dir/intern.cc.o
[build] [63/88  52% :: 18.416] Building CXX object compiler/CMakeFiles/veronac.dir/main.cc.o
[build] [64/88  53% :: 18.631] Building CXX object compiler/CMakeFiles/veronac-sys.dir/main.cc.o
[build] [65/88  54% :: 19.241] Building CXX object compiler/CMakeFiles/veronac-lib.dir/typecheck/assertion.cc.o
[build] [66/88  55% :: 19.314] Building CXX object compiler/CMakeFiles/veronac-lib.dir/regionck/region_graph.cc.o
[build] [67/88  56% :: 20.172] Building CXX object compiler/CMakeFiles/veronac-lib.dir/resolution.cc.o
[build] [68/88  57% :: 20.454] Building CXX object interpreter/CMakeFiles/interpreter-sys.dir/bytecode.cc.o
[build] [69/88  59% :: 20.619] Building CXX object compiler/CMakeFiles/veronac-lib.dir/printing.cc.o
[build] [70/88  60% :: 20.936] Building CXX object compiler/CMakeFiles/veronac-lib.dir/typecheck/constraint.cc.o
[build] [71/88  61% :: 21.514] Building CXX object compiler/CMakeFiles/veronac-lib.dir/parser.cc.o
[build] [72/88  62% :: 21.978] Building CXX object compiler/CMakeFiles/veronac-lib.dir/typecheck/permission_check.cc.o
[build] [73/88  63% :: 22.310] Building CXX object compiler/CMakeFiles/veronac-lib.dir/typecheck/solver.cc.o
[build] [74/88  64% :: 23.239] Building CXX object compiler/CMakeFiles/veronac-lib.dir/typecheck/structural.cc.o
[build] [75/88  65% :: 23.386] Building CXX object interpreter/CMakeFiles/interpreter.dir/bytecode.cc.o
[build] [76/88  67% :: 24.083] Building CXX object interpreter/CMakeFiles/interpreter-sys.dir/object.cc.o
[build] [77/88  68% :: 24.796] Building CXX object compiler/CMakeFiles/veronac-lib.dir/typecheck/infer.cc.o
[build] [78/88  69% :: 25.062] Building CXX object compiler/CMakeFiles/veronac-lib.dir/typecheck/wf_types.cc.o
[build] [78/88  70% :: 25.391] Building CXX object mlir/CMakeFiles/verona-mlir.dir/error.cc.o
[build] [78/88  71% :: 25.552] Building CXX object compiler/CMakeFiles/veronac-lib.dir/typecheck/typecheck.cc.o
[build] [79/88  72% :: 25.702] Building CXX object interpreter/CMakeFiles/interpreter.dir/object.cc.o
[build] [79/88  73% :: 25.971] Building CXX object interpreter/CMakeFiles/interpreter-sys.dir/value.cc.o
[build] [79/88  75% :: 26.680] Building CXX object interpreter/CMakeFiles/interpreter-bin.dir/main.cc.o
[build] [79/88  76% :: 26.715] Building CXX object interpreter/CMakeFiles/interpreter-sys-bin.dir/main.cc.o
[build] [79/88  77% :: 27.194] Building CXX object interpreter/CMakeFiles/interpreter.dir/value.cc.o
[build] [79/88  78% :: 27.983] Building CXX object interpreter/CMakeFiles/interpreter-sys.dir/interpreter.cc.o
[build] [79/88  79% :: 28.563] Linking CXX static library parser/libverona-parser-lib.a
[build] [80/88  80% :: 28.935] Building CXX object interpreter/CMakeFiles/interpreter-sys.dir/vm.cc.o
[build] [81/88  81% :: 29.121] Building CXX object interpreter/CMakeFiles/interpreter.dir/interpreter.cc.o
[build] [81/88  82% :: 29.520] Building CXX object mlir/CMakeFiles/verona-mlir.dir/generator.cc.o
[build] [81/88  84% :: 30.057] Building CXX object mlir/CMakeFiles/verona-mlir.dir/consumer.cc.o
[build] [81/88  85% :: 30.096] Building CXX object interpreter/CMakeFiles/interpreter.dir/vm.cc.o
[build] [82/88  86% :: 31.225] Building CXX object mlir/CMakeFiles/verona-mlir.dir/driver.cc.o
[build] [82/88  87% :: 34.384] Building CXX object mlir/CMakeFiles/verona-mlir.dir/verona-mlir.cc.o
[build] [83/88  88% :: 38.872] Building CXX object interop/CMakeFiles/verona-interop.dir/verona-interop.cc.o
[build] [84/88  89% :: 42.232] Linking CXX static library interpreter/libinterpreter-sys.a
[build] [85/88  90% :: 43.131] Linking CXX static library interpreter/libinterpreter.a
[build] [86/88  92% :: 45.036] Linking CXX executable parser/verona-parser
[build] [86/88  93% :: 57.432] Linking CXX executable interpreter/interpreter-sys
[build] [86/88  94% :: 58.023] Linking CXX executable interpreter/interpreter
[build] [86/88  95% :: 115.098] Linking CXX static library compiler/libveronac-lib.a
[build] [88/88  96% :: 142.395] Linking CXX executable bin/verona-interop
[build] [88/88  97% :: 177.136] Linking CXX executable compiler/veronac
[build] [88/88  98% :: 177.277] Linking CXX executable compiler/veronac-sys
[build] [88/88 100% :: 181.467] Linking CXX executable bin/verona-mlir
[build] [16/17  88% :: 475.426] Performing install step for 'verona'
[build] [18/89   1% :: 0.547] Building CXX object parser/CMakeFiles/verona-parser-lib.dir/escaping.cc.o
[build] [19/89   2% :: 0.705] Building CXX object parser/CMakeFiles/verona-parser-lib.dir/ast.cc.o
[build] [20/89   3% :: 0.755] Building CXX object parser/CMakeFiles/verona-parser-lib.dir/lexer.cc.o
[build] [21/89   4% :: 0.800] Building CXX object parser/CMakeFiles/verona-parser-lib.dir/path.cc.o
[build] [22/89   5% :: 1.058] Building CXX object parser/CMakeFiles/verona-parser-lib.dir/source.cc.o
[build] [23/89   6% :: 1.173] Building CXX object external/fmt/CMakeFiles/fmt.dir/src/os.cc.o
[build] [24/89   7% :: 1.206] Building CXX object external/pegmatite/CMakeFiles/pegmatite-static.dir/ast.cc.o
[build] [25/89   8% :: 1.341] Building CXX object parser/CMakeFiles/verona-parser-lib.dir/lookup.cc.o
[build] [26/89  10% :: 1.435] Building CXX object parser/CMakeFiles/verona-parser-lib.dir/rewrite.cc.o
[build] [27/89  11% :: 1.462] Building CXX object parser/CMakeFiles/verona-parser-lib.dir/print.cc.o
[build] [28/89  12% :: 1.476] Building CXX object parser/CMakeFiles/verona-parser-lib.dir/pretty.cc.o
[build] [29/89  13% :: 1.773] Building CXX object parser/CMakeFiles/verona-parser-lib.dir/dnf.cc.o
[build] [30/89  14% :: 2.052] Building CXX object parser/CMakeFiles/verona-parser-lib.dir/resolve.cc.o
[build] [31/89  15% :: 2.446] Building CXX object parser/CMakeFiles/verona-parser-lib.dir/anf.cc.o
[build] [32/89  16% :: 3.237] Building CXX object compiler/CMakeFiles/veronac-lib.dir/codegen/generator.cc.o
[build] [33/89  17% :: 3.690] Building CXX object external/fmt/CMakeFiles/fmt.dir/src/format.cc.o
[build] [34/89  19% :: 4.853] Building CXX object compiler/CMakeFiles/veronac-lib.dir/codegen/selector.cc.o
[build] [35/89  20% :: 4.897] Building CXX object compiler/CMakeFiles/veronac-lib.dir/codegen/descriptor.cc.o
[build] [36/89  21% :: 4.997] Building CXX object parser/CMakeFiles/verona-parser.dir/main.cc.o
[build] [37/89  22% :: 5.465] Building CXX object parser/CMakeFiles/verona-parser-lib.dir/parser.cc.o
[build] [38/89  23% :: 6.403] Building CXX object compiler/CMakeFiles/veronac-lib.dir/codegen/builtins.cc.o
[build] [39/89  24% :: 6.555] Building CXX object compiler/CMakeFiles/veronac-lib.dir/ast.cc.o
[build] [40/89  25% :: 6.959] Building CXX object external/pegmatite/CMakeFiles/pegmatite-static.dir/parser.cc.o
[build] /workspaces/verona/external/pegmatite/parser.cc:1657:9: warning: parameter 'r' not found in the function declaration [-Wdocumentation]
[build]         @param r rule.
[build]                ^
[build] /workspaces/verona/external/pegmatite/parser.cc:1657:9: note: did you mean 's'?
[build]         @param r rule.
[build]                ^
[build]                s
[build] /workspaces/verona/external/pegmatite/parser.cc:1785:9: warning: parameter 'el' not found in the function declaration [-Wdocumentation]
[build]         @param el list of errors.
[build]                ^~
[build] 2 warnings generated.
[build] [41/89  26% :: 7.023] Building CXX object compiler/CMakeFiles/veronac-lib.dir/dataflow/liveness.cc.o
[build] [42/89  28% :: 7.296] Linking CXX static library external/fmt/libfmtd.a
[build] [43/89  29% :: 7.597] Building CXX object compiler/CMakeFiles/veronac-lib.dir/fixpoint.cc.o
[build] [44/89  30% :: 8.332] Building CXX object compiler/CMakeFiles/veronac-lib.dir/context.cc.o
[build] [45/89  31% :: 9.056] Building CXX object compiler/CMakeFiles/veronac-lib.dir/codegen/codegen.cc.o
[build] [46/89  32% :: 9.101] Building CXX object compiler/CMakeFiles/veronac-lib.dir/elaboration.cc.o
[build] [47/89  33% :: 9.464] Building CXX object compiler/CMakeFiles/veronac-lib.dir/ir/dominance.cc.o
[build] [48/89  34% :: 9.542] Building CXX object compiler/CMakeFiles/veronac-lib.dir/instantiation.cc.o
[build] [49/89  35% :: 11.385] Building CXX object compiler/CMakeFiles/veronac-lib.dir/codegen/function.cc.o
[build] [50/89  37% :: 11.608] Building CXX object compiler/CMakeFiles/veronac-lib.dir/ir/ir.cc.o
[build] [51/89  38% :: 12.350] Building CXX object compiler/CMakeFiles/veronac-lib.dir/analysis.cc.o
[build] [52/89  39% :: 12.388] Building CXX object compiler/CMakeFiles/veronac-lib.dir/ir/point.cc.o
[build] [53/89  40% :: 12.712] Building CXX object compiler/CMakeFiles/veronac-lib.dir/codegen/reachability.cc.o
[build] [54/89  41% :: 13.294] Building CXX object compiler/CMakeFiles/veronac-lib.dir/ir/variable_renaming.cc.o
[build] [55/89  42% :: 13.457] Building CXX object compiler/CMakeFiles/veronac-lib.dir/mapper.cc.o
[build] [56/89  43% :: 14.324] Building CXX object compiler/CMakeFiles/veronac-lib.dir/type.cc.o
[build] [57/89  44% :: 16.024] Building CXX object compiler/CMakeFiles/veronac-lib.dir/ir/print.cc.o
[build] [58/89  46% :: 16.076] Linking CXX static library external/pegmatite/libpegmatite.a
[build] [59/89  47% :: 16.478] Building CXX object compiler/CMakeFiles/veronac-lib.dir/polarize.cc.o
[build] [60/89  48% :: 17.046] Building CXX object compiler/CMakeFiles/veronac-lib.dir/typecheck/capability_predicate.cc.o
[build] [61/89  49% :: 17.062] Building CXX object compiler/CMakeFiles/veronac-lib.dir/ir/builder.cc.o
[build] [62/89  50% :: 17.665] Building CXX object compiler/CMakeFiles/veronac-lib.dir/intern.cc.o
[build] [63/89  51% :: 17.839] Building CXX object compiler/CMakeFiles/veronac.dir/main.cc.o
[build] [64/89  52% :: 18.053] Building CXX object compiler/CMakeFiles/veronac-sys.dir/main.cc.o
[build] [65/89  53% :: 18.761] Building CXX object compiler/CMakeFiles/veronac-lib.dir/regionck/region_graph.cc.o
[build] [66/89  55% :: 18.846] Building CXX object compiler/CMakeFiles/veronac-lib.dir/typecheck/assertion.cc.o
[build] [67/89  56% :: 20.038] Building CXX object compiler/CMakeFiles/veronac-lib.dir/resolution.cc.o
[build] [68/89  57% :: 20.076] Building CXX object compiler/CMakeFiles/veronac-lib.dir/printing.cc.o
[build] [69/89  58% :: 20.436] Building CXX object interpreter/CMakeFiles/interpreter-sys.dir/bytecode.cc.o
[build] [70/89  59% :: 20.847] Building CXX object compiler/CMakeFiles/veronac-lib.dir/typecheck/constraint.cc.o
[build] [71/89  60% :: 21.260] Building CXX object compiler/CMakeFiles/veronac-lib.dir/typecheck/permission_check.cc.o
[build] [72/89  61% :: 21.431] Building CXX object compiler/CMakeFiles/veronac-lib.dir/parser.cc.o
[build] [73/89  62% :: 21.616] Building CXX object compiler/CMakeFiles/veronac-lib.dir/typecheck/solver.cc.o
[build] [74/89  64% :: 22.179] Building CXX object compiler/CMakeFiles/veronac-lib.dir/typecheck/structural.cc.o
[build] [75/89  65% :: 22.823] Building CXX object interpreter/CMakeFiles/interpreter.dir/bytecode.cc.o
[build] [76/89  66% :: 22.979] Building CXX object interpreter/CMakeFiles/interpreter-sys.dir/object.cc.o
[build] [77/89  67% :: 23.572] Building CXX object compiler/CMakeFiles/veronac-lib.dir/typecheck/infer.cc.o
[build] [78/89  68% :: 24.078] Building CXX object compiler/CMakeFiles/veronac-lib.dir/typecheck/wf_types.cc.o
[build] [78/89  69% :: 24.325] Building CXX object mlir/CMakeFiles/verona-mlir.dir/error.cc.o
[build] [78/89  70% :: 24.605] Building CXX object compiler/CMakeFiles/veronac-lib.dir/typecheck/typecheck.cc.o
[build] [79/89  71% :: 25.016] Building CXX object interpreter/CMakeFiles/interpreter.dir/object.cc.o
[build] [79/89  73% :: 25.069] Building CXX object interpreter/CMakeFiles/interpreter-sys.dir/value.cc.o
[build] [79/89  74% :: 25.803] Building CXX object interpreter/CMakeFiles/interpreter-sys-bin.dir/main.cc.o
[build] [79/89  75% :: 25.826] Building CXX object interpreter/CMakeFiles/interpreter-bin.dir/main.cc.o
[build] [79/89  76% :: 26.461] Building CXX object interpreter/CMakeFiles/interpreter.dir/value.cc.o
[build] [79/89  77% :: 27.022] Building CXX object interpreter/CMakeFiles/interpreter-sys.dir/interpreter.cc.o
[build] [79/89  78% :: 27.161] Linking CXX static library parser/libverona-parser-lib.a
[build] [80/89  79% :: 27.974] Building CXX object interpreter/CMakeFiles/interpreter-sys.dir/vm.cc.o
[build] [81/89  80% :: 28.175] Building CXX object interpreter/CMakeFiles/interpreter.dir/interpreter.cc.o
[build] [81/89  82% :: 28.778] Building CXX object mlir/CMakeFiles/verona-mlir.dir/generator.cc.o
[build] [81/89  83% :: 29.161] Building CXX object mlir/CMakeFiles/verona-mlir.dir/consumer.cc.o
[build] [81/89  84% :: 29.386] Building CXX object interpreter/CMakeFiles/interpreter.dir/vm.cc.o
[build] [82/89  85% :: 30.361] Building CXX object mlir/CMakeFiles/verona-mlir.dir/driver.cc.o
[build] [82/89  86% :: 33.256] Building CXX object mlir/CMakeFiles/verona-mlir.dir/verona-mlir.cc.o
[build] [83/89  87% :: 37.698] Building CXX object interop/CMakeFiles/verona-interop.dir/verona-interop.cc.o
[build] [84/89  88% :: 40.694] Linking CXX static library interpreter/libinterpreter-sys.a
[build] [85/89  89% :: 41.905] Linking CXX static library interpreter/libinterpreter.a
[build] [86/89  91% :: 43.091] Linking CXX executable parser/verona-parser
[build] [86/89  92% :: 55.745] Linking CXX executable interpreter/interpreter-sys
[build] [86/89  93% :: 56.513] Linking CXX executable interpreter/interpreter
[build] [86/89  94% :: 112.574] Linking CXX static library compiler/libveronac-lib.a
[build] [88/89  95% :: 139.958] Linking CXX executable bin/verona-interop
[build] [88/89  96% :: 174.800] Linking CXX executable compiler/veronac
[build] [88/89  97% :: 174.919] Linking CXX executable compiler/veronac-sys
[build] [88/89  98% :: 179.119] Linking CXX executable bin/verona-mlir
[build] [89/89  98% :: 179.120] Install the project...
[build] -- Install configuration: "Debug"
[build] -- Installing: /workspaces/verona/build/dist/stdlib
[build] -- Installing: /workspaces/verona/build/dist/stdlib/boolean
[build] -- Installing: /workspaces/verona/build/dist/stdlib/boolean/boolean.verona
[build] -- Installing: /workspaces/verona/build/dist/stdlib/boolean/compare.verona
[build] -- Installing: /workspaces/verona/build/dist/stdlib/builtin.verona
[build] -- Installing: /workspaces/verona/build/dist/stdlib/controlflow
[build] -- Installing: /workspaces/verona/build/dist/stdlib/controlflow/bind.verona
[build] -- Installing: /workspaces/verona/build/dist/stdlib/controlflow/conditional.verona
[build] -- Installing: /workspaces/verona/build/dist/stdlib/controlflow/controlflow.verona
[build] -- Installing: /workspaces/verona/build/dist/stdlib/controlflow/loop.verona
[build] -- Installing: /workspaces/verona/build/dist/stdlib/controlflow/match.verona
[build] -- Installing: /workspaces/verona/build/dist/stdlib/controlflow/return.verona
[build] -- Installing: /workspaces/verona/build/dist/stdlib/iterators
[build] -- Installing: /workspaces/verona/build/dist/stdlib/iterators/for.verona
[build] -- Installing: /workspaces/verona/build/dist/stdlib/iterators/iterator.verona
[build] -- Installing: /workspaces/verona/build/dist/stdlib/iterators/option.verona
[build] -- Installing: /workspaces/verona/build/dist/stdlib/numbers
[build] -- Installing: /workspaces/verona/build/dist/stdlib/numbers/numbers.verona
[build] -- Installing: /workspaces/verona/build/dist/stdlib/sequence
[build] -- Installing: /workspaces/verona/build/dist/stdlib/sequence/array.verona
[build] -- Installing: /workspaces/verona/build/dist/stdlib/variadic
[build] -- Installing: /workspaces/verona/build/dist/stdlib/variadic/length.verona
[build] -- Installing: /workspaces/verona/build/dist/./verona-parser
[build] -- Installing: /workspaces/verona/build/dist/./veronac
[build] -- Installing: /workspaces/verona/build/dist/./veronac-sys
[build] -- Installing: /workspaces/verona/build/dist/./interpreter
[build] -- Installing: /workspaces/verona/build/dist/./interpreter-sys
[build] -- Installing: /workspaces/verona/build/dist/./verona-mlir
[build] -- Installing: /workspaces/verona/build/dist/./verona-interop
[build] [17/17 100% :: 669.500] Completed 'verona'
[build] Build finished with exit code 0
```