### PR TITLE
Update the process sandbox code for snmalloc2.

### DIFF
--- a/devops/ci.yml
+++ b/devops/ci.yml
@@ -105,7 +105,7 @@ jobs:
 - job:
   displayName: LinuxSandboxTests
   dependsOn: ConfigureCIRun
-  condition: false # eq(dependencies.ConfigureCIRun.outputs['setVarStep.testProcSandbox'], 'On')
+  condition: eq(dependencies.ConfigureCIRun.outputs['setVarStep.testProcSandbox'], 'On')
   pool:
     vmImage: 'ubuntu-20.04'
   timeoutInMinutes: 120

--- a/experiments/process_sandbox/CMakeLists.txt
+++ b/experiments/process_sandbox/CMakeLists.txt
@@ -68,7 +68,7 @@ target_link_libraries(sandbox fmt)
 target_link_options(library_runner PRIVATE -Wl,-export-dynamic)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-	target_link_libraries(library_runner -ldl -lbsd)
+	target_link_libraries(library_runner -ldl -lbsd -lrt)
 	target_link_libraries(sandbox -ldl -lbsd -lrt)
 endif()
 

--- a/experiments/process_sandbox/include/process_sandbox/helpers.h
+++ b/experiments/process_sandbox/include/process_sandbox/helpers.h
@@ -138,7 +138,7 @@ namespace sandbox
    * and so we need to pack those into a tuple.
    */
   template<DebugOption Enable = DebugAndRelease, typename Msg, typename... Args>
-  __attribute__((always_inline)) void invariant(
+  __attribute__((always_inline)) inline void invariant(
     bool cond,
     Msg msg = "Assertion failure",
     std::tuple<Args...> fmt_args = {},

--- a/experiments/process_sandbox/include/process_sandbox/sandbox.h
+++ b/experiments/process_sandbox/include/process_sandbox/sandbox.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 #include <string.h>
 #include <tuple>
 #include <vector>
@@ -20,40 +21,13 @@
 
 #include <snmalloc.h>
 
-#ifndef SANDBOX_PAGEMAP
-#  ifdef SNMALLOC_DEFAULT_PAGEMAP
-#    define SANDBOX_PAGEMAP SNMALLOC_DEFAULT_PAGEMAP
-#  else
-#    define SANDBOX_PAGEMAP snmalloc::SuperslabMap
-#  endif
-#endif
-
-namespace snmalloc
-{
-  template<class T>
-  class MemoryProviderStateMixin;
-  template<class T>
-  class PALPlainMixin;
-  template<
-    bool (*NeedsInitialisation)(void*),
-    void* (*InitThreadAllocator)(function_ref<void*(void*)>),
-    class MemoryProvider,
-    class ChunkMap,
-    bool IsQueueInline>
-  class Allocator;
-  template<typename T>
-  struct SuperslabMap;
-  void* no_replacement(void*);
-}
-
 namespace sandbox
 {
   struct SharedMemoryRegion;
-  struct SharedPagemapAdaptor;
-  struct MemoryProviderBumpPointerState;
   class CallbackDispatcher;
   class ExportedFileTree;
   struct CallbackHandlerBase;
+  class Library;
 
   /**
    * An snmalloc Platform Abstraction Layer (PAL) that cannot be used to
@@ -61,54 +35,369 @@ namespace sandbox
    * pre-defined shared region.
    */
   using NoOpPal = snmalloc::PALNoAlloc<snmalloc::DefaultPal>;
+
   using snmalloc::pointer_offset;
 
   /**
-   * The memory provider for the shared region.  This manages a single
-   * contiguous address range.
+   * Snmalloc back-end structure for shared memory allocations.  This defines
+   * how snmalloc will interact with allocations that are per-sandbox.
+   *
+   * Globals used by the snmalloc instances that allocate sandbox memory from
+   * the outside.
    */
-  class SharedMemoryProvider
-  : public snmalloc::MemoryProviderStateMixin<NoOpPal>
+  struct SharedAllocConfig : public snmalloc::CommonConfig
   {
     /**
-     * Base address of the shared memory region.
+     * Forward definition of `Pagemap` so that `LocalState` can refer to it.
      */
-    void* base;
+    class Pagemap;
 
     /**
-     * Top of the shared memory region.
+     * The memory provider for the shared region.  This manages a single
+     * contiguous address range.  This class is used both by the sandboxing code
+     * and directly by snmalloc, which holds a reference to an instance of this
+     * in the allocator and uses it to allocate memory.  Snmalloc does not call
+     * any methods on this class but will pass it as the local-state parameter
+     * to the back-end functions that allocate memory.
+     *
+     * This class must be thread safe: both the RPC thread that services
+     * requests from the child process and the allocator that is owned by the
+     * sandboxed library object will access it concurrently.  There are two
+     * pieces of shared mutable state:
+     *
+     *  - The shared address-space manager.  This is protected by a flag lock
+     *    internally.
+     *  - The chunk allocator state.  This contains a fixed-size array of
+     *    multi-producer, multi-consumer stacks and so is safe to access from
+     * both threads.
      */
-    void* top;
-
-  public:
-    /**
-     * Constructor.  Takes the memory range allocated for the sandbox heap as
-     * arguments.
-     */
-    SharedMemoryProvider(void* base_address, size_t length)
-    : MemoryProviderStateMixin<NoOpPal>(base_address, length),
-      base(base_address),
-      top(pointer_offset(base, length))
-    {}
-
-    /**
-     * Predicate to test whether an object of size `sz` starting at `ptr`
-     * is within the region managed by this memory provider.
-     */
-    bool contains(const void* ptr, size_t sz)
+    class LocalState
     {
-      // We shouldn't need the const cast here, but pointer_offset doesn't
-      // correctly handle const pointers yet.
-      return (ptr >= base) &&
-        (pointer_offset(const_cast<void*>(ptr), sz) < top);
+      /**
+       * Base address of the shared memory region.
+       */
+      void* base;
+
+      /**
+       * Top of the shared memory region.
+       */
+      void* top;
+
+      /**
+       * Chunks that have been allocated by the shared allocator and not yet
+       * returned to the child.
+       */
+      snmalloc::ChunkAllocatorState chunk_alloc_state;
+
+    public:
+      /**
+       * The address-space manager that manages this region.
+       */
+      snmalloc::AddressSpaceManager<snmalloc::PALNoAlloc<snmalloc::DefaultPal>>
+        shared_asm;
+
+      /**
+       * Constructor.  Takes the memory range allocated for the sandbox heap as
+       * arguments.  This class takes responsibility for allocating memory from
+       * the provided range.  Nothing should access any of the memory in this
+       * range without first calling the `reserve` method on this class to
+       * acquire a chunk.
+       */
+      LocalState(void* start, size_t size);
+
+      /**
+       * Returns the chunk allocator state for this sandbox.  This is called
+       * only by the corresponding method in the `SharedAllocConfig` class,
+       * which is called from snmalloc.
+       */
+      snmalloc::ChunkAllocatorState& get_slab_allocator_state()
+      {
+        return chunk_alloc_state;
+      }
+
+      /**
+       * Predicate to test whether an object of size `sz` starting at `ptr`
+       * is within the region managed by this memory provider.
+       */
+      bool contains(const void* ptr, size_t sz)
+      {
+        // We shouldn't need the const cast here, but pointer_offset doesn't
+        // correctly handle const pointers yet.
+        return (ptr >= base) &&
+          (pointer_offset(const_cast<void*>(ptr), sz) < top);
+      }
+
+      /**
+       * Return the top of the sandbox.
+       */
+      void* top_address()
+      {
+        return top;
+      }
+
+      /**
+       * Return the top of the sandbox.
+       */
+      void* get_base()
+      {
+        return base;
+      }
+    };
+
+    /**
+     * The type of a pagemap that spans the entire address space.
+     *
+     * This is used for all compartments.  Currently, this is not the same
+     * pagemap that the parent process uses for any non-shared allocations.
+     * This could be changed in environments (such as Verona) that can
+     * guarantee that in-compartment pointers are never freed with the global
+     * `free` or if we have a default `Alloc` that checks for this case
+     * (perhaps with a flag in the metadata entry indicating whether the slab
+     * is compartment-owned).
+     */
+    class Pagemap
+    {
+      /**
+       * Concrete instance of a pagemap.  This is updated only with
+       * `pagemap_lock` held.
+       */
+      inline static snmalloc::FlatPagemap<
+        snmalloc::MIN_CHUNK_BITS,
+        snmalloc::MetaEntry,
+        NoOpPal,
+        /*fixed range*/ false>
+        pagemap;
+
+      /**
+       * Shared memory object backing the pagemap.  Every compartment has a
+       * read-only view of this that is mapped into its address space on start.
+       *
+       * This is a `unique_ptr` because otherwise this is not discarded in
+       * debug builds of the library runner and so ends up trying to initialise
+       * a new shared memory (which is not needed) in the child.  This doesn't
+       * matter too much, except that on GNU/Linux (and possibly other Linux
+       * variants) `shm_open` forwards to `open`, which then tries to do the
+       * `open` callback, before the callback mechanism is initialised.
+       */
+      inline static std::unique_ptr<platform::SharedMemoryMap> pagemap_mem;
+
+      /**
+       * Mutex that must be held while writing to the pagemap.
+       *
+       * This is a recursive mutex because it must be held during destruction
+       * of a `Library` and by each call to `set_meta_data` in that destructor.
+       */
+      inline static std::recursive_mutex pagemap_lock;
+
+    public:
+      using LocalState = SharedAllocConfig::LocalState;
+
+      /**
+       * Helper to get a reference to the pagemap and a lock guard.  This is the
+       * only way of accessing the pagemap outside of this class.  It should be
+       * used as:
+       *
+       * ```c++
+       * auto [g, pm] = Pagemap::get_pagemap_writeable();
+       * ```
+       *
+       * It is then safe to update `pm` for as long as `g` remains in scope.
+       * By default, these have the same lifetime.
+       */
+      std::tuple<
+        std::unique_lock<decltype(pagemap_lock)>,
+        decltype(pagemap)&> static get_pagemap_writeable()
+      {
+        std::unique_lock g(pagemap_lock);
+        return {std::move(g), pagemap};
+      }
+
+      /**
+       * Return a reference to the handle used for the pagemap.
+       */
+      static auto& get_pagemap_handle()
+      {
+        return pagemap_mem->get_handle();
+      }
+
+      /**
+       * Reserve a chunk of memory in the shared address space for this sandbox.
+       */
+      static void* reserve(LocalState& local_state, size_t size)
+      {
+        return local_state.shared_asm.reserve<true, Pagemap>(&local_state, size)
+          .unsafe_ptr();
+      }
+
+      /**
+       * Look up the metadata entry for an address.  This is called by snmalloc
+       * on the deallocation path to determine who owns the memory and, if it's
+       * the deallocating allocator, where to find the metadata.
+       */
+      template<bool potentially_out_of_range = false>
+      static const snmalloc::MetaEntry&
+      get_metaentry(LocalState*, snmalloc::address_t p)
+      {
+        return pagemap.template get<potentially_out_of_range>(p);
+      }
+
+      /**
+       * Sets metadata in the shared pagemap.  This assumes callers are trusted
+       * and does not validate the metadata.  This is called only by the trusted
+       * allocator, the RPC thread updating the pagemap on behalf of a child
+       * will write to the pagemap directly.
+       *
+       * In the case of a conflict over ownership, the caller of this always
+       * wins.  The RPC handler will check (with the lock held) if a `MetaEntry`
+       * identifies an out-of-sandbox allocator as the owner already and refuse
+       * to install a new version if it does.  This method, in contrast, will
+       * update the pagemap unconditionally.  This means that if the update by
+       * the trusted allocator is ordered first (by the lock) then the child
+       * will not install an update and if it is ordered second then it will
+       * overwrite the child's entry.  This means that the trusted allocator can
+       * end up with surprising values in its message queue (which it must
+       * protect against anyway because its message queue is writeable by
+       * untrusted code) but we cannot leak out-of-sandbox metaslabs as a result
+       * of activity by the child.
+       */
+      static void set_metaentry(
+        LocalState*, snmalloc::address_t p, size_t size, snmalloc::MetaEntry t)
+      {
+        auto [g, pm] = get_pagemap_writeable();
+        for (snmalloc::address_t a = p; a < p + size;
+             a += snmalloc::MIN_CHUNK_SIZE)
+        {
+          pm.set(a, t);
+        }
+      }
+
+      /**
+       * Register an address range.  This is used by the address-space manager.
+       */
+      static void register_range(LocalState*, snmalloc::address_t p, size_t sz)
+      {
+        auto [g, pm] = get_pagemap_writeable();
+        pm.register_range(p, sz);
+      }
+
+      /**
+       * Initialise the pagemap.  This must be called precisely once, from
+       * `SharedAllocConfig::ensure_init`.
+       */
+      static void init()
+      {
+        pagemap_mem = std::make_unique<platform::SharedMemoryMap>(
+          static_cast<uint8_t>(snmalloc::bits::next_pow2_bits_const(
+            decltype(pagemap)::required_size())));
+        assert(pagemap_mem->get_base());
+        pagemap.init(
+          static_cast<snmalloc::MetaEntry*>((pagemap_mem->get_base())));
+      }
+    };
+
+    /**
+     * The PAL that snmalloc will use for this back end.  This is used only by
+     * snmalloc.
+     */
+    using Pal = NoOpPal;
+
+    /**
+     * Allocate a chunk, its associated metaslab, and install its metadata
+     * entry in the pagemap.  This allocates the chunk in the sandbox-shared
+     * memory region and the metaslab in host-owned memory.  This means that
+     * all metadata associated with an allocation from outside is inaccessible
+     * by the sandbox and does not need to be validated.
+     */
+    static std::
+      pair<snmalloc::CapPtr<void, snmalloc::CBChunk>, snmalloc::Metaslab*>
+      alloc_chunk(
+        LocalState* local_state,
+        size_t size,
+        snmalloc::RemoteAllocator* remote,
+        snmalloc::sizeclass_t sizeclass)
+    {
+      auto p = Pagemap::reserve(*local_state, size);
+      if (p == nullptr)
+      {
+        return {nullptr, nullptr};
+      }
+      auto* meta = new snmalloc::Metaslab();
+      snmalloc::MetaEntry t(meta, remote, sizeclass);
+      auto [g, pm] = Pagemap::get_pagemap_writeable();
+
+      for (snmalloc::address_t a = snmalloc::address_cast(p);
+           a < snmalloc::address_cast(pointer_offset(p, size));
+           a += snmalloc::MIN_CHUNK_SIZE)
+      {
+        pm.set(a, t);
+      }
+      return {snmalloc::CapPtr<void, snmalloc::CBChunk>{p}, meta};
     }
 
     /**
-     * Return the top of the sandbox.
+     * Allocate metadata.  Metadata is stored outside of the sandbox and so
+     * this is just allocated with the normal malloc.
+     *
+     * This has a single concrete specialisation, to allocate metaslabs.  Any
+     * modifications to snmalloc that try to allocate other types though this
+     * interface will cause linker failures, allowing us to check whether they
+     * need to be allocated in the shared memory region or not.
+     *
+     * Note that there is not specialisation of this function to allocate
+     * allocators.  This would be used by the pool allocator functionality in
+     * snmalloc.  We should have exactly one shared allocator per sandbox and
+     * so we don't use the pool allocator and will get a link failure if we
+     * accidentally do.
      */
-    void* top_address()
+    template<typename T>
+    static snmalloc::CapPtr<void, snmalloc::CBChunk>
+    alloc_meta_data(LocalState*, size_t size);
+
+    /**
+     * Return the slab allocator.  This is per sandbox: memory must not be
+     * freed by one sandbox and then allocated to another (getting this wrong
+     * shouldn't break the security guarantees but it can lead to crashes).
+     */
+    static snmalloc::ChunkAllocatorState&
+    get_slab_allocator_state(LocalState* mp)
     {
-      return top;
+      SANDBOX_INVARIANT(mp != nullptr, "Chunk allocator state is per-sandbox");
+      return mp->get_slab_allocator_state();
+    }
+
+    /**
+     * Options for configuring snmalloc.  This allocator is almost the exact
+     * opposite of the default.  There is only one of them per sandbox, they
+     * aren't per-thread, they're allocated and deallocated by the sandbox
+     * library.
+     */
+    constexpr static snmalloc::Flags Options{.IsQueueInline = false,
+                                             .CoreAllocOwnsLocalState = false,
+                                             .CoreAllocIsPoolAllocated = false,
+                                             .LocalAllocSupportsLazyInit =
+                                               false};
+
+  private:
+    friend class LocalState;
+
+    /**
+     * Construct the global state object.  This allocates the huge region for
+     * the pagemap (512 GiB currently, subject to change) and initialises the
+     * pagemap object to point to it.
+     *
+     * This does not use snmalloc's lazy initialisation logic because we need
+     * to create the shared memory *before* we create any allocators.  It is
+     * called in LocalState's constructor.
+     */
+    inline static void ensure_initialised()
+    {
+      static std::atomic<bool> isInitialised = false;
+      if (isInitialised)
+      {
+        return;
+      }
+      isInitialised = true;
+      Pagemap::init();
     }
   };
 
@@ -128,36 +417,33 @@ namespace sandbox
      */
     using handle_t = platform::handle_t;
 
-    SNMALLOC_FAST_PATH static bool needs_initialisation(void*)
-    {
-      return false;
-    }
-    SNMALLOC_FAST_PATH static void*
-      init_thread_allocator(snmalloc::function_ref<void*(void*)>)
-    {
-      return nullptr;
-    }
     /**
      * The type of the allocator that allocates within the shared region from
      * outside.  This has an out-of-line message queue, allocated in the shared
      * memory region, and updates both the child and parent views of the
      * pagemap when allocating new slabs.
      */
-    using SharedAlloc = snmalloc::Allocator<
-      needs_initialisation,
-      init_thread_allocator,
-      SharedMemoryProvider,
-      SharedPagemapAdaptor,
-      false>;
+    using SharedAlloc = snmalloc::LocalAllocator<SharedAllocConfig>;
+
+    /**
+     * A pointer to the core allocator.  Each snmalloc allocator is a pair of a
+     * core allocator and a local allocator.  The former provides the slow-path
+     * operations and is managed by the latter, which provides fast-path
+     * operations.
+     */
+    std::unique_ptr<snmalloc::CoreAllocator<SharedAllocConfig>> core_alloc;
+
     /**
      * The allocator used for allocating memory inside this sandbox.
      */
-    SharedAlloc* allocator;
+    std::unique_ptr<SharedAlloc> allocator;
+
     /**
      * The handle to the socket that is used to pass file descriptors to the
      * sandboxed process.
      */
     platform::SocketPair::Socket socket;
+
     /**
      * The platform-specific child process.
      */
@@ -194,16 +480,11 @@ namespace sandbox
     platform::SharedMemoryMap shm;
 
     /**
-     * The shared pagemap page.
-     */
-    platform::SharedMemoryMap shared_pagemap;
-
-    /**
      * The (trusted) memory provider that is used to allocate large regions to
      * memory allocators.  This is used directly from outside of the sandbox
      * and via an RPC mechanism that checks arguments from inside.
      */
-    SharedMemoryProvider memory_provider;
+    SharedAllocConfig::LocalState memory_provider;
 
     /**
      * Allocate some memory in the sandbox.  Returns `nullptr` if the
@@ -229,8 +510,9 @@ namespace sandbox
      * The `sharedmem_addr` is the address at which the shared memory region
      * should be mapped in the child.
      *
-     * The `pagemap_mem` parameter is the file descriptor for the pagemap
-     * shared page.
+     * The `pagemap_mem` parameter is the file descriptor for the shared memory
+     * backing the pagemap that is used by all sandboxes.  This must not be
+     * closed in the parent process.
      *
      * The `pagemap_pipe` parameter is the file descriptor for the pipe used to
      * send pagemap updates from the child to the parent.
@@ -242,7 +524,7 @@ namespace sandbox
       const char* library_name,
       const char* librunnerpath,
       const void* sharedmem_addr,
-      platform::Handle& pagemap_mem,
+      const platform::Handle& pagemap_mem,
       platform::Handle&& pagemap_pipe,
       platform::Handle&& fd_socket);
 

--- a/experiments/process_sandbox/src/child_malloc.h
+++ b/experiments/process_sandbox/src/child_malloc.h
@@ -2,15 +2,17 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
-#include <aal/aal.h>
-#include <ds/bits.h>
-#include <pal/pal.h>
-#include <stdint.h>
+#ifdef __FreeBSD__
+#  define SNMALLOC_USE_THREAD_CLEANUP 1
+#endif
+#define SNMALLOC_PLATFORM_HAS_GETENTROPY 1
+#define SNMALLOC_PROVIDE_OWN_CONFIG 1
+#include <process_sandbox/helpers.h>
+#include <process_sandbox/sandbox_fd_numbers.h>
+#include <snmalloc_core.h>
 
 namespace snmalloc
 {
-  template<typename T>
-  struct SuperslabMap;
   class Superslab;
   class Mediumslab;
   class Largeslab;
@@ -19,157 +21,227 @@ namespace snmalloc
 namespace sandbox
 {
   /**
-   * The proxy pagemap.  In the sandboxed process, there are two parts of the
-   * pagemap.  The child process maintains a private pagemap for process-local
-   * memory, the parent process maintains a fragment of this pagemap
-   * corresponding to the shared memory region.
-   *
-   * This class is responsible for managing the composition of the two page
-   * maps.  All queries are local but updates must be forwarded to either the
-   * parent process or the private pagemap.
+   * The snmalloc configuration used for the child process.
    */
-  struct ProxyPageMap
+  class SnmallocGlobals : public snmalloc::CommonConfig
   {
     /**
-     * Singleton instance of this class.
+     * Non-templated version of reserve_with_left_over.  Calls the parent
+     * process to request a new chunk of memory.
      */
-    static ProxyPageMap p;
+    static snmalloc::CapPtr<void, snmalloc::CBChunk> reserve(size_t size);
+
     /**
-     * Accessor, returns the singleton instance of this class.
+     * Private address-space manager.  Used to manage allocations that are
+     * not shared with the parent.
      */
-    static ProxyPageMap& pagemap()
+    inline static snmalloc::AddressSpaceManager<snmalloc::DefaultPal>
+      private_asm;
+
+  public:
+    /**
+     * Interface to a pagemap that is private to the child.  This is used with
+     * the private address-space manage.
+     */
+    struct PrivatePagemap
     {
-      return p;
+      /**
+       * Empty local state.  This is required to exist by snmalloc.
+       */
+      struct LocalState
+      {};
+
+      /**
+       * Private pagemap, allocated in memory owned exclusively by the child.
+       */
+      inline static snmalloc::FlatPagemap<
+        snmalloc::MIN_CHUNK_BITS,
+        snmalloc::MetaEntry,
+        snmalloc::DefaultPal,
+        /*fixed range*/ false>
+        pagemap;
+
+      /**
+       * Return the metadata associated with an address.  This reads the
+       * private pagemap.
+       */
+      template<bool potentially_out_of_range = false>
+      SNMALLOC_FAST_PATH static const snmalloc::MetaEntry&
+      get_metaentry(LocalState*, snmalloc::address_t p)
+      {
+        return pagemap.template get<potentially_out_of_range>(p);
+      }
+
+      /**
+       * Set the metadata associated with an address range.  Updates the private
+       * pagemap directly.
+       */
+      SNMALLOC_FAST_PATH
+      static void set_metaentry(
+        LocalState*, snmalloc::address_t p, size_t size, snmalloc::MetaEntry t)
+      {
+        for (auto a = p; a < p + size; a += snmalloc::MIN_CHUNK_SIZE)
+        {
+          pagemap.set(a, t);
+        }
+      }
+
+      /**
+       * Ensure that the range is valid in the private pagemap.
+       */
+      static void
+      register_range(LocalState*, snmalloc::address_t p, size_t size)
+      {
+        pagemap.register_range(p, size);
+      }
+    };
+
+    /**
+     * Expose a PAL that doesn't do allocation.
+     */
+    using Pal = snmalloc::PALNoAlloc<snmalloc::DefaultPal>;
+
+    /**
+     * Thread-local state.  Currently not used.
+     */
+    struct LocalState
+    {};
+
+    struct Pagemap
+    {
+      /**
+       * Local state for pagemap updates.  Currently unused.
+       */
+      using LocalState = SnmallocGlobals::LocalState;
+
+      /**
+       * The pagemap that spans the entire address space.  This uses a read-only
+       * mapping of a shared memory region as its backing store.
+       */
+      inline static snmalloc::FlatPagemap<
+        snmalloc::MIN_CHUNK_BITS,
+        snmalloc::MetaEntry,
+        snmalloc::DefaultPal,
+        /*fixed range*/ false>
+        pagemap;
+
+      /**
+       * Return the metadata associated with an address.  This reads the
+       * read-only mapping of the pagemap directly.
+       */
+      template<bool potentially_out_of_range = false>
+      SNMALLOC_FAST_PATH static const snmalloc::MetaEntry&
+      get_metaentry(LocalState*, snmalloc::address_t p)
+      {
+        return pagemap.template get<potentially_out_of_range>(p);
+      }
+
+      /**
+       * Set the metadata associated with an address range.  Sends an RPC to the
+       * parent, which validates and inserts the entry.
+       */
+      SNMALLOC_FAST_PATH
+      static void set_metaentry(
+        LocalState*, snmalloc::address_t p, size_t size, snmalloc::MetaEntry t);
+
+      /**
+       * Ensure that the range is valid.  This is a no-op: the parent is
+       * responsible for ensuring that the pagemap covers the entire address
+       * range.
+       */
+      static void register_range(LocalState*, snmalloc::address_t, size_t) {}
+    };
+
+    /**
+     * Allocate a chunk of memory and install its metadata in the pagemap.
+     * This performs a single RPC that validates the metadata and then
+     * allocates and installs the entry.
+     */
+    static std::
+      pair<snmalloc::CapPtr<void, snmalloc::CBChunk>, snmalloc::Metaslab*>
+      alloc_chunk(
+        LocalState* local_state,
+        size_t size,
+        snmalloc::RemoteAllocator* remote,
+        snmalloc::sizeclass_t sizeclass);
+
+    /**
+     * Allocate metadata.  This allocates non-shared memory for metaslabs and
+     * shared memory for allocators.
+     */
+    template<typename T>
+    static snmalloc::CapPtr<void, snmalloc::CBChunk>
+    alloc_meta_data(LocalState*, size_t size);
+
+    /**
+     * The allocator pool type used to allocate per-thread allocators.
+     */
+    using AllocPool =
+      snmalloc::PoolState<snmalloc::CoreAllocator<SnmallocGlobals>>;
+
+    /**
+     * The state associated with the chunk allocator.
+     */
+    inline static snmalloc::ChunkAllocatorState chunk_alloc_state;
+
+    /**
+     * The concrete instance of the pool allocator.
+     */
+    inline static AllocPool alloc_pool;
+
+  public:
+    /**
+     * Returns the allocation pool.
+     */
+    static AllocPool& pool()
+    {
+      return alloc_pool;
     }
-    /**
-     * Helper function used by the set methods that are part of the page map
-     * interface.  Requires that the address (`p`) is in the shared region.
-     * This writes the required change as a message to the parent process and
-     * spins waiting for the parent to make the required update.
-     */
-    void set(snmalloc::address_t p, uint8_t x);
-    /**
-     * Get the pagemap entry for a specific address.
-     */
-    static uint8_t get(snmalloc::address_t p);
-    /**
-     * Get the pagemap entry for a specific address.
-     */
-    static uint8_t get(void* p);
-    /**
-     * Type-safe interface for setting that a particular memory region contains
-     * a superslab. This calls `set`.
-     */
-    void set_slab(snmalloc::Superslab* slab);
-    /**
-     * Type-safe interface for notifying that a region no longer contains a
-     * superslab.  Calls `set`.
-     */
-    void clear_slab(snmalloc::Superslab* slab);
-    /**
-     * Type-safe interface for notifying that a region no longer contains a
-     * medium slab.  Calls `set`.
-     */
-    void clear_slab(snmalloc::Mediumslab* slab);
-    /**
-     * Type-safe interface for setting that a particular memory region contains
-     * a medium slab. This calls `set`.
-     */
-    void set_slab(snmalloc::Mediumslab* slab);
-    /**
-     * Type-safe interface for setting the pagemap values for a region to
-     * indicate a large allocation.
-     */
-    void set_large_size(void* p, size_t size);
-    /**
-     * The inverse operation of `set_large_size`, updates a range to indicate
-     * that it is not in use.
-     */
-    void clear_large_size(void* p, size_t size);
-  };
-
-  /**
-   * The proxy memory provider.  This uses a simple RPC protocol to forward all
-   * requests to the parent process, which validates the arguments and forwards
-   * them to the trusted address-space manager for the sandbox.
-   */
-  struct MemoryProviderProxy
-  {
-    /**
-     * The PAL that we use inside the sandbox.  This is incapable of
-     * allocating memory.
-     */
-    typedef snmalloc::PALNoAlloc<snmalloc::DefaultPal> Pal;
 
     /**
-     * Pop a large allocation from the stack to the address space manager in
-     * the parent process corresponding to a large size class.
+     * Ensure that all of the early bootstrapping is done.
      */
-    void* pop_large_stack(size_t large_class);
+    static void ensure_init() noexcept;
 
     /**
-     * Push a large allocation to the address space manager in the parent
-     * process.
+     * Returns true if the system has bootstrapped, false otherwise.
      */
-    void push_large_stack(snmalloc::Largeslab* slab, size_t large_class);
+    static bool is_initialised();
 
     /**
-     * Reserve committed memory of a large size class size by calling into the
-     * parent to request address space in the shared region.
+     * Message queues are currently always allocated inline for
+     * in-sandbox allocators.  When we move to dynamically creating
+     * shared memory objects one per chunk then they will move to a
+     * separate place. For now, all options are the defaults.
      */
-    void* reserve_committed(size_t large_class) noexcept;
+    constexpr static snmalloc::Flags Options{};
 
     /**
-     * Reserve a range of memory identified by a size, not a size class.  This
-     * is used only in `alloc_chunk` and is not inlined because its
-     * implementation needs to refer to snmalloc size classes, which are
-     * defined only in a header inclusion that requires this class to be
-     * defined.
+     * Register per-thread cleanup.
      */
-    void* reserve_committed_size(size_t size) noexcept;
-
-    /**
-     * Public interface to reserve memory.  Ignores the `committed` argument,
-     * the shared memory is always committed.
-     */
-    template<bool committed>
-    void* reserve(size_t large_class) noexcept
+    static void register_clean_up()
     {
-      return reserve_committed(large_class);
+#ifndef SNMALLOC_USE_THREAD_CLEANUP
+      snmalloc::register_clean_up();
+#endif
     }
 
     /**
-     * Factory method, used by the `Singleton` helper.  This is responsible for
-     * any bootstrapping needed to communicate with the parent.
+     * Returns the singleton instance of the chunk allocator state.
      */
-    static MemoryProviderProxy* make() noexcept;
-
-    /**
-     * Allocate a chunk.  This implementation is wasteful, rounding the
-     * requested sizes up to the smallest large size class (typically one MiB).
-     * This is called only twice in normal use for a sandbox, so wasting a bit
-     * of address space is not the highest priority fix yet.  Given how little
-     * this is actually needed, a better implementation would reserve some
-     * space in the non-heap shared memory region for these requests.
-     */
-    template<typename T, size_t alignment, typename... Args>
-    T* alloc_chunk(Args&&... args)
+    static snmalloc::ChunkAllocatorState& get_slab_allocator_state(void*)
     {
-      // Cache line align
-      size_t size = snmalloc::bits::align_up(sizeof(T), 64);
-      size = snmalloc::bits::next_pow2(snmalloc::bits::max(size, alignment));
-      void* p = reserve_committed_size(size);
-      if (p == nullptr)
-        return nullptr;
-
-      return new (p) T(std::forward<Args...>(args)...);
+      return chunk_alloc_state;
     }
   };
 }
 
-#define SNMALLOC_DEFAULT_CHUNKMAP sandbox::ProxyPageMap
-#define SNMALLOC_DEFAULT_MEMORY_PROVIDER sandbox::MemoryProviderProxy
-#ifdef __FreeBSD__
-#  define SNMALLOC_USE_THREAD_CLEANUP 1
-#endif
-#include "override/malloc.cc"
+namespace snmalloc
+{
+  /**
+   * The standard allocator type that we provide.
+   */
+  using Alloc = LocalAllocator<sandbox::SnmallocGlobals>;
+}
+
+#include <override/malloc.cc>

--- a/experiments/process_sandbox/src/host_service_calls.h
+++ b/experiments/process_sandbox/src/host_service_calls.h
@@ -22,44 +22,34 @@ namespace sandbox
   enum HostServiceCallID : uintptr_t
   {
     /**
-     * Push a large allocation to the stack.  The first argument is the address
-     * of the slab, the second the large sizeclass.  The return value is unused.
-     *
-     * The slab must be within the shared memory region for the sandbox and so
-     * must have been previously returned with a call to either
-     * `MemoryProviderPopLargeStack` or `MemoryProviderReserve`.
-     */
-    MemoryProviderPushLargeStack,
-    /**
-     * Pop a large allocation from the stack.  The first argument is the large
-     * sizeclass, the second is unused.  The return value is the address of the
-     * large allocation that was popped from the stack, 0 indicates that the
-     * stack was empty.
-     */
-    MemoryProviderPopLargeStack,
-    /**
-     * Reserve memory.  The first argument is the large sizeclass, the second
-     * is unused.  The return value is the start of the reserved address range.
+     * Reserve memory.  The first (and only) argument is the number of bytes.
+     * static_cast<he>(return value is the start of the reserved address range.
      *
      * Note: The `committed` template parameter is ignored, the shared memory
      * region is assumed to always be committed.
      */
     MemoryProviderReserve,
     /**
-     * Set a chunk map element. The first argument is the address, the second
-     * is the chunkmap entry.  The return value is unused.
+     * Sets the metadata for a slab.  The arguments are:
+     *
+     * - The slab address
+     * - The slab size
+     * - The pointer to the metadata (MetaSlab)
+     * - The message queue with the size class encoded in the low bits.
      */
-    ChunkMapSet,
+    MetadataSet,
     /**
-     * Set a range in the chunk map.  The first argument is the base address,
-     * the second is the base-2 logarithm of the size (rounded up).
+     * Allocate a chunk.  The arguments are:
+     *  - The size to allocate
+     *  - The address of the message queue
+     *  - The size class of the allocation
+     *  - The address of the metadata.
+     *
+     * Note that the address of the metadata should never be
+     * accessed from outside the sandbox and so does not need to be in the
+     * shared memory region.
      */
-    ChunkMapSetRange,
-    /**
-     * Clear a range in the chunk map.  The first argument is the base address,
-     * the second is the base-2 logarithm of the size (rounded up).
-     */
-    ChunkMapClearRange,
+    AllocChunk,
   };
 
   /**
@@ -74,13 +64,9 @@ namespace sandbox
     HostServiceCallID kind;
 
     /**
-     * The first argument.  The interpretation of this is depends on the call.
+     * The arguments.  The interpretation of this is depends on the call.
      */
-    uintptr_t arg0;
-    /**
-     * The second argument.  The interpretation of this is depends on the call.
-     */
-    uintptr_t arg1;
+    uintptr_t args[4];
   };
 
   /**

--- a/experiments/process_sandbox/src/libsandbox.cc
+++ b/experiments/process_sandbox/src/libsandbox.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include <array>
+#include <chrono>
 #include <functional>
 #include <mutex>
 #include <queue>
@@ -33,6 +34,8 @@
 #include "process_sandbox/sandbox.h"
 #include "process_sandbox/shared_memory_region.h"
 
+using namespace std::chrono_literals;
+
 namespace
 {
   // The library load paths.  We're going to pass all of these to the
@@ -42,6 +45,14 @@ namespace
 
 namespace sandbox
 {
+  SharedAllocConfig::LocalState::LocalState(void* start, size_t size)
+  : base(start), top(pointer_offset(base, size))
+  {
+    // Force initialisation of the shared memory object backing the pagemap.
+    SharedAllocConfig::ensure_initialised();
+    shared_asm.add_range<SharedAllocConfig::Pagemap>(
+      this, snmalloc::CapPtr<void, snmalloc::CBChunk>{start}, size);
+  }
   /**
    * Singleton class that handles pagemap updates from children.  This listens
    * on a socket for updates, validates that they correspond to the memory that
@@ -53,7 +64,6 @@ namespace sandbox
    */
   class MemoryServiceProvider
   {
-    snmalloc::DefaultChunkMap<> pm;
     platform::Poller poller;
     /**
      * Add a new socket that we'll wait for.  This can be called from any
@@ -68,21 +78,6 @@ namespace sandbox
      */
     std::mutex m;
     /**
-     * Metadata about a sandbox for which we are updating the page map.
-     */
-    struct Sandbox
-    {
-      /**
-       * The memory provider that owns the above range.
-       */
-      SharedMemoryProvider* memory_provider;
-      /**
-       * The shared pagemap page that we need to update on behalf of this
-       * process.
-       */
-      uint8_t* shared_page = nullptr;
-    };
-    /**
      * A map from file descriptor over which we've received an update request
      * to the sandbox metadata.
      *
@@ -91,7 +86,9 @@ namespace sandbox
      * by storing an owning copy of the handle in the value and using the
      * non-owning value in the value.
      */
-    std::unordered_map<platform::handle_t, std::pair<platform::Handle, Sandbox>>
+    std::unordered_map<
+      platform::handle_t,
+      std::pair<platform::Handle, SharedAllocConfig::LocalState*>>
       ranges;
     /**
      * Run loop.  Wait for updates from the child.
@@ -122,7 +119,7 @@ namespace sandbox
           // but slightly misses the point of fault isolation.
         }
         HostServiceResponse reply{1, 0};
-        Sandbox s;
+        SharedAllocConfig::LocalState* s;
         {
           decltype(ranges)::iterator r;
           std::lock_guard g(m);
@@ -133,62 +130,69 @@ namespace sandbox
           }
           s = r->second.second;
         }
-        auto is_large_sizeclass = [](auto large_size) {
-          return (large_size < snmalloc::NUM_LARGE_CLASSES);
-        };
         // No default so we get range checking.  Fallthrough returns the error
         // result.
         switch (rpc.kind)
         {
-          case MemoryProviderPushLargeStack:
-          {
-            // This may truncate, but only if the sandbox is doing
-            // something bad.  We'll catch that on the range check (or get
-            // some in-sandbox corruption that the sandbox could do
-            // anyway), so don't bother checking it now.
-            void* base = reinterpret_cast<void*>(rpc.arg0);
-            uint8_t large_size = static_cast<uint8_t>(rpc.arg1);
-            if (
-              !is_large_sizeclass(large_size) ||
-              !s.memory_provider->contains(
-                base, snmalloc::large_sizeclass_to_size(large_size)))
-            {
-              break;
-            }
-            s.memory_provider->push_large_stack(
-              static_cast<snmalloc::Largeslab*>(base), large_size);
-            reply = {0, 0};
-            break;
-          }
-          case MemoryProviderPopLargeStack:
-          {
-            uint8_t large_size = static_cast<uint8_t>(rpc.arg1);
-            if (!is_large_sizeclass(large_size))
-            {
-              break;
-            }
-            reply = {0,
-                     reinterpret_cast<uintptr_t>(
-                       s.memory_provider->pop_large_stack(large_size))};
-            break;
-          }
           case MemoryProviderReserve:
           {
-            uint8_t large_size = static_cast<uint8_t>(rpc.arg0);
-            if (!is_large_sizeclass(large_size))
-            {
-              break;
-            }
+            size_t large_size = static_cast<size_t>(rpc.args[0]);
             reply = {0,
                      reinterpret_cast<uintptr_t>(
-                       s.memory_provider->template reserve<true>(large_size))};
+                       SharedAllocConfig::Pagemap::reserve(*s, large_size))};
             break;
           }
-          case ChunkMapSet:
-          case ChunkMapSetRange:
-          case ChunkMapClearRange:
+          case MetadataSet:
           {
-            reply.error = !validate_and_insert(s, rpc);
+            snmalloc::MetaEntry m{
+              reinterpret_cast<snmalloc::Metaslab*>(rpc.args[2]), rpc.args[3]};
+            char* p = reinterpret_cast<char*>(rpc.args[0]);
+            size_t size = static_cast<size_t>(rpc.args[1]);
+            for (char* a = p; a < p + size; a += snmalloc::MIN_CHUNK_SIZE)
+            {
+              reply.error |= validate_and_insert(s, a, m);
+            }
+            break;
+          }
+          case AllocChunk:
+          {
+            auto size = static_cast<size_t>(rpc.args[0]);
+            auto sizeclass = static_cast<snmalloc::sizeclass_t>(rpc.args[2]);
+            bool isLarge = size > snmalloc::MIN_CHUNK_SIZE;
+            auto msgq =
+              reinterpret_cast<snmalloc::RemoteAllocator*>(rpc.args[1]);
+            if (
+              !(s->contains(msgq, sizeof(snmalloc::RemoteAllocator))) &&
+              ((isLarge && (snmalloc::sizeclass_to_size(sizeclass) == size)) ||
+               (!isLarge && (snmalloc::sizeclass_to_size(sizeclass) <= size))))
+            {
+              reply.error = 1;
+              break;
+            }
+            void* alloc = SharedAllocConfig::Pagemap::reserve(
+              *s, static_cast<size_t>(rpc.args[0]));
+            if (alloc == nullptr)
+            {
+              reply.error = 1;
+              break;
+            }
+            // For large allocations we store the power of two size, not the
+            // sizeclass.
+            if (isLarge)
+            {
+              sizeclass = snmalloc::bits::next_pow2_bits(size);
+            }
+            char* p = static_cast<char*>(alloc);
+            snmalloc::MetaEntry m{
+              reinterpret_cast<snmalloc::Metaslab*>(rpc.args[3]),
+              msgq,
+              sizeclass};
+            for (char* a = p; a < p + size; a += snmalloc::MIN_CHUNK_SIZE)
+            {
+              reply.error |= validate_and_insert(s, a, m);
+            }
+
+            reply = {0, reinterpret_cast<uintptr_t>(alloc)};
             break;
           }
         }
@@ -215,65 +219,48 @@ namespace sandbox
     }
     /**
      * Validate a request from the sandbox to update a pagemap and insert it if
-     * allowed.  The `sender` parameter is the file descriptor over which the
-     * message was sent. The `position` parameter is the address of the memory
-     * for which the corresponding pagemap entry is to be updated.  For the
-     * update to succeed, this must be within the range owned by the sandbox
-     * identified by the sending socket.  The last two parameters indicate
-     * whether this is a large allocation (one that spans multiple pagemap
-     * entries) and the value.  If `isBig` is 0, then this is a simple update
-     * of a single pagemap entry (typically a slab), specified in the `value`
-     * parameter.  Otherwise, `value` is the base-2 logarithm of the size,
-     * which is either being set or cleared (`isBig` values of 1 and 2,
-     * respectively).
+     * allowed.
      */
-    bool validate_and_insert(Sandbox& s, HostServiceRequest rpc)
+    bool validate_and_insert(
+      SharedAllocConfig::LocalState* s, void* address, snmalloc::MetaEntry m)
     {
-      void* address = reinterpret_cast<void*>(rpc.arg0);
-      snmalloc::ChunkmapPagemap& cpm = snmalloc::GlobalPagemap::pagemap();
-      size_t index = cpm.index_for_address(rpc.arg0);
-      size_t entries = 1;
-      bool safe = true;
-      auto check_large_update = [&]() {
-        size_t alloc_size = (1ULL << rpc.arg1);
-        entries = alloc_size / snmalloc::SUPERSLAB_SIZE;
-        return s.memory_provider->contains(address, alloc_size);
-      };
-      switch (rpc.kind)
+      size_t range_size;
+      void* base_address = address;
+      bool is_fake = m.get_remote() == SharedAllocConfig::fake_large_remote;
+      if (is_fake)
       {
-        default:
-          // Should be unreachable
-          SANDBOX_DEBUG_INVARIANT(false, "Invalid RPC kind: {}", rpc.kind);
-          __builtin_unreachable();
-          break;
-        case ChunkMapSet:
-          if ((safe = s.memory_provider->contains(
-                 address, snmalloc::SUPERSLAB_SIZE)))
-          {
-            cpm.set(rpc.arg0, rpc.arg1);
-          }
-          break;
-        case ChunkMapSetRange:
-          if ((safe = check_large_update()))
-          {
-            pm.set_large_size(address, 1ULL << rpc.arg1);
-          }
-          break;
-        case ChunkMapClearRange:
-          if ((safe = check_large_update()))
-          {
-            pm.clear_large_size(address, 1ULL << rpc.arg1);
-          }
+        range_size = 1 << m.get_sizeclass();
+        base_address = snmalloc::pointer_align_down(address, range_size);
       }
-      if (safe)
+      else
       {
-        for (size_t i = 0; i < entries; i++)
-        {
-          s.shared_page[index + i] =
-            pm.get(pointer_offset(address, i * snmalloc::SUPERSLAB_SIZE));
-        }
+        range_size = snmalloc::sizeclass_to_size(m.get_sizeclass());
       }
-      return safe;
+      // Metadata updates must refer to addresses associated with the sandbox.
+      if (!s->contains(base_address, range_size))
+      {
+        return false;
+      }
+      // The message queue must be in the allocator.
+      if (
+        !is_fake &&
+        !s->contains(m.get_remote(), sizeof(snmalloc::RemoteAllocator)))
+      {
+        return false;
+      }
+      // Protect against a race where the child tries to claim ownership of a
+      // chunk of memory at the same time as the parent.  In the case of a
+      // conflict, the trusted parent is allowed to take ownership so that we
+      // don't leak a metaslab in the parent.
+      auto [g, pm] = SharedAllocConfig::Pagemap::get_pagemap_writeable();
+      auto p = snmalloc::address_cast(address);
+      auto* old = pm.template get<false>(p).get_remote();
+      if ((old != nullptr) && !s->contains(old, sizeof(*old)))
+      {
+        return false;
+      }
+      pm.set(p, m);
+      return true;
     }
 
   public:
@@ -293,17 +280,14 @@ namespace sandbox
      * page.
      */
     void add_range(
-      SharedMemoryProvider* memory_provider,
-      platform::Handle&& socket,
-      platform::SharedMemoryMap& page)
+      SharedAllocConfig::LocalState& memory_provider, platform::Handle&& socket)
     {
       {
         std::lock_guard g(m);
         register_fd(socket);
         platform::handle_t socket_fd = socket.fd;
-        ranges[socket_fd] = std::make_pair(
-          std::move(socket),
-          Sandbox{memory_provider, static_cast<uint8_t*>(page.get_base())});
+        ranges.emplace(
+          socket_fd, std::make_pair(std::move(socket), &memory_provider));
       }
     }
   };
@@ -316,111 +300,6 @@ namespace sandbox
     static MemoryServiceProvider* p = new MemoryServiceProvider();
     return *p;
   }
-
-  /**
-   * Adaptor for allocators in the shared region to update the pagemap.
-   * These treat the global pagemap in the process as canonical but also
-   * update the pagemap in the child whenever the parent allocates within the
-   * shared region.
-   */
-  struct SharedPagemapAdaptor
-  {
-    /**
-     * Interface to the global pagemap.  Used to update the global pagemap and
-     * to query values to propagate to the child process.
-     */
-    snmalloc::DefaultChunkMap<> global_pagemap;
-    /**
-     * The page in the child process that will be mapped into its pagemap.  Any
-     * slab allocations by the parent must be propagated into this page.
-     */
-    uint8_t* shared_page;
-
-    /**
-     * Constructor.  Takes a shared pagemap page that this adaptor will update
-     * in addition to updating the global pagemap.
-     */
-    SharedPagemapAdaptor(uint8_t* p) : shared_page(p) {}
-
-    /**
-     * Update the child, propagating `entries` entries from the global pagemap
-     * into the shared pagemap region.
-     */
-    void update_child(uintptr_t p, size_t entries = 1)
-    {
-      snmalloc::ChunkmapPagemap& cpm = snmalloc::GlobalPagemap::pagemap();
-      size_t index = cpm.index_for_address(p);
-      for (size_t i = 0; i < entries; i++)
-      {
-        shared_page[index + i] =
-          global_pagemap.get(p + (i * snmalloc::SUPERSLAB_SIZE));
-      }
-    }
-    /**
-     * Accessor.  We treat the global pagemap as canonical, so only look values
-     * up here.
-     */
-    uint8_t get(uintptr_t p)
-    {
-      return global_pagemap.get(p);
-    }
-    /**
-     * Set a superslab entry in the pagemap.  Inserts it into the global
-     * pagemap and then propagates to the child.
-     */
-    void set_slab(snmalloc::Superslab* slab)
-    {
-      global_pagemap.set_slab(slab);
-      update_child(reinterpret_cast<uintptr_t>(slab));
-    }
-    /**
-     * Clear a superslab entry in the pagemap.  Removes it from the global
-     * pagemap and then propagates to the child.
-     */
-    void clear_slab(snmalloc::Superslab* slab)
-    {
-      global_pagemap.clear_slab(slab);
-      update_child(reinterpret_cast<uintptr_t>(slab));
-    }
-    /**
-     * Clear a medium slab entry in the pagemap.  Removes it from the global
-     * pagemap and then propagates to the child.
-     */
-    void clear_slab(snmalloc::Mediumslab* slab)
-    {
-      global_pagemap.clear_slab(slab);
-      update_child(reinterpret_cast<uintptr_t>(slab));
-    }
-    /**
-     * Set a medium slab entry in the pagemap.  Inserts it into the global
-     * pagemap and then propagates to the child.
-     */
-    void set_slab(snmalloc::Mediumslab* slab)
-    {
-      global_pagemap.set_slab(slab);
-      update_child(reinterpret_cast<uintptr_t>(slab));
-    }
-    /**
-     * Set a large entry in the pagemap.  Inserts it into the global
-     * pagemap and then propagates to the child.
-     */
-    void set_large_size(void* p, size_t size)
-    {
-      global_pagemap.set_large_size(p, size);
-      size_t entries = size / snmalloc::SUPERSLAB_SIZE;
-      update_child(reinterpret_cast<uintptr_t>(p), entries);
-    }
-    /**
-     * Clear a large entry in the pagemap.  Removes it from the global
-     * pagemap and then propagates to the child.
-     */
-    void clear_large_size(void* p, size_t size)
-    {
-      global_pagemap.clear_large_size(p, size);
-      size_t entries = size / snmalloc::SUPERSLAB_SIZE;
-      update_child(reinterpret_cast<uintptr_t>(p), entries);
-    }
-  };
 
   /**
    * Class that handles callbacks.  Each `Library` holds a single one
@@ -692,6 +571,31 @@ namespace sandbox
   Library::~Library()
   {
     wait_for_child_exit();
+    {
+      auto [g, pm] = SharedAllocConfig::Pagemap::get_pagemap_writeable();
+      snmalloc::address_t base =
+        snmalloc::address_cast(memory_provider.get_base());
+      auto top = snmalloc::address_cast(memory_provider.top_address());
+      // Scan the pagemap for all memory associated with this and deallocate
+      // the metaslabs.  Note that we don't need to do any cleanup for the
+      // memory referenced by these metaslabs: it will all go away when the
+      // shared memory region is deallocated.
+      for (snmalloc::address_t a = base; a < top; a += snmalloc::MIN_CHUNK_SIZE)
+      {
+        auto& meta =
+          SharedAllocConfig::Pagemap::get_metaentry(&memory_provider, a);
+        auto* remote = meta.get_remote();
+        if (
+          (remote != nullptr) &&
+          !contains(remote, sizeof(snmalloc::RemoteAllocator)))
+        {
+          delete meta.get_metaslab();
+        }
+        // Reset all of these pagemap entries to unused.
+        SharedAllocConfig::Pagemap::set_metaentry(
+          &memory_provider, a, 1, {nullptr, 0});
+      }
+    }
     shared_mem->destroy();
   }
 
@@ -699,13 +603,12 @@ namespace sandbox
     const char* library_name,
     const char* librunnerpath,
     const void* sharedmem_addr,
-    platform::Handle& pagemap_mem,
+    const platform::Handle& pagemap_mem,
     platform::Handle&& malloc_rpc_socket,
     platform::Handle&& fd_socket)
   {
     static const int last_fd = OtherLibraries;
     auto move_fd = [](int x) {
-      assert(x >= 0);
       SANDBOX_DEBUG_INVARIANT(
         x >= 0, "Attempting to move invalid file descriptor {}", x);
       while (x < last_fd)
@@ -717,7 +620,7 @@ namespace sandbox
     // Move all of the file descriptors that we're going to use out of the
     // region that we're going to populate.
     int shm_fd = move_fd(shm.get_handle().take());
-    pagemap_mem = move_fd(pagemap_mem.take());
+    int pagemap_fd = move_fd(pagemap_mem.fd);
     fd_socket = move_fd(fd_socket.take());
     malloc_rpc_socket = move_fd(malloc_rpc_socket.take());
     // Open the library binary.  If this fails, kill the child process.  Note
@@ -732,7 +635,7 @@ namespace sandbox
     library = move_fd(library);
     // The child process expects to find these in fixed locations.
     shm_fd = dup2(shm_fd, SharedMemRegion);
-    dup2(pagemap_mem.take(), PageMapPage);
+    dup2(pagemap_fd, PageMapPage);
     dup2(fd_socket.take(), FDSocket);
     assert(library);
     library = dup2(library, MainLibrary);
@@ -773,7 +676,6 @@ namespace sandbox
 
   Library::Library(const char* library_name, size_t size)
   : shm(snmalloc::bits::next_pow2_bits(size << 30)),
-    shared_pagemap(snmalloc::bits::next_pow2_bits(snmalloc::OS_PAGE_SIZE)),
     memory_provider(
       pointer_offset(shm.get_base(), sizeof(SharedMemoryRegion)),
       shm.get_size() - sizeof(SharedMemoryRegion)),
@@ -789,7 +691,7 @@ namespace sandbox
     // Create a pair of sockets that we can use to
     auto malloc_rpc_sockets = platform::SocketPair::create();
     memory_service_provider().add_range(
-      &memory_provider, std::move(malloc_rpc_sockets.first), shared_pagemap);
+      memory_provider, std::move(malloc_rpc_sockets.first));
     // Construct a UNIX domain socket.  This will eventually be used to send
     // file descriptors from the parent to the child, but isn't yet.
     auto socks = platform::SocketPair::create();
@@ -827,16 +729,18 @@ namespace sandbox
         library_name,
         librunnerpath,
         shm_base,
-        shared_pagemap.get_handle(),
+        SharedAllocConfig::Pagemap::get_pagemap_handle(),
         std::move(malloc_rpc_sockets.second),
         std::move(socks.second));
     });
     callback_dispatcher->socket = std::move(socks.first);
     // Allocate an allocator in the shared memory region.
-    allocator = new SharedAlloc(
-      memory_provider,
-      SharedPagemapAdaptor(static_cast<uint8_t*>(shared_pagemap.get_base())),
-      &shared_mem->allocator_state);
+
+    allocator = std::make_unique<SharedAlloc>();
+    core_alloc = std::make_unique<snmalloc::CoreAllocator<SharedAllocConfig>>(
+      &allocator->get_local_cache(), &memory_provider);
+    core_alloc->init_message_queue(&shared_mem->allocator_state);
+    allocator->init(core_alloc.get());
   }
 
   void Library::send(int idx, void* ptr)
@@ -929,5 +833,18 @@ namespace sandbox
   void Library::dealloc_in_sandbox(void* ptr)
   {
     allocator->dealloc(ptr);
+  }
+
+  template<>
+  snmalloc::CapPtr<void, snmalloc::CBChunk>
+  SharedAllocConfig::alloc_meta_data<snmalloc::Metaslab>(
+    LocalState*, size_t size)
+  {
+    SANDBOX_INVARIANT(
+      size == sizeof(snmalloc::Metaslab),
+      "Requested to allocate {} bytes for {}-byte metaslab",
+      size,
+      sizeof(snmalloc::Metaslab));
+    return snmalloc::CapPtr<void, snmalloc::CBChunk>{new snmalloc::Metaslab()};
   }
 }


### PR DESCRIPTION
Snmalloc now has a single point for providing configurations, which
cleans up some of this code.  This is now used for both of our uses of
snmalloc.

In this implementation, the in-sandbox allocator uses most of the
generic snmalloc infrastructure but uses RPC to get chunks of address
space to use.  There's scope for some caching here but it's not
currently done.

The parent process has a customised snmalloc implementation that
does not do any of the lazy initialisation.  This implementation
allocates `Metaslab`s outside of the shared memory region so all
metadata is now trusted.  This implementation should check any pointers
it walks in allocatable memory (free lists and message queues) but does
not yet.