### PR TITLE
User friendly LLVM option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,13 +12,17 @@ macro (option_top VAR HELP DEFAULT)
   set_cache_top(${VAR} ${HELP} BOOL ${DEFAULT})
 endmacro ()
 
-option_top (VERONA_DOWNLOAD_LLVM "Download cached version of LLVM. Do not set with LLVM_EXTRA_CMAKE_ARGS or VERONS_EXTERNAL_LLVM_DIR" ON)
-option_top (VERBOSE_LLVM_DOWNLOAD "Verbose LLVM/MLIR download step" OFF)
-set_cache_top(VERONA_EXTERNAL_LLVM_DIR "Location of an external LLVM installation to use. Do not set with VERONA_DOWNLOAD_LLVM or LLVM_EXTRA_CMAKE_ARGS" PATH "")
-set_cache_top(LLVM_EXTRA_CMAKE_ARGS "Additional options to pass to LLVM submodule. Do not set with VERONA_DOWNLOAD_LLVM or VERONS_EXTERNAL_LLVM_DIR" STRING "")
+# Default is to download LLVM blob, this shows progress
+option_top(VERBOSE_LLVM_DOWNLOAD "Verbose LLVM/LLVM download step" OFF)
 
-message (STATUS "Download LLVM: ${VERONA_DOWNLOAD_LLVM}")
+# Use external LLVM directory options
+set_cache_top(VERONA_USE_EXTERNAL_LLVM_DIR "Location of an external LLVM installation to use. Do not set with DOWNLOAD LLVM / LLVM SUBMODULE options." PATH "")
 
+# Build LLVM from submodule
+option_top(VERONA_BUILD_LLVM_SUBMODULE "Force building the LLVM submodule. Do not set with DOWNLOAD LLVM / EXTERNAL LLVM options." OFF)
+set_cache_top(LLVM_EXTRA_CMAKE_ARGS "Additional options for building LLVM submodule. Do not set with DOWNLOAD LLVM / EXTERNAL LLVM options." STRING "")
+
+# Other Verona options
 option(ENABLE_ASSERTS "Enable asserts even in release builds" OFF)
 option_top(RT_TESTS "Including unit tests for the runtime" OFF)
 option_top(VERONA_EXPENSIVE_SYSTEMATIC_TESTING "Increase the range of seeds covered by systematic testing" OFF)
@@ -76,46 +80,72 @@ if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}" CACHE STRING "Choose the type of build." FORCE)
 endif()
 
-if (VERONA_DOWNLOAD_LLVM AND LLVM_EXTRA_CMAKE_ARGS)
-  message (SEND_ERROR "Incompatible options LLVM_EXTRA_CMAKE_ARGS and VERONA_DOWNLOAD_LLVM.")
-endif ()
-
-if (VERONA_DOWNLOAD_LLVM AND VERONA_EXTERNAL_LLVM_DIR)
-  message (SEND_ERROR "Incompatible options VERONA_DOWNLOAD_LLVM and VERONA_EXTERNAL_LLVM_DIR.")
-endif ()
-
-if (VERONA_EXTERNAL_LLVM_DIR AND LLVM_EXTRA_CMAKE_ARGS)
-  message (SEND_ERROR "Incompatible options LLVM_EXTRA_CMAKE_ARGS and VERONA_EXTERNAL_LLVM_DIR.")
-endif ()
+# LLVM Options
+#
+# Each option below works on their own and are incompatible with each other.
+#  * VERONA_DOWNLOAD_LLVM (Default=ON): Downloads a pre-build LLVM for Verona.
+#    (+ VERBOSE_LLVM_DOWNLOAD: Shows download progress (Default=OFF))
+#  * VERONA_USE_EXTERNAL_LLVM_DIR: The path of a pre-built install dir of an LLVM toolchain.
+#  * VERONA_BUILD_LLVM_SUBMODULE: Builds from the submodule.
+#    (+ LLVM_EXTRA_CMAKE_ARGS: Extra CMake arguments to build LLVM)
+#
+# Note: On both download and build options, the LLVM checkout are guaranteed to
+# be the same as the submodule, and have been validated by CI. For the external
+# build, users need to make sure they either get the same commit or they know what
+# they're doing.
+if (VERONA_USE_EXTERNAL_LLVM_DIR OR (VERONA_BUILD_LLVM_SUBMODULE OR LLVM_EXTRA_CMAKE_ARGS))
+  if (VERONA_USE_EXTERNAL_LLVM_DIR AND (VERONA_BUILD_LLVM_SUBMODULE OR LLVM_EXTRA_CMAKE_ARGS))
+    message (SEND_ERROR "Incompatible options VERONA_BUILD_LLVM_SUBMODULE/LLVM_EXTRA_CMAKE_ARGS and VERONA_USE_EXTERNAL_LLVM_DIR.")
+  elseif (LLVM_EXTRA_CMAKE_ARGS AND NOT VERONA_BUILD_LLVM_SUBMODULE)
+    message (SEND_ERROR "Invalid use of LLVM_EXTRA_CMAKE_ARGS without VERONA_BUILD_LLVM_SUBMODULE.")
+  else()
+    if (VERONA_USE_EXTERNAL_LLVM_DIR)
+      message (STATUS "Import LLVM from: ${VERONA_USE_EXTERNAL_LLVM_DIR}")
+    elseif(VERONA_BUILD_LLVM_SUBMODULE)
+      if (LLVM_EXTRA_CMAKE_ARGS)
+        message (STATUS "Build LLVM with args: ${LLVM_EXTRA_CMAKE_ARGS}")
+      else()
+        message (STATUS "Build LLVM: ${VERONA_BUILD_LLVM_SUBMODULE}")
+      endif()
+    endif()
+  endif ()
+  # Download is default, so if we pick one of these, we want to turn off download
+  set(VERONA_DOWNLOAD_LLVM OFF)
+else()
+  set(VERONA_DOWNLOAD_LLVM ON)
+  message (STATUS "Download LLVM: ${VERONA_DOWNLOAD_LLVM}")
+endif()
 
 ##########################################################
-#  Configure MLIR installation
+#  Configure LLVM installation
 ##########################################################
-if (VERONA_EXTERNAL_LLVM_DIR)
-  # Fake target for MLIR, it is built externally.
+
+if(VERONA_USE_EXTERNAL_LLVM_DIR)
+  # Fake target for LLVM, it is built externally.
   add_custom_target(external)
   # Use existing installation from system
   list (APPEND VERONA_EXTRA_CMAKE_ARGS
-    -DVERONA_LLVM_LOCATION=${VERONA_EXTERNAL_LLVM_DIR}
+    -DVERONA_LLVM_LOCATION=${VERONA_USE_EXTERNAL_LLVM_DIR}
   )
 else()
-  set (MLIR_INSTALL ${CMAKE_BINARY_DIR}/$<CONFIG>/mlir)
-  #  Build or Download MLIR installation
+  set(LLVM_INSTALL ${CMAKE_BINARY_DIR}/$<CONFIG>/mlir)
+  #  Build or Download LLVM installation
   set (EXTERNAL_EXTRA_CMAKE_ARGS)
   list (APPEND EXTERNAL_EXTRA_CMAKE_ARGS 
     -DVERONA_DOWNLOAD_LLVM=${VERONA_DOWNLOAD_LLVM}
-    -DMLIR_INSTALL=${MLIR_INSTALL}
+    -DLLVM_INSTALL=${LLVM_INSTALL}
     -DCMAKE_BUILD_TYPE=$<CONFIG>)
 
-  if (NOT VERONA_DOWNLOAD_LLVM)
+  # Extra options for building or downloading LLVM
+  if(VERONA_BUILD_LLVM_SUBMODULE)
     list (APPEND EXTERNAL_EXTRA_CMAKE_ARGS
       -DLLVM_EXTRA_CMAKE_ARGS=${LLVM_EXTRA_CMAKE_ARGS}
     )
-  else ()
+  elseif(VERONA_DOWNLOAD_LLVM)
     list (APPEND EXTERNAL_EXTRA_CMAKE_ARGS
       -DVERBOSE_LLVM_DOWNLOAD=${VERBOSE_LLVM_DOWNLOAD}
     )
-  endif ()
+  endif()
 
   ExternalProject_Add(external
     SOURCE_DIR ${CMAKE_SOURCE_DIR}/external
@@ -127,7 +157,7 @@ else()
     USES_TERMINAL_CONFIGURE true
   )
 
-  # Point Verona at the MLIR install, we just built/downloaded
+  # Point Verona at the LLVM install, we just built/downloaded
   list (APPEND VERONA_EXTRA_CMAKE_ARGS
     -DVERONA_LLVM_LOCATION=${CMAKE_BINARY_DIR}/$<CONFIG>/mlir/install
   )

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -148,7 +148,7 @@ stages:
           -DUSE_ASAN=$(Asan)                       \
           -DVERONA_CI_BUILD=On                     \
           -DRT_TESTS=ON                            \
-          -DVERONA_DOWNLOAD_LLVM=OFF               \
+          -DVERONA_BUILD_LLVM_SUBMODULE=ON         \
           -DLLVM_EXTRA_CMAKE_ARGS="                \
             -Wno-dev                               \
             -DCMAKE_C_COMPILER=$(LLVM_CC)          \

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required(VERSION 3.10.0)
 project(verona_external CXX)
 include(ExternalProject)
 
-message (STATUS "Install MLIR to ${MLIR_INSTALL}")
+message (STATUS "Install LLVM to ${LLVM_INSTALL}")
 
 if (VERONA_DOWNLOAD_LLVM)
   find_package(Git)
@@ -56,7 +56,7 @@ if (VERONA_DOWNLOAD_LLVM)
     DOWNLOAD_NO_PROGRESS NOT ${VERBOSE_LLVM_DOWNLOAD}
     CONFIGURE_COMMAND ""
     PREFIX mlir-${LLVM_BUILD_TYPE}
-    SOURCE_DIR ${MLIR_INSTALL}
+    SOURCE_DIR ${LLVM_INSTALL}
     BUILD_COMMAND ""
     INSTALL_COMMAND ""
     TEST_COMMAND ""
@@ -65,7 +65,7 @@ if (VERONA_DOWNLOAD_LLVM)
 else()
   separate_arguments(LLVM_EXTRA_CMAKE_ARGS UNIX_COMMAND ${LLVM_EXTRA_CMAKE_ARGS})
   list (APPEND LLVM_EXTRA_CMAKE_ARGS
-    -DCMAKE_INSTALL_PREFIX=${MLIR_INSTALL}/install  # Add install as tar has install prefix. Outer project knows about this.
+    -DCMAKE_INSTALL_PREFIX=${LLVM_INSTALL}/install  # Add install as tar has install prefix. Outer project knows about this.
     # Note: We must use the SEMICOLON generator expression here because CMake
     # uses semicolons as list separators and this must be a literal semicolon
     # in the final output.  There are at least two steps in between this line


### PR DESCRIPTION
When asking to build LLVM or re-use an already built directory, CMake
forced users to turn off VERBOSE_LLVM_DOWNLOAD, which was on by default
and emitted a confusing error message.

To avoid having to pass -DVERBOSE_LLVM_DOWNLOAD=OFF on the other two
ways to build Verona, we just assume that, when users set those
variables, they really don't need to download it, too.

Keeping the error message when both build and reuse options are set, as
neither are set by default and it would clearly be an error.