### PR TITLE
Changed std::thread usage in harness to verona::InternalThread

### DIFF
--- a/src/rt/pal/cpu.h
+++ b/src/rt/pal/cpu.h
@@ -29,6 +29,7 @@
 #endif
 
 #include <algorithm>
+#include <functional>
 #include <vector>
 
 namespace verona::rt

--- a/src/rt/pal/threading.h
+++ b/src/rt/pal/threading.h
@@ -10,7 +10,7 @@
 
 namespace verona::rt
 {
-  using InternalThread = std::thread;
+  using PlatformThread = std::thread;
 }
 
 #else

--- a/src/rt/pal/threadpoolbuilder.h
+++ b/src/rt/pal/threadpoolbuilder.h
@@ -14,7 +14,7 @@ namespace verona::rt
   class ThreadPoolBuilder
   {
     Topology topology;
-    std::list<InternalThread> threads;
+    std::list<PlatformThread> threads;
     size_t thread_count;
     size_t index = 0;
 

--- a/src/rt/test/func/external_threading/verona_external_threading.h
+++ b/src/rt/test/func/external_threading/verona_external_threading.h
@@ -46,7 +46,7 @@ namespace verona::rt
     inline void set_affinity(size_t) {}
   }
 
-  class InternalThread
+  class PlatformThread
   {
   public:
     /**
@@ -54,18 +54,18 @@ namespace verona::rt
      * on it.
      */
     template<typename F, typename... Args>
-    InternalThread(F&&, Args&&...)
+    PlatformThread(F&&, Args&&...)
     {}
 
-    InternalThread() = delete;
-    InternalThread(const InternalThread&) = delete;
-    InternalThread(InternalThread&&) = delete;
+    PlatformThread() = delete;
+    PlatformThread(const PlatformThread&) = delete;
+    PlatformThread(PlatformThread&&) = delete;
 
     /**
      * Destructor to be called after the thread has finished executing (and was
      * joined).
      */
-    ~InternalThread(){};
+    ~PlatformThread(){};
 
     /**
      * Wait until the thread has finished executing the function it was

--- a/src/rt/test/harness.h
+++ b/src/rt/test/harness.h
@@ -35,10 +35,10 @@ class SystematicTestHarness
    * execution has finished, we make the harness responsible for tracking and
    * joining on external threads.
    *
-   * Storage type is verona::InternalThread, so that the harness can be reused
+   * Storage type is verona::PlatformThread, so that the harness can be reused
    * on platforms with custom threading.
    */
-  std::list<InternalThread> external_threads;
+  std::list<PlatformThread> external_threads;
 
 public:
   opt::Opt opt;
@@ -143,7 +143,7 @@ public:
 
   /**
    * Add an external thread to the system, which will be joined after
-   * sched.run() finishes. Do not create any verona::InternalThread or
+   * sched.run() finishes. Do not create any verona::PlatformThread or
    * std::thread explicitly in a test when using SystematicTestHarness.
    *
    * Same arguments as the std::thread constructor.

--- a/src/rt/test/harness.h
+++ b/src/rt/test/harness.h
@@ -6,7 +6,6 @@
 #include <chrono>
 #include <list>
 #include <test/opt.h>
-#include <thread>
 #include <verona.h>
 
 using namespace verona::rt;
@@ -35,8 +34,11 @@ class SystematicTestHarness
    * snmalloc::debug_check_empty. Since the test has no way to detect when the
    * execution has finished, we make the harness responsible for tracking and
    * joining on external threads.
+   *
+   * Storage type is verona::InternalThread, so that the harness can be reused
+   * on platforms with custom threading.
    */
-  std::list<std::thread> external_threads;
+  std::list<InternalThread> external_threads;
 
 public:
   opt::Opt opt;
@@ -141,13 +143,13 @@ public:
 
   /**
    * Add an external thread to the system, which will be joined after
-   * sched.run() finishes. Do not create any std::thread explicitly in a test
-   * when using SystematicTestHarness.
+   * sched.run() finishes. Do not create any verona::InternalThread or
+   * std::thread explicitly in a test when using SystematicTestHarness.
    *
    * Same arguments as the std::thread constructor.
    */
   template<typename F, typename... Args>
-  void external_thread(F f, Args... args)
+  void external_thread(F&& f, Args&&... args)
   {
     external_threads.emplace_back(f, args...);
   }

--- a/src/rt/test/threadping.h
+++ b/src/rt/test/threadping.h
@@ -36,7 +36,7 @@ namespace verona::rt
     std::mutex mutx{};
 
     /// Internal thread that will handle the pings.
-    InternalThread thrd;
+    PlatformThread thrd;
 
   public:
     /// Creates a thread that can be pinged to execute f


### PR DESCRIPTION
This allows custom platforms to reuse the harness code. Updated comments to hopefully address confusion from the internal/external naming.