### PR TITLE
UBSAN - vptr because of LLVM's no-rtti

### DIFF
--- a/devops/ci.yml
+++ b/devops/ci.yml
@@ -63,13 +63,12 @@ jobs:
         CXXFLAGS:
         BuildType: Release
         SANITIZER:
-      Clang RelDbg+ASAN:
+      Clang RelDbg+SAN:
         CC: clang
         CXX: clang++
         CXXFLAGS: -stdlib=libstdc++
         BuildType: RelWithDebInfo
-        SANITIZER: address
-      # TODO: Add UBSAN (undefined)
+        SANITIZER: address,undefined,leak
   steps:
   - checkout: self
 

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -56,30 +56,18 @@ stages:
           CXXFLAGS: -stdlib=libstdc++
           BuildType: Release
           SANITIZER:
-        Clang Debug (ASAN):
+        Clang Debug (SAN):
           CC: clang
           CXX: clang++
           CXXFLAGS: -stdlib=libstdc++
           BuildType: Debug
-          SANITIZER: address
-        Clang Release (ASAN):
+          SANITIZER: address,undefined,leak
+        Clang Release (SAN):
           CC: clang
           CXX: clang++
           CXXFLAGS: -stdlib=libstdc++
           BuildType: Release
-          SANITIZER: address
-        Clang Debug (UBSAN):
-          CC: clang
-          CXX: clang++
-          CXXFLAGS: -stdlib=libstdc++
-          BuildType: Debug
-          SANITIZER: undefined
-        Clang Release (UBSAN):
-          CC: clang
-          CXX: clang++
-          CXXFLAGS: -stdlib=libstdc++
-          BuildType: Release
-          SANITIZER: undefined
+          SANITIZER: address,undefined,leak
     steps:
     - checkout: self
 
@@ -124,12 +112,12 @@ stages:
           CXXFLAGS:
           BuildType: Release
           SANITIZER:
-        Clang Debug (ASAN):
+        Clang Debug (SAN):
           CC: clang
           CXX: clang++
           CXXFLAGS: -stdlib=libstdc++
           BuildType: Debug
-          SANITIZER: address
+          SANITIZER: address,undefined,leak
 
     variables:
       - template: ./vars/anybuild-vars.yml

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,12 @@ if(SANITIZER)
   message(STATUS "Using sanitizer=${SANITIZER}")
   add_compile_options(-fsanitize=${SANITIZER})
   add_link_options(-fsanitize=${SANITIZER})
+  # Disable vptr check in UBSAN (incompatible with -no-rtti used by LLVM)
+  # https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html#available-checks
+  if (SANITIZER MATCHES "undefined")
+    add_compile_options(-fno-sanitize=vptr)
+    add_link_options(-fno-sanitize=vptr)
+  endif()
 endif()
 
 add_subdirectory(../external/CLI11 ./external/CLI11 EXCLUDE_FROM_ALL)


### PR DESCRIPTION
Re-enable all sanitizers' tests in CI and Nightly.