### PR TITLE
[cmake] Allow LLVM_EXTRA_CMAKE_ARGS to override CMAKE_BUILD_TYPE

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -64,8 +64,15 @@ if (VERONA_DOWNLOAD_LLVM)
   )
 else()
   separate_arguments(LLVM_EXTRA_CMAKE_ARGS UNIX_COMMAND ${LLVM_EXTRA_CMAKE_ARGS})
-  list (APPEND LLVM_EXTRA_CMAKE_ARGS
+  set (LLVM_CMAKE_ARGS
+    # set a default CMAKE_BUILD_TYPE to be the same as for Verona
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+
+    # append LLVM_EXTRA_CMAKE_ARGS (which may override CMAKE_BUILD_TYPE)
+    ${LLVM_EXTRA_CMAKE_ARGS}
+
+    # set mandatory cmake args below
+
     -DCMAKE_INSTALL_PREFIX=${LLVM_INSTALL}/install  # Add install as tar has install prefix. Outer project knows about this.
     # Note: We must use the SEMICOLON generator expression here because CMake
     # uses semicolons as list separators and this must be a literal semicolon
@@ -80,7 +87,7 @@ else()
 
   ExternalProject_Add(mlir
     SOURCE_DIR ${CMAKE_SOURCE_DIR}/llvm-project/llvm
-    CMAKE_ARGS ${LLVM_EXTRA_CMAKE_ARGS}
+    CMAKE_ARGS ${LLVM_CMAKE_ARGS}
     BUILD_ALWAYS true
     USES_TERMINAL_BUILD true
     USES_TERMINAL_CONFIGURE true

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -65,8 +65,8 @@ if (VERONA_DOWNLOAD_LLVM)
 else()
   separate_arguments(LLVM_EXTRA_CMAKE_ARGS UNIX_COMMAND ${LLVM_EXTRA_CMAKE_ARGS})
   set (LLVM_CMAKE_ARGS
-    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} # set a default CMAKE_BUILD_TYPE to be the same as for Verona
-    -DCMAKE_INSTALL_PREFIX=${LLVM_INSTALL}/install # Add install as tar has install prefix. Outer project knows about this.
+    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}          # set a default CMAKE_BUILD_TYPE to be the same as for Verona
+    -DCMAKE_INSTALL_PREFIX=${LLVM_INSTALL}/install  # Add install as tar has install prefix. Outer project knows about this.
     # Note: We must use the SEMICOLON generator expression here because CMake
     # uses semicolons as list separators and this must be a literal semicolon
     # in the final output.  There are at least two steps in between this line

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -65,12 +65,8 @@ if (VERONA_DOWNLOAD_LLVM)
 else()
   separate_arguments(LLVM_EXTRA_CMAKE_ARGS UNIX_COMMAND ${LLVM_EXTRA_CMAKE_ARGS})
   set (LLVM_CMAKE_ARGS
-    # set a default CMAKE_BUILD_TYPE to be the same as for Verona
-    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-
-    # Add install as tar has install prefix. Outer project knows about this.
-    -DCMAKE_INSTALL_PREFIX=${LLVM_INSTALL}/install
-
+    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} # set a default CMAKE_BUILD_TYPE to be the same as for Verona
+    -DCMAKE_INSTALL_PREFIX=${LLVM_INSTALL}/install # Add install as tar has install prefix. Outer project knows about this.
     # Note: We must use the SEMICOLON generator expression here because CMake
     # uses semicolons as list separators and this must be a literal semicolon
     # in the final output.  There are at least two steps in between this line

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -68,12 +68,9 @@ else()
     # set a default CMAKE_BUILD_TYPE to be the same as for Verona
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
 
-    # append LLVM_EXTRA_CMAKE_ARGS (which may override CMAKE_BUILD_TYPE)
-    ${LLVM_EXTRA_CMAKE_ARGS}
+    # Add install as tar has install prefix. Outer project knows about this.
+    -DCMAKE_INSTALL_PREFIX=${LLVM_INSTALL}/install
 
-    # set mandatory cmake args below
-
-    -DCMAKE_INSTALL_PREFIX=${LLVM_INSTALL}/install  # Add install as tar has install prefix. Outer project knows about this.
     # Note: We must use the SEMICOLON generator expression here because CMake
     # uses semicolons as list separators and this must be a literal semicolon
     # in the final output.  There are at least two steps in between this line
@@ -83,6 +80,9 @@ else()
     -DLLVM_TARGETS_TO_BUILD=X86
     -DLLVM_ENABLE_ASSERTIONS=On
     -DCMAKE_CXX_STANDARD=17
+
+    # append LLVM_EXTRA_CMAKE_ARGS (which may override any previously set values)
+    ${LLVM_EXTRA_CMAKE_ARGS}
   )
 
   ExternalProject_Add(mlir


### PR DESCRIPTION
Otherwise, when building Verona + LLVM all together, the build type for LLVM is set to the same build type as specified for Verona.  Consequently, it's not possible to at once build Verona in Debug and LLVM in Release.