### PR TITLE
Address Sanitizer fixes

### DIFF
--- a/src/interop/CXXQuery.h
+++ b/src/interop/CXXQuery.h
@@ -201,15 +201,19 @@ namespace verona::interop
       // Search for class, enum or template.
       name = "::" + name;
       MatchFinder finder;
+      auto recDeclMatch = std::make_unique<CXXTypeMatch<clang::CXXRecordDecl>>(ty);
+      auto classTempMatch = std::make_unique<CXXTypeMatch<clang::ClassTemplateDecl>>(ty);
+      auto enumDeclMatch = std::make_unique<CXXTypeMatch<clang::EnumDecl>>(ty);
+
       finder.addMatcher(
         cxxRecordDecl(hasName(name)).bind("id"),
-        new CXXTypeMatch<clang::CXXRecordDecl>(ty));
+        recDeclMatch.get());
       finder.addMatcher(
         classTemplateDecl(hasName(name)).bind("id"),
-        new CXXTypeMatch<clang::ClassTemplateDecl>(ty));
+        classTempMatch.get());
       finder.addMatcher(
         enumDecl(hasName(name)).bind("id"),
-        new CXXTypeMatch<clang::EnumDecl>(ty));
+        enumDeclMatch.get());
       finder.matchAST(*ast);
 
       // Return the type matched directly.

--- a/src/interop/CXXQuery.h
+++ b/src/interop/CXXQuery.h
@@ -201,19 +201,18 @@ namespace verona::interop
       // Search for class, enum or template.
       name = "::" + name;
       MatchFinder finder;
-      auto recDeclMatch = std::make_unique<CXXTypeMatch<clang::CXXRecordDecl>>(ty);
-      auto classTempMatch = std::make_unique<CXXTypeMatch<clang::ClassTemplateDecl>>(ty);
+      auto recDeclMatch =
+        std::make_unique<CXXTypeMatch<clang::CXXRecordDecl>>(ty);
+      auto classTempMatch =
+        std::make_unique<CXXTypeMatch<clang::ClassTemplateDecl>>(ty);
       auto enumDeclMatch = std::make_unique<CXXTypeMatch<clang::EnumDecl>>(ty);
 
       finder.addMatcher(
-        cxxRecordDecl(hasName(name)).bind("id"),
-        recDeclMatch.get());
+        cxxRecordDecl(hasName(name)).bind("id"), recDeclMatch.get());
       finder.addMatcher(
-        classTemplateDecl(hasName(name)).bind("id"),
-        classTempMatch.get());
+        classTemplateDecl(hasName(name)).bind("id"), classTempMatch.get());
       finder.addMatcher(
-        enumDecl(hasName(name)).bind("id"),
-        enumDeclMatch.get());
+        enumDecl(hasName(name)).bind("id"), enumDeclMatch.get());
       finder.matchAST(*ast);
 
       // Return the type matched directly.

--- a/src/interop/FS.h
+++ b/src/interop/FS.h
@@ -58,7 +58,8 @@ namespace verona::interop
     {
       llvm::SmallVector<char, 16> out;
       llvm::sys::fs::real_path(path, out, /*expand_tilde*/ true);
-      return out.data();
+      std::string res(out.data(), out.size());
+      return res;
     }
 
     /**

--- a/src/interop/verona-interop.cc
+++ b/src/interop/verona-interop.cc
@@ -131,6 +131,10 @@ namespace
     // Parse the command line
     cl::ParseCommandLineOptions(
       args.size(), args.data(), "Verona Interop test\n");
+
+    // Manual cleanup because char* doesn't have a destructor
+    for (auto arg : args)
+      delete arg;
   }
 
   /// Test call


### PR DESCRIPTION
Running `verona-interop` through ASAN & UBSAN & LSAN has produced issues that are now fixed by this PR.

This allows us to turn on ASAN on all builds (but not UBSAN, which still has issues in the parser).