### PR TITLE
Upgrade LLVM to a19747ea739

### DIFF
--- a/src/interop/CXXBuilder.h
+++ b/src/interop/CXXBuilder.h
@@ -125,7 +125,7 @@ namespace verona::interop
         clang::CK_FunctionToPointerDecay,
         expr,
         /*base path=*/nullptr,
-        clang::VK_RValue,
+        clang::VK_PRValue,
         clang::FPOptionsOverride());
 
       return implCast;
@@ -151,7 +151,7 @@ namespace verona::interop
           expr,
           args,
           retTy,
-          clang::VK_RValue,
+          clang::VK_PRValue,
           loc,
           clang::FPOptionsOverride());
       }
@@ -165,7 +165,7 @@ namespace verona::interop
           expr,
           args,
           retTy,
-          clang::VK_RValue,
+          clang::VK_PRValue,
           loc,
           clang::FPOptionsOverride());
       }
@@ -335,7 +335,7 @@ namespace verona::interop
           clang::CK_LValueToRValue,
           e,
           /*base path=*/nullptr,
-          clang::VK_RValue,
+          clang::VK_PRValue,
           clang::FPOptionsOverride());
 
         argExpr.push_back(cast);

--- a/src/mlir/verona-mlir.cc
+++ b/src/mlir/verona-mlir.cc
@@ -10,6 +10,7 @@
 #include "parser/resolve.h"
 
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/Path.h"
 

--- a/testsuite/verona-mlir/arithmetic.out/stdout.txt
+++ b/testsuite/verona-mlir/arithmetic.out/stdout.txt
@@ -1,5 +1,5 @@
-module  {
-  func @"$module-0__I32__+"(%arg0: i32, %arg1: i32) -> i32 {
+builtin.module  {
+  builtin.func @"$module-0__I32__+"(%arg0: i32, %arg1: i32) -> i32 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i32 : (i32) -> !llvm.ptr<i32>
     %1 = llvm.mlir.addressof @std.addi : !llvm.ptr<array<8 x i8>>
@@ -20,7 +20,7 @@ module  {
     %12 = llvm.load %11 : !llvm.ptr<i32>
     return %12 : i32
   }
-  func @"$module-0__I32__-"(%arg0: i32, %arg1: i32) -> i32 {
+  builtin.func @"$module-0__I32__-"(%arg0: i32, %arg1: i32) -> i32 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i32 : (i32) -> !llvm.ptr<i32>
     %1 = llvm.mlir.addressof @std.subi : !llvm.ptr<array<8 x i8>>
@@ -41,7 +41,7 @@ module  {
     %12 = llvm.load %11 : !llvm.ptr<i32>
     return %12 : i32
   }
-  func @"$module-0__I32__*"(%arg0: i32, %arg1: i32) -> i32 {
+  builtin.func @"$module-0__I32__*"(%arg0: i32, %arg1: i32) -> i32 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i32 : (i32) -> !llvm.ptr<i32>
     %1 = llvm.mlir.addressof @std.muli : !llvm.ptr<array<8 x i8>>
@@ -62,7 +62,7 @@ module  {
     %12 = llvm.load %11 : !llvm.ptr<i32>
     return %12 : i32
   }
-  func @"$module-0__I32__/"(%arg0: i32, %arg1: i32) -> i32 {
+  builtin.func @"$module-0__I32__/"(%arg0: i32, %arg1: i32) -> i32 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i32 : (i32) -> !llvm.ptr<i32>
     %1 = llvm.mlir.addressof @std.divi_signed : !llvm.ptr<array<15 x i8>>
@@ -83,7 +83,7 @@ module  {
     %12 = llvm.load %11 : !llvm.ptr<i32>
     return %12 : i32
   }
-  func @"$module-0__I32__ext"(%arg0: i32) -> i64 {
+  builtin.func @"$module-0__I32__ext"(%arg0: i32) -> i64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
     %1 = llvm.mlir.addressof @std.sexti : !llvm.ptr<array<9 x i8>>
@@ -95,7 +95,7 @@ module  {
     %5 = llvm.load %4 : !llvm.ptr<i64>
     return %5 : i64
   }
-  func @"$module-0__U32__+"(%arg0: i32, %arg1: i32) -> i32 {
+  builtin.func @"$module-0__U32__+"(%arg0: i32, %arg1: i32) -> i32 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i32 : (i32) -> !llvm.ptr<i32>
     %1 = llvm.mlir.addressof @std.addi : !llvm.ptr<array<8 x i8>>
@@ -116,7 +116,7 @@ module  {
     %12 = llvm.load %11 : !llvm.ptr<i32>
     return %12 : i32
   }
-  func @"$module-0__U32__ext"(%arg0: i32) -> i64 {
+  builtin.func @"$module-0__U32__ext"(%arg0: i32) -> i64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
     %1 = llvm.mlir.addressof @std.zexti : !llvm.ptr<array<9 x i8>>
@@ -128,7 +128,7 @@ module  {
     %5 = llvm.load %4 : !llvm.ptr<i64>
     return %5 : i64
   }
-  func @"$module-0__I64__+"(%arg0: i64, %arg1: i64) -> i64 {
+  builtin.func @"$module-0__I64__+"(%arg0: i64, %arg1: i64) -> i64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
     %1 = llvm.mlir.addressof @std.addi : !llvm.ptr<array<8 x i8>>
@@ -149,7 +149,7 @@ module  {
     %12 = llvm.load %11 : !llvm.ptr<i64>
     return %12 : i64
   }
-  func @"$module-0__I64__trunc"(%arg0: i64) -> i32 {
+  builtin.func @"$module-0__I64__trunc"(%arg0: i64) -> i32 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i32 : (i32) -> !llvm.ptr<i32>
     %1 = llvm.mlir.addressof @std.trunci : !llvm.ptr<array<10 x i8>>
@@ -161,7 +161,7 @@ module  {
     %5 = llvm.load %4 : !llvm.ptr<i32>
     return %5 : i32
   }
-  func @"$module-0__I64__toFloat"(%arg0: i64) -> f32 {
+  builtin.func @"$module-0__I64__toFloat"(%arg0: i64) -> f32 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x f32 : (i32) -> !llvm.ptr<f32>
     %1 = llvm.mlir.addressof @std.sitofp : !llvm.ptr<array<10 x i8>>
@@ -173,7 +173,7 @@ module  {
     %5 = llvm.load %4 : !llvm.ptr<f32>
     return %5 : f32
   }
-  func @"$module-0__I64__toDouble"(%arg0: i64) -> f64 {
+  builtin.func @"$module-0__I64__toDouble"(%arg0: i64) -> f64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
     %1 = llvm.mlir.addressof @std.sitofp : !llvm.ptr<array<10 x i8>>
@@ -185,7 +185,7 @@ module  {
     %5 = llvm.load %4 : !llvm.ptr<f64>
     return %5 : f64
   }
-  func @"$module-0__U64__+"(%arg0: i64, %arg1: i64) -> i64 {
+  builtin.func @"$module-0__U64__+"(%arg0: i64, %arg1: i64) -> i64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
     %1 = llvm.mlir.addressof @std.addi : !llvm.ptr<array<8 x i8>>
@@ -206,7 +206,7 @@ module  {
     %12 = llvm.load %11 : !llvm.ptr<i64>
     return %12 : i64
   }
-  func @"$module-0__U64__trunc"(%arg0: i64) -> i32 {
+  builtin.func @"$module-0__U64__trunc"(%arg0: i64) -> i32 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i32 : (i32) -> !llvm.ptr<i32>
     %1 = llvm.mlir.addressof @std.trunci : !llvm.ptr<array<10 x i8>>
@@ -218,7 +218,7 @@ module  {
     %5 = llvm.load %4 : !llvm.ptr<i32>
     return %5 : i32
   }
-  func @"$module-0__U64__toFloat"(%arg0: i64) -> f32 {
+  builtin.func @"$module-0__U64__toFloat"(%arg0: i64) -> f32 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x f32 : (i32) -> !llvm.ptr<f32>
     %1 = llvm.mlir.addressof @std.uitofp : !llvm.ptr<array<10 x i8>>
@@ -230,7 +230,7 @@ module  {
     %5 = llvm.load %4 : !llvm.ptr<f32>
     return %5 : f32
   }
-  func @"$module-0__U64__toDouble"(%arg0: i64) -> f64 {
+  builtin.func @"$module-0__U64__toDouble"(%arg0: i64) -> f64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
     %1 = llvm.mlir.addressof @std.uitofp : !llvm.ptr<array<10 x i8>>
@@ -242,7 +242,7 @@ module  {
     %5 = llvm.load %4 : !llvm.ptr<f64>
     return %5 : f64
   }
-  func @"$module-0__F32__+"(%arg0: f32, %arg1: f32) -> f32 {
+  builtin.func @"$module-0__F32__+"(%arg0: f32, %arg1: f32) -> f32 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x f32 : (i32) -> !llvm.ptr<f32>
     %1 = llvm.mlir.addressof @std.addf : !llvm.ptr<array<8 x i8>>
@@ -263,7 +263,7 @@ module  {
     %12 = llvm.load %11 : !llvm.ptr<f32>
     return %12 : f32
   }
-  func @"$module-0__F32__-"(%arg0: f32, %arg1: f32) -> f32 {
+  builtin.func @"$module-0__F32__-"(%arg0: f32, %arg1: f32) -> f32 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x f32 : (i32) -> !llvm.ptr<f32>
     %1 = llvm.mlir.addressof @std.subf : !llvm.ptr<array<8 x i8>>
@@ -284,7 +284,7 @@ module  {
     %12 = llvm.load %11 : !llvm.ptr<f32>
     return %12 : f32
   }
-  func @"$module-0__F32__*"(%arg0: f32, %arg1: f32) -> f32 {
+  builtin.func @"$module-0__F32__*"(%arg0: f32, %arg1: f32) -> f32 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x f32 : (i32) -> !llvm.ptr<f32>
     %1 = llvm.mlir.addressof @std.mulf : !llvm.ptr<array<8 x i8>>
@@ -305,7 +305,7 @@ module  {
     %12 = llvm.load %11 : !llvm.ptr<f32>
     return %12 : f32
   }
-  func @"$module-0__F32__/"(%arg0: f32, %arg1: f32) -> f32 {
+  builtin.func @"$module-0__F32__/"(%arg0: f32, %arg1: f32) -> f32 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x f32 : (i32) -> !llvm.ptr<f32>
     %1 = llvm.mlir.addressof @std.divf : !llvm.ptr<array<8 x i8>>
@@ -326,7 +326,7 @@ module  {
     %12 = llvm.load %11 : !llvm.ptr<f32>
     return %12 : f32
   }
-  func @"$module-0__F32__ext"(%arg0: f32) -> f64 {
+  builtin.func @"$module-0__F32__ext"(%arg0: f32) -> f64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
     %1 = llvm.mlir.addressof @std.fpext : !llvm.ptr<array<9 x i8>>
@@ -338,7 +338,7 @@ module  {
     %5 = llvm.load %4 : !llvm.ptr<f64>
     return %5 : f64
   }
-  func @"$module-0__F64__+"(%arg0: f64, %arg1: f64) -> f64 {
+  builtin.func @"$module-0__F64__+"(%arg0: f64, %arg1: f64) -> f64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
     %1 = llvm.mlir.addressof @std.addf : !llvm.ptr<array<8 x i8>>
@@ -359,7 +359,7 @@ module  {
     %12 = llvm.load %11 : !llvm.ptr<f64>
     return %12 : f64
   }
-  func @"$module-0__F64__trunc"(%arg0: f64) -> f32 {
+  builtin.func @"$module-0__F64__trunc"(%arg0: f64) -> f32 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x f32 : (i32) -> !llvm.ptr<f32>
     %1 = llvm.mlir.addressof @std.fptrunc : !llvm.ptr<array<11 x i8>>
@@ -371,7 +371,7 @@ module  {
     %5 = llvm.load %4 : !llvm.ptr<f32>
     return %5 : f32
   }
-  func @"$module-0__F64__toInt"(%arg0: f64) -> i64 {
+  builtin.func @"$module-0__F64__toInt"(%arg0: f64) -> i64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
     %1 = llvm.mlir.addressof @std.fptosi : !llvm.ptr<array<10 x i8>>
@@ -383,7 +383,7 @@ module  {
     %5 = llvm.load %4 : !llvm.ptr<i64>
     return %5 : i64
   }
-  func @"$module-0__F64__toUInt"(%arg0: f64) -> i64 {
+  builtin.func @"$module-0__F64__toUInt"(%arg0: f64) -> i64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
     %1 = llvm.mlir.addressof @std.fptoui : !llvm.ptr<array<10 x i8>>
@@ -395,7 +395,7 @@ module  {
     %5 = llvm.load %4 : !llvm.ptr<i64>
     return %5 : i64
   }
-  func @"$module-0__F64__neg"(%arg0: f64) -> f64 {
+  builtin.func @"$module-0__F64__neg"(%arg0: f64) -> f64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
     %1 = llvm.mlir.addressof @std.negf : !llvm.ptr<array<8 x i8>>
@@ -407,7 +407,7 @@ module  {
     %5 = llvm.load %4 : !llvm.ptr<f64>
     return %5 : f64
   }
-  func @"$module-0__simple_int"(%arg0: i32, %arg1: i32) -> i32 {
+  builtin.func @"$module-0__simple_int"(%arg0: i32, %arg1: i32) -> i32 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i32 : (i32) -> !llvm.ptr<i32>
     %1 = llvm.alloca %c1_i32 x !llvm.struct<(i32, i32)> : (i32) -> !llvm.ptr<struct<(i32, i32)>>
@@ -463,7 +463,7 @@ module  {
     %38 = llvm.load %37 : !llvm.ptr<i32>
     return %38 : i32
   }
-  func @"$module-0__simple_fp"(%arg0: f32, %arg1: f32) -> f32 {
+  builtin.func @"$module-0__simple_fp"(%arg0: f32, %arg1: f32) -> f32 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x f32 : (i32) -> !llvm.ptr<f32>
     %1 = llvm.alloca %c1_i32 x !llvm.struct<(f32, f32)> : (i32) -> !llvm.ptr<struct<(f32, f32)>>
@@ -519,7 +519,7 @@ module  {
     %38 = llvm.load %37 : !llvm.ptr<f32>
     return %38 : f32
   }
-  func @"$module-0__int_upcast"(%arg0: i32, %arg1: i64) -> i64 {
+  builtin.func @"$module-0__int_upcast"(%arg0: i32, %arg1: i64) -> i64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
     %1 = call @"$module-0__I32__ext"(%arg0) : (i32) -> i64
@@ -545,7 +545,7 @@ module  {
     %16 = llvm.load %15 : !llvm.ptr<i64>
     return %16 : i64
   }
-  func @"$module-0__fp_upcast"(%arg0: f64, %arg1: f32) -> f64 {
+  builtin.func @"$module-0__fp_upcast"(%arg0: f64, %arg1: f32) -> f64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
     %1 = call @"$module-0__F32__ext"(%arg1) : (f32) -> f64
@@ -571,7 +571,7 @@ module  {
     %16 = llvm.load %15 : !llvm.ptr<f64>
     return %16 : f64
   }
-  func @"$module-0__simple_unsigned"(%arg0: i32, %arg1: i32) -> i32 {
+  builtin.func @"$module-0__simple_unsigned"(%arg0: i32, %arg1: i32) -> i32 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i32 : (i32) -> !llvm.ptr<i32>
     %1 = llvm.alloca %c1_i32 x !llvm.struct<(i32, i32)> : (i32) -> !llvm.ptr<struct<(i32, i32)>>
@@ -591,7 +591,7 @@ module  {
     %11 = llvm.load %10 : !llvm.ptr<i32>
     return %11 : i32
   }
-  func @"$module-0__unsigned_upcast"(%arg0: i32, %arg1: i64) -> i64 {
+  builtin.func @"$module-0__unsigned_upcast"(%arg0: i32, %arg1: i64) -> i64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
     %1 = call @"$module-0__U32__ext"(%arg0) : (i32) -> i64
@@ -617,7 +617,7 @@ module  {
     %16 = llvm.load %15 : !llvm.ptr<i64>
     return %16 : i64
   }
-  func @"$module-0__literals"() -> f64 {
+  builtin.func @"$module-0__literals"() -> f64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i32 : (i32) -> !llvm.ptr<i32>
     %c21_i64 = constant 21 : i64
@@ -696,7 +696,7 @@ module  {
     %55 = llvm.load %54 : !llvm.ptr<f64>
     return %55 : f64
   }
-  func @"$module-0__conversions"() -> i64 {
+  builtin.func @"$module-0__conversions"() -> i64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
     %c42_i64 = constant 42 : i64
@@ -724,7 +724,7 @@ module  {
     %17 = llvm.load %16 : !llvm.ptr<i64>
     return %17 : i64
   }
-  func @"$module-0__update_value"() -> i64 {
+  builtin.func @"$module-0__update_value"() -> i64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
     %c21_i64 = constant 21 : i64

--- a/testsuite/verona-mlir/call.out/stdout.txt
+++ b/testsuite/verona-mlir/call.out/stdout.txt
@@ -1,9 +1,9 @@
-module  {
-  func @"$module-0__foo"(%arg0: i64) -> i64 {
+builtin.module  {
+  builtin.func @"$module-0__foo"(%arg0: i64) -> i64 {
     %c42_i64 = constant 42 : i64
     return %c42_i64 : i64
   }
-  func @"$module-0__bar"(%arg0: i64) -> i64 {
+  builtin.func @"$module-0__bar"(%arg0: i64) -> i64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
     %1 = call @"$module-0__foo"(%arg0) : (i64) -> i64
@@ -14,7 +14,7 @@ module  {
     %4 = llvm.load %3 : !llvm.ptr<i64>
     return %4 : i64
   }
-  func @"$module-0__baz"(%arg0: i64) -> i64 {
+  builtin.func @"$module-0__baz"(%arg0: i64) -> i64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
     %c42_i64 = constant 42 : i64

--- a/testsuite/verona-mlir/declaration-order.out/stdout.txt
+++ b/testsuite/verona-mlir/declaration-order.out/stdout.txt
@@ -1,9 +1,9 @@
-module  {
-  func @"$module-0__bar"() {
+builtin.module  {
+  builtin.func @"$module-0__bar"() {
     call @"$module-0__foo"() : () -> ()
     return
   }
-  func @"$module-0__foo"() {
+  builtin.func @"$module-0__foo"() {
     return
   }
 }

--- a/testsuite/verona-mlir/empty-class.out/stdout.txt
+++ b/testsuite/verona-mlir/empty-class.out/stdout.txt
@@ -1,2 +1,2 @@
-module  {
+builtin.module  {
 }

--- a/testsuite/verona-mlir/example.out/stdout.txt
+++ b/testsuite/verona-mlir/example.out/stdout.txt
@@ -1,5 +1,5 @@
-module @__  {
-  func @"____$module-0__Math__getTruth"() -> i64 {
+builtin.module @__  {
+  builtin.func @"____$module-0__Math__getTruth"() -> i64 {
     %c42_i64 = constant 42 : i64
     %c1_i32 = constant 1 : i32
     %c0_i32 = constant 0 : i32
@@ -10,7 +10,7 @@ module @__  {
     %3 = llvm.load %1 : !llvm.ptr<i64>
     return %3 : i64
   }
-  func @"____$module-0__Math__getRandom"() -> i64 {
+  builtin.func @"____$module-0__Math__getRandom"() -> i64 {
     %c1_i64 = constant 1 : i64
     %c1_i32 = constant 1 : i32
     %c0_i32 = constant 0 : i32
@@ -21,7 +21,7 @@ module @__  {
     %3 = llvm.load %1 : !llvm.ptr<i64>
     return %3 : i64
   }
-  func @"____$module-0__bar"() -> i64 {
+  builtin.func @"____$module-0__bar"() -> i64 {
     %c1_i32 = constant 1 : i32
     %c0_i32 = constant 0 : i32
     %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
@@ -32,7 +32,7 @@ module @__  {
     %4 = llvm.load %2 : !llvm.ptr<i64>
     return %4 : i64
   }
-  func @"____$module-0__foo"(%arg0: i64) -> i64 {
+  builtin.func @"____$module-0__foo"(%arg0: i64) -> i64 {
     %c1_i32 = constant 1 : i32
     %c0_i32 = constant 0 : i32
     %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
@@ -53,7 +53,7 @@ module @__  {
     %12 = llvm.load %10 : !llvm.ptr<i64>
     return %12 : i64
   }
-  func @main() -> i64 {
+  builtin.func @main() -> i64 {
     %c21_i64 = constant 21 : i64
     %c1_i32 = constant 1 : i32
     %c0_i32 = constant 0 : i32

--- a/testsuite/verona-mlir/function.out/stdout.txt
+++ b/testsuite/verona-mlir/function.out/stdout.txt
@@ -1,21 +1,21 @@
-module  {
-  func @"$module-0__apply"() {
+builtin.module  {
+  builtin.func @"$module-0__apply"() {
     return
   }
-  func @"$module-0__retOnly"() -> i64 {
+  builtin.func @"$module-0__retOnly"() -> i64 {
     %c42_i64 = constant 42 : i64
     return %c42_i64 : i64
   }
-  func @"$module-0__retOneArg"(%arg0: i64) -> i64 {
+  builtin.func @"$module-0__retOneArg"(%arg0: i64) -> i64 {
     return %arg0 : i64
   }
-  func @"$module-0__retFirstArg"(%arg0: i64, %arg1: i64) -> i64 {
+  builtin.func @"$module-0__retFirstArg"(%arg0: i64, %arg1: i64) -> i64 {
     return %arg0 : i64
   }
-  func @"$module-0__retSecondArg"(%arg0: i64, %arg1: i64) -> i64 {
+  builtin.func @"$module-0__retSecondArg"(%arg0: i64, %arg1: i64) -> i64 {
     return %arg1 : i64
   }
-  func @"$module-0__retSecondArgDiff"(%arg0: i64, %arg1: i32) -> i32 {
+  builtin.func @"$module-0__retSecondArgDiff"(%arg0: i64, %arg1: i32) -> i32 {
     return %arg1 : i32
   }
 }

--- a/testsuite/verona-mlir/main.out/stdout.txt
+++ b/testsuite/verona-mlir/main.out/stdout.txt
@@ -1,5 +1,5 @@
-module  {
-  func @"$module-0__I64__+"(%arg0: i64, %arg1: i64) -> i64 {
+builtin.module  {
+  builtin.func @"$module-0__I64__+"(%arg0: i64, %arg1: i64) -> i64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
     %1 = llvm.mlir.addressof @std.addi : !llvm.ptr<array<8 x i8>>
@@ -20,7 +20,7 @@ module  {
     %12 = llvm.load %11 : !llvm.ptr<i64>
     return %12 : i64
   }
-  func @"$module-0__Math__getTruth"() -> i64 {
+  builtin.func @"$module-0__Math__getTruth"() -> i64 {
     %c42_i64 = constant 42 : i64
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
@@ -31,7 +31,7 @@ module  {
     %3 = llvm.load %2 : !llvm.ptr<i64>
     return %3 : i64
   }
-  func @"$module-0__Math__getRandom"() -> i64 {
+  builtin.func @"$module-0__Math__getRandom"() -> i64 {
     %c1_i64 = constant 1 : i64
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
@@ -42,7 +42,7 @@ module  {
     %3 = llvm.load %2 : !llvm.ptr<i64>
     return %3 : i64
   }
-  func @"$module-0__bar"() -> i64 {
+  builtin.func @"$module-0__bar"() -> i64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
     %1 = call @"$module-0__Math__getRandom"() : () -> i64
@@ -53,7 +53,7 @@ module  {
     %4 = llvm.load %3 : !llvm.ptr<i64>
     return %4 : i64
   }
-  func @"$module-0__foo"(%arg0: i64) -> i64 {
+  builtin.func @"$module-0__foo"(%arg0: i64) -> i64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
     %1 = call @"$module-0__bar"() : () -> i64
@@ -79,7 +79,7 @@ module  {
     %16 = llvm.load %15 : !llvm.ptr<i64>
     return %16 : i64
   }
-  func @main() -> i64 {
+  builtin.func @main() -> i64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x !llvm.struct<"Math", (i64, i64)> : (i32) -> !llvm.ptr<struct<"Math", (i64, i64)>>
     %1 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>

--- a/testsuite/verona-mlir/string.out/stdout.txt
+++ b/testsuite/verona-mlir/string.out/stdout.txt
@@ -1,5 +1,5 @@
-module  {
-  func @"$module-0__foo"() {
+builtin.module  {
+  builtin.func @"$module-0__foo"() {
     %0 = llvm.mlir.addressof @hello : !llvm.ptr<array<5 x i8>>
     %1 = llvm.mlir.addressof @world : !llvm.ptr<array<5 x i8>>
     return

--- a/testsuite/verona-mlir/struct.out/stdout.txt
+++ b/testsuite/verona-mlir/struct.out/stdout.txt
@@ -1,5 +1,5 @@
-module  {
-  func @"$module-0__I64__trunc"(%arg0: i64) -> i32 {
+builtin.module  {
+  builtin.func @"$module-0__I64__trunc"(%arg0: i64) -> i32 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i32 : (i32) -> !llvm.ptr<i32>
     %1 = llvm.mlir.addressof @std.trunci : !llvm.ptr<array<10 x i8>>
@@ -11,7 +11,7 @@ module  {
     %5 = llvm.load %4 : !llvm.ptr<i32>
     return %5 : i32
   }
-  func @"$module-0__Boop__getPI"() -> f64 {
+  builtin.func @"$module-0__Boop__getPI"() -> f64 {
     %cst = constant 3.141500e+00 : f64
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
@@ -22,7 +22,7 @@ module  {
     %3 = llvm.load %2 : !llvm.ptr<f64>
     return %3 : f64
   }
-  func @"$module-0__foo"() -> i32 {
+  builtin.func @"$module-0__foo"() -> i32 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x !llvm.struct<"Foo", (i32, i64)> : (i32) -> !llvm.ptr<struct<"Foo", (i32, i64)>>
     %1 = llvm.alloca %c1_i32 x !llvm.struct<"Bar", (i32, i64)> : (i32) -> !llvm.ptr<struct<"Bar", (i32, i64)>>
@@ -70,7 +70,7 @@ module  {
     %31 = llvm.load %30 : !llvm.ptr<i32>
     return %31 : i32
   }
-  func @"$module-0__bar"() -> f64 {
+  builtin.func @"$module-0__bar"() -> f64 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x f64 : (i32) -> !llvm.ptr<f64>
     %1 = call @"$module-0__Boop__getPI"() : () -> f64

--- a/testsuite/verona-mlir/tuple.out/stdout.txt
+++ b/testsuite/verona-mlir/tuple.out/stdout.txt
@@ -1,5 +1,5 @@
-module  {
-  func @"$module-0__foo"() {
+builtin.module  {
+  builtin.func @"$module-0__foo"() {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x !llvm.struct<(i64, f64)> : (i32) -> !llvm.ptr<struct<(i64, f64)>>
     %c42_i64 = constant 42 : i64
@@ -26,16 +26,16 @@ module  {
     llvm.store %13, %14 : !llvm.ptr<struct<(i64, f64)>>
     return
   }
-  func @"$module-0__has_tuple"(%arg0: !llvm.struct<(i64, i64)>, %arg1: i64) {
+  builtin.func @"$module-0__has_tuple"(%arg0: !llvm.struct<(i64, i64)>, %arg1: i64) {
     return
   }
-  func @"$module-0__no_tuples"(%arg0: i64, %arg1: i64, %arg2: i64) {
+  builtin.func @"$module-0__no_tuples"(%arg0: i64, %arg1: i64, %arg2: i64) {
     return
   }
-  func @"$module-0__just_tuple"(%arg0: !llvm.struct<(i64, i64, i64)>) {
+  builtin.func @"$module-0__just_tuple"(%arg0: !llvm.struct<(i64, i64, i64)>) {
     return
   }
-  func @"$module-0__bar"() {
+  builtin.func @"$module-0__bar"() {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i64 : (i32) -> !llvm.ptr<i64>
     %c42_i64 = constant 42 : i64

--- a/testsuite/verona-mlir/using.out/stdout.txt
+++ b/testsuite/verona-mlir/using.out/stdout.txt
@@ -1,5 +1,5 @@
-module  {
-  func @"$module-0__trunc_64_8"(%arg0: i64) -> i8 {
+builtin.module  {
+  builtin.func @"$module-0__trunc_64_8"(%arg0: i64) -> i8 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i8 : (i32) -> !llvm.ptr<i8>
     %1 = llvm.mlir.addressof @std.trunci : !llvm.ptr<array<10 x i8>>
@@ -11,7 +11,7 @@ module  {
     %5 = llvm.load %4 : !llvm.ptr<i8>
     return %5 : i8
   }
-  func @"$module-0__trunc_64_16"(%arg0: i64) -> i16 {
+  builtin.func @"$module-0__trunc_64_16"(%arg0: i64) -> i16 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i16 : (i32) -> !llvm.ptr<i16>
     %1 = llvm.mlir.addressof @std.trunci : !llvm.ptr<array<10 x i8>>
@@ -23,7 +23,7 @@ module  {
     %5 = llvm.load %4 : !llvm.ptr<i16>
     return %5 : i16
   }
-  func @"$module-0__trunc_64_32"(%arg0: i64) -> i32 {
+  builtin.func @"$module-0__trunc_64_32"(%arg0: i64) -> i32 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i32 : (i32) -> !llvm.ptr<i32>
     %1 = llvm.mlir.addressof @std.trunci : !llvm.ptr<array<10 x i8>>
@@ -35,7 +35,7 @@ module  {
     %5 = llvm.load %4 : !llvm.ptr<i32>
     return %5 : i32
   }
-  func @"$module-0__ext_64_128"(%arg0: i64) -> i128 {
+  builtin.func @"$module-0__ext_64_128"(%arg0: i64) -> i128 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i128 : (i32) -> !llvm.ptr<i128>
     %1 = llvm.mlir.addressof @std.sexti : !llvm.ptr<array<9 x i8>>
@@ -47,7 +47,7 @@ module  {
     %5 = llvm.load %4 : !llvm.ptr<i128>
     return %5 : i128
   }
-  func @"$module-0__truncf_64_32"(%arg0: f64) -> f32 {
+  builtin.func @"$module-0__truncf_64_32"(%arg0: f64) -> f32 {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x f32 : (i32) -> !llvm.ptr<f32>
     %1 = llvm.mlir.addressof @std.fptrunc : !llvm.ptr<array<11 x i8>>
@@ -59,7 +59,7 @@ module  {
     %5 = llvm.load %4 : !llvm.ptr<f32>
     return %5 : f32
   }
-  func @"$module-0__foo"() {
+  builtin.func @"$module-0__foo"() {
     %c1_i32 = constant 1 : i32
     %0 = llvm.alloca %c1_i32 x i8 : (i32) -> !llvm.ptr<i8>
     %c10_i64 = constant 10 : i64


### PR DESCRIPTION
Brings LLVM forward 4 months, across versions, and has no noticeable differences in the API (clang or MLIR), which is incredible.