### PR TITLE
Fixes a few UB on the run-time

### DIFF
--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -265,7 +265,8 @@ namespace verona::rt
         {
           cown = q.dequeue(*alloc);
           if (cown != nullptr)
-            Systematic::cout() << "Pop cown " << cown << Systematic::endl;
+            Systematic::cout()
+              << "Pop cown " << clear_thread_bit(cown) << Systematic::endl;
         }
 
         if (cown == nullptr)
@@ -404,8 +405,9 @@ namespace verona::rt
         if (cown != nullptr)
         {
           // stats.steal();
-          Systematic::cout() << "Fast-steal cown " << cown << " from "
-                             << victim->systematic_id << Systematic::endl;
+          Systematic::cout()
+            << "Fast-steal cown " << clear_thread_bit(cown) << " from "
+            << victim->systematic_id << Systematic::endl;
           result = cown;
           return true;
         }
@@ -476,8 +478,9 @@ namespace verona::rt
           if (cown != nullptr)
           {
             stats.steal();
-            Systematic::cout() << "Stole cown " << cown << " from "
-                               << victim->systematic_id << Systematic::endl;
+            Systematic::cout()
+              << "Stole cown " << clear_thread_bit(cown) << " from "
+              << victim->systematic_id << Systematic::endl;
             return cown;
           }
         }

--- a/src/rt/sched/spmcq.h
+++ b/src/rt/sched/spmcq.h
@@ -128,7 +128,7 @@ namespace verona::rt
 
       assert(epoch != T::NO_EPOCH_SET);
 
-      fnt->epoch_when_popped = epoch;
+      unmask(fnt)->epoch_when_popped = epoch;
 
       return fnt;
     }

--- a/src/rt/sched/threadsyncsystematic.h
+++ b/src/rt/sched/threadsyncsystematic.h
@@ -64,7 +64,8 @@ namespace verona::rt
         return;
       }
 
-      auto i = snmalloc::bits::ctz(Systematic::get_prng_next());
+      auto r = Systematic::get_prng_next();
+      auto i = snmalloc::bits::ctz(r != 0 ? r : 1);
       auto start = running_thread;
       assert(me == start);
       UNUSED(me);


### PR DESCRIPTION
These were found running tests with UBSAN and a specific random seed
that made tests fail.

Hopefully this will reduce the issues on the MacOS nightly runs. But it
also gives us a way to debug further issues if they arise.

All debug was done on Linux, so YMMV on the effects on Macs.

Co-authoredr-by: Matthew Parkinson <mattpark@microsoft.com>