### PR TITLE
Disable assert on mac

### DIFF
--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -259,7 +259,7 @@ stages:
       displayName: 'CMake'
       inputs:
         cmakeArgs: |
-          .. -DCMAKE_BUILD_TYPE=$(BuildType) -DENABLE_ASSERTS=ON -DVERONA_CI_BUILD=On -DRT_TESTS=ON
+          .. -DCMAKE_BUILD_TYPE=$(BuildType) -DVERONA_CI_BUILD=On -DRT_TESTS=ON
 
     - script: |
         set -eo pipefail


### PR DESCRIPTION
Mac nightly is having some trouble with the runtime and pthread
libraries that we can't reproduce on local machines. Matt suggested we
disable asserts and early tests confirmed that this doesn't fail after
two rounds.

It could be lock or not, but technically we don't need asserts on all
platforms, especially when using the same compiler (clang).

If/when we find and fix the actual problem (or move to a newer platform)
we can turn this back on.