### PR TITLE
Generic sanitizer run on CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,13 +27,17 @@ option(ENABLE_ASSERTS "Enable asserts even in release builds" OFF)
 option_top(RT_TESTS "Including unit tests for the runtime" OFF)
 option_top(VERONA_EXPENSIVE_SYSTEMATIC_TESTING "Increase the range of seeds covered by systematic testing" OFF)
 option(USE_SCHED_STATS "Track scheduler stats" OFF)
-option(USE_ASAN "Use address sanitizer" OFF)
 option(VERONA_CI_BUILD "Disable features not sensible for CI" OFF)
 option(USE_SYSTEMATIC_TESTING "Enable systematic testing in the runtime" OFF)
 option(USE_CRASH_LOGGING "Enable crash logging in the runtime" OFF)
 if (NOT MSVC)
   option(CMAKE_EXPORT_COMPILE_COMMANDS "Export compilation commands" ON)
 endif ()
+
+set(SANITIZER "" CACHE STRING "Use sanitizer type (address|undefined|memory|...)")
+if (SANITIZER)
+  message(STATUS "Using sanitizer=${SANITIZER}")
+endif()
 
 ##########################################################
 # Pass parameters to subbuild.

--- a/devops/ci.yml
+++ b/devops/ci.yml
@@ -62,13 +62,14 @@ jobs:
         CXX: g++
         CXXFLAGS:
         BuildType: Release
-        Asan: Off
+        SANITIZER:
       Clang RelDbg+ASAN:
         CC: clang
         CXX: clang++
         CXXFLAGS: -stdlib=libstdc++
         BuildType: RelWithDebInfo
-        Asan: On
+        SANITIZER: address
+      # TODO: Add UBSAN (undefined)
   steps:
   - checkout: self
 
@@ -90,7 +91,7 @@ jobs:
     displayName: 'CMake'
     inputs:
       cmakeArgs: |
-        .. -GNinja -DCMAKE_BUILD_TYPE=$(BuildType) -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_COMPILER=$(CXX) -DCMAKE_CXX_FLAGS=$(CXXFLAGS) -DENABLE_ASSERTS=ON -DUSE_ASAN=$(Asan) -DVERONA_CI_BUILD=On -DRT_TESTS=$(RTTests)
+        .. -GNinja -DCMAKE_BUILD_TYPE=$(BuildType) -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_COMPILER=$(CXX) -DCMAKE_CXX_FLAGS=$(CXXFLAGS) -DENABLE_ASSERTS=ON -DSANITIZER=$(SANITIZER) -DVERONA_CI_BUILD=On -DRT_TESTS=$(RTTests)
 
   - script: |
       set -eo pipefail
@@ -100,7 +101,8 @@ jobs:
 
   - script: |
       set -eo pipefail
-      export ASAN_OPTIONS="alloc_dealloc_mismatch=0 symbolize=1"
+      export UBSAN_OPTIONS="print_stacktrace=1"
+      export ASAN_OPTIONS="alloc_dealloc_mismatch=0 symbolize=1 print_stacktrace=1"
       ninja check
     workingDirectory: build
     displayName: 'Tests'

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -37,37 +37,38 @@ stages:
           CXX: g++
           CXXFLAGS:
           BuildType: Debug
-          Asan: Off
+          SANITIZER:
         GCC Release:
           CC: gcc
           CXX: g++
           CXXFLAGS:
-          Asan: Off
           BuildType: Release
+          SANITIZER:
         Clang Debug:
           CC: clang
           CXX: clang++
           CXXFLAGS: -stdlib=libstdc++
           BuildType: Debug
-          Asan: Off
+          SANITIZER:
         Clang Release:
           CC: clang
           CXX: clang++
           CXXFLAGS: -stdlib=libstdc++
-          Asan: Off
           BuildType: Release
+          SANITIZER:
         Clang Debug (ASAN):
           CC: clang
           CXX: clang++
           CXXFLAGS: -stdlib=libstdc++
           BuildType: Debug
-          Asan: On
+          SANITIZER: address
         Clang Release (ASAN):
           CC: clang
           CXX: clang++
           CXXFLAGS: -stdlib=libstdc++
           BuildType: Release
-          Asan: On
+          SANITIZER: address
+        # TODO: Add UBSAN (undefined)
     steps:
     - checkout: self
 
@@ -83,7 +84,7 @@ stages:
       displayName: 'CMake'
       inputs:
         cmakeArgs: |
-          .. -GNinja -DCMAKE_BUILD_TYPE=$(BuildType) -DCMAKE_CXX_FLAGS=$(CXXFLAGS) -DENABLE_ASSERTS=ON -DUSE_ASAN=$(Asan) -DVERONA_CI_BUILD=On -DRT_TESTS=ON
+          .. -GNinja -DCMAKE_BUILD_TYPE=$(BuildType) -DCMAKE_CXX_FLAGS=$(CXXFLAGS) -DENABLE_ASSERTS=ON -DSANITIZER=$(SANITIZER) -DVERONA_CI_BUILD=On -DRT_TESTS=ON
 
     - script: |
         set -eo pipefail
@@ -110,14 +111,14 @@ stages:
           CC: gcc
           CXX: g++
           CXXFLAGS:
-          Asan: Off
           BuildType: Release
+          SANITIZER:
         Clang Debug (ASAN):
           CC: clang
           CXX: clang++
           CXXFLAGS: -stdlib=libstdc++
           BuildType: Debug
-          Asan: On
+          SANITIZER: address
 
     variables:
       - template: ./vars/anybuild-vars.yml
@@ -145,7 +146,7 @@ stages:
           -DCMAKE_BUILD_TYPE=$(BuildType)          \
           -DCMAKE_CXX_FLAGS=$(CXXFLAGS)            \
           -DENABLE_ASSERTS=ON                      \
-          -DUSE_ASAN=$(Asan)                       \
+          -DSANITIZER=$(SANITIZER)                 \
           -DVERONA_CI_BUILD=On                     \
           -DRT_TESTS=ON                            \
           -DVERONA_BUILD_LLVM_SUBMODULE=ON         \
@@ -161,7 +162,7 @@ stages:
 
     - template: ./steps/linux/anybuild.yml
       parameters:
-        BuildName: Verona-$(BuildType)-$(CC)-Asan$(Asan)-AnyBuild
+        BuildName: Verona-$(BuildType)-$(CC)-san$(SANITIZER)-AnyBuild
         BuildCommandLine: env CMAKE_BUILD_PARALLEL_LEVEL=${{ parameters.AnyBuildParallelism }} cmake --build .
         WorkingDirectory: build
 

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -68,7 +68,18 @@ stages:
           CXXFLAGS: -stdlib=libstdc++
           BuildType: Release
           SANITIZER: address
-        # TODO: Add UBSAN (undefined)
+        Clang Debug (UBSAN):
+          CC: clang
+          CXX: clang++
+          CXXFLAGS: -stdlib=libstdc++
+          BuildType: Debug
+          SANITIZER: undefined
+        Clang Release (UBSAN):
+          CC: clang
+          CXX: clang++
+          CXXFLAGS: -stdlib=libstdc++
+          BuildType: Release
+          SANITIZER: undefined
     steps:
     - checkout: self
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,16 @@ if (ENABLE_ASSERTS)
   enable_asserts()
 endif()
 
+# Sanitizers must be added first, or it gets upset.
+if(SANITIZER)
+  if(MSVC)
+    message(FATAL_ERROR "MSVC does not support sanitizers")
+  endif()
+  message(STATUS "Using sanitizer=${SANITIZER}")
+  add_compile_options(-fsanitize=${SANITIZER})
+  add_link_options(-fsanitize=${SANITIZER})
+endif()
+
 add_subdirectory(../external/CLI11 ./external/CLI11 EXCLUDE_FROM_ALL)
 add_subdirectory(../external/fmt ./external/fmt EXCLUDE_FROM_ALL)
 add_subdirectory(../external/pegmatite ./external/pegmatite EXCLUDE_FROM_ALL)

--- a/src/rt/CMakeLists.txt
+++ b/src/rt/CMakeLists.txt
@@ -27,13 +27,14 @@ endif()
 
 add_library(verona_rt INTERFACE)
 # ASAN must be added first, or it gets upset.
-if(USE_ASAN)
+if(SANITIZER)
   if(MSVC)
-    message(FATAL_ERROR "MSVC does not support ASAN")
+    message(FATAL_ERROR "MSVC does not support sanitizers")
   endif()
+  message(STATUS "Run-time sanitizer=${SANITIZER}")
   target_compile_definitions(verona_rt INTERFACE -DSNMALLOC_PASS_THROUGH)
-  target_compile_options(verona_rt INTERFACE -g -fsanitize=address -fno-omit-frame-pointer)
-  target_link_libraries(verona_rt INTERFACE -fsanitize=address)
+  target_compile_options(verona_rt INTERFACE -g -fsanitize=${SANITIZER} -fno-omit-frame-pointer)
+  target_link_libraries(verona_rt INTERFACE -fsanitize=${SANITIZER})
 endif()
 
 if(USE_SYSTEMATIC_TESTING)


### PR DESCRIPTION
Change USE_ASAN option to SANITIZER, so that we can choose any sanitizer
to run on local builds or CI.

Runs ASAN on both commit CI and nightly, so we can catch errors earlier.

Not running UBSAN yet because some errors in the parser are still
failing and there may be some spurious run-time errors that need fixing
before turning it on.

But from this commit onwards, anyone can use any sanitizer (even
combining them with -DSANITIZER="address,undefined,leak") on a local
build for all programs, not just ASAN on the run-time.