### PR TITLE
Dialect changes from current semantic discussions

### DIFF
--- a/docs/internal/dialect.md
+++ b/docs/internal/dialect.md
@@ -470,8 +470,8 @@ Example:
 {
   %a = call @factory(...): !join<A, B, throw<E>, throw<F>>
   %threw = verona.catch(%a): i1
-  %values = verona.cast(%a): !join<A, B>
-  %exceptions = verona.cast(%a): !join<E, F>
+  %values = verona.cast(%a): !join<A, B>     // Note, only "regular" objects here
+  %exceptions = verona.cast(%a): !join<E, F> // Note, only "exception" objects here
   cond_br %threw, error(%exceptions), cont(%values)
   ...
 }
@@ -483,7 +483,7 @@ Example:
 ```ts
 factory(a: I32): A | Throw[E]
 {
-  if (a > 10)
+  if (a > 10)            // When inlined, this condition is always false
     throw E
   let obj = A::create(a)
   obj
@@ -493,7 +493,7 @@ user(...): A
 {
   let a = 5
   try {
-    let obj = factory(a) // clearly, a<10
+    let obj = factory(a) // clearly, a < 10
     obj
   }
   catch

--- a/docs/internal/dialect.md
+++ b/docs/internal/dialect.md
@@ -298,15 +298,15 @@ freeze(%x : !join<iso<Type>, mut<Type>>) ->
 Freeze::apply(alloc, x)
 ```
 
-## IR Optimisation
+# IR Optimisation
 
 The main reason for an MLIR dialect, rather than direct lowering to LLVM IR, is so we can do high-level transformations that would be costly or impossible in a low-level IR.
 
 This section justifies the existence of the operations and types declared for what optimisations they allow.
 
-### Types
+## Types
 
-#### Concrete Types
+### Concrete Types
 
 Concrete types are just LLVM pointers to structures which are allocated by the run-time using the `verona.alloc` operation.
 
@@ -314,7 +314,7 @@ Objects that have a limited lifetime (ex. not captured by a lambda or passed ont
 
 The compiler can detect lifetime locally and change a `verona.alloc` to an `llvm.alloca` to avoid run-time calls, reference counting, garbage collection, etc.
 
-#### Capabilities
+### Capabilities
 
 With the type inference and final checks being done before MLIR, there is no need to keep reference capabilities at this level, other than potential optimisations.
 
@@ -380,7 +380,7 @@ which allows the compiler to match the type of `%x` with `!imm` directly and sub
 }
 ```
 
-#### Union Types, Throw Types and Casts
+### Union Types, Throw Types and Casts
 
 This less for code optimisation per se, more for simplifying code generation.
 But in conjunction with `match`, it can help similar optimisations as above.

--- a/docs/internal/dialect.md.bak
+++ b/docs/internal/dialect.md.bak
@@ -98,7 +98,7 @@ This makes the distinction between `std.ret` and `verona.throw` clear, with the 
 
 ## Region type
 
-The new semantics only allows one region to be writable at any given point, so when creating new objects, we know in which region, if any, to allocate it.
+The new semantics only allows one region to be writeable at any given point, so when creating new objects, we know in which region, if any, to allocate it.
 But to know which is the current region at any given time, the ABI has to change so that every function receives a region object and uses it for the `alloc` operation.
 
 For this, we need a new type, `!region`, which is a pointer to an object that defines the region, or `undef` if there are no regions defined.
@@ -250,7 +250,7 @@ Alternatively, we could create two operations: `region_push()` and `region_pop()
 cast(%obj: !Type1): !Type2
 ```
 
-Expressions where union and interface types are requested, their sub-types can be used, but MLIR doesn't know the Verona type relationships.
+Expressions where union and interface types are requested, their sub-types can be used, but MLIR doens't know the Verona type relationships.
 
 This operation just changes the type on a new SSA variable, allowing the type checker to pass.
 
@@ -272,15 +272,15 @@ Region::release(alloc, x)
 
 ## Region Handling
 
-This may not have direct correlation with the language, but is needed in order to implement the run-time semantics correctly.
+This may not have direct correlation with the language, but is needed in order to implement the run-time semantics correcty.
 
-`move` inserts an object into a region by transferring the ownership of the new region.
+`move` inserts an object into a region by transfering the ownership of the new region.
 ```mlir
 move(%x : !region, %z : !mut<Type>) ->
 RegionType::insert<YesTransfer>(alloc, x, z)
 ```
 
-`extref` inserts an external reference to an object in another region but not transferring the ownership to the new region.
+`extref` inserts an external reference to an object in another region but not transfering the ownership to the new region.
 ```mlir
 extref(%x : !region, %z : !mut<Type>) ->
 RegionType::insert<NoTransfer>(alloc, x, z)
@@ -300,7 +300,7 @@ Freeze::apply(alloc, x)
 
 ## IR Optimisation
 
-The main reason for an MLIR dialect, rather than direct lowering to LLVM IR, is so we can do high-level transformations that would be costly or impossible in a low-level IR.
+The main reason for an MLIR dialect, rather than direct lowring to LLVM IR, is to we can do high-level transformations that would be costly or impossible in a low-level IR.
 
 This section justifies the existence of the operations and types declared for what optimisations they allow.
 


### PR DESCRIPTION
Recent changes in semantics have inspired additions to the dialect, to allow optimisations and easy representation in IR.

This change adds more detail to existing operations as well as new types (`!throw`, `!region`) and new operations (`throw`, `catch`, `match`, etc) which will all be used for high-level optimisations. It also adds some examples of optimisations and how those operations help.

Not really final, by a long shot, but I think we're getting close to a semantics that connects Verona AST with LLVM IR really well.