### PR TITLE
Add bag data structure

### DIFF
--- a/src/rt/ds/bag.h
+++ b/src/rt/ds/bag.h
@@ -1,0 +1,234 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <cassert>
+#include <snmalloc.h>
+
+namespace verona::rt
+{
+  /**
+   * This class contains the core functionality for a bag using aligned blocks
+   * which is optimised for constant time insertion and removal.
+   *
+   * Removal is O(1) because a removed item will leave a hole in the bag rather
+   * than shifting remaining items down like in a bag. To reduce fragmentation
+   * which can occur with deallocation churn, the bag maintains a freelist which
+   * is threaded through the holes left in the bag.  Insertion of new items will
+   * first query the freelist to see if a hole can be reused, otherwise items
+   * are bump allocated.
+   *
+   * To maintain an internal freelist with no additional space requirements, the
+   * item `T` must be at least 1 machine word in size.
+   */
+  template<class T, class U, class Alloc>
+  class Bag
+  {
+  public:
+    struct Elem
+    {
+      T* object;
+      U metadata;
+    };
+
+  private:
+    static constexpr size_t ITEM_COUNT = 32;
+    static_assert(
+      snmalloc::bits::next_pow2_const(ITEM_COUNT) == ITEM_COUNT,
+      "Should be power of 2 for alignment.");
+
+    static constexpr size_t BLOCK_COUNT = ITEM_COUNT - 1;
+    static constexpr uintptr_t EMPTY_MASK = 1 << 0;
+
+    // An element in the Bag may be empty. Where this is the case, a
+    // freelist is threaded through holes so that the element's slot can be
+    // reused. This is encoded as the `hole_ptr` field in the union.
+    union MaybeElem
+    {
+      MaybeElem* hole_ptr;
+      Elem item;
+    };
+
+    struct alignas(ITEM_COUNT * sizeof(MaybeElem)) Block
+    {
+      MaybeElem prev;
+      MaybeElem data[BLOCK_COUNT];
+    };
+
+    // Dummy block to effectively allow pointer arithmetic on nullptr
+    // which is undefined behaviour.  So we statically allocate a block
+    // to represent the end of the bag.
+    inline static Block null_block{};
+
+    // Index of the full dummy block
+    // Due to pointer arithmetic with nullptr being undefined behaviour
+    // we use a statically allocated null block.
+    static constexpr MaybeElem* null_index =
+      &(null_block.data[BLOCK_COUNT - 1]);
+
+    /// Mask to access the index component of the pointer to a block.
+    static constexpr uintptr_t INDEX_MASK =
+      (ITEM_COUNT - 1) * sizeof(MaybeElem);
+
+    /// Pointer into a block.  As the blocks are strongly aligned
+    /// the bits 9-3 represent the element in the block, with 0 being
+    /// a pointer to the `prev` pointer, and implying the empty block.
+    MaybeElem* index;
+
+    // Used to thread a freelist pointer through the bag.
+    MaybeElem* next_free;
+
+    /// Takes an index and returns the pointer to the Block
+    static Block* get_block(MaybeElem* ptr)
+    {
+      return snmalloc::pointer_align_down<sizeof(Block), Block>(ptr);
+    }
+
+    /// Checks if an index into a block means the block is empty.
+    static bool is_first_block_elem(MaybeElem* ptr)
+    {
+      return ((uintptr_t)ptr & INDEX_MASK) == 0;
+    }
+
+    /// Checks if an index into a block means the block has no space.
+    static bool is_last_block_elem(MaybeElem* index)
+    {
+      return ((uintptr_t)index & INDEX_MASK) == INDEX_MASK;
+    }
+
+  public:
+    Bag<T, U, Alloc>() : index(null_index), next_free(nullptr)
+    {
+      static_assert(
+        sizeof(*this) == sizeof(void*) * 2,
+        "Stack should contain only the index and freelist pointer");
+    }
+
+    /// Deallocate the linked blocks for this bag.
+    void dealloc(Alloc& alloc)
+    {
+      auto local_block = get_block(index);
+      while (local_block != &null_block)
+      {
+        auto prev = get_block(local_block->prev.hole_ptr);
+        alloc.template dealloc<sizeof(Block)>(local_block);
+        local_block = prev;
+      }
+      index = null_index;
+    }
+
+    ALWAYSINLINE void remove(Elem* item)
+    {
+      MaybeElem* hole = (MaybeElem*)item;
+      hole->hole_ptr = (MaybeElem*)((uintptr_t)next_free | EMPTY_MASK);
+      next_free = hole;
+    }
+
+    /// Insert an element into the bag.
+    ALWAYSINLINE Elem* insert(Elem item, Alloc& alloc)
+    {
+      if (next_free != nullptr)
+      {
+        MaybeElem* prev = next_free->hole_ptr;
+        next_free->item = item;
+        assert((uintptr_t)prev & EMPTY_MASK);
+        MaybeElem* cur = next_free;
+        next_free = (MaybeElem*)((uintptr_t)prev & ~EMPTY_MASK);
+        return &(cur->item);
+      }
+      if (!is_last_block_elem(index))
+      {
+        index++;
+        index->item = item;
+        return &(index->item);
+      }
+      return insert_slow(item, alloc);
+    }
+
+  private:
+    /// Slow path for insert, performs an insert, when allocation is required.
+    Elem* insert_slow(Elem item, Alloc& alloc)
+    {
+      assert(is_last_block_elem(index));
+
+      Block* next = (Block*)alloc.template alloc<sizeof(Block)>();
+      assert(((uintptr_t)next) % alignof(Block) == 0);
+      next->prev.hole_ptr = index;
+      index = &(next->data[0]);
+      index->item = item;
+      return &(index->item);
+    }
+
+    static void step(MaybeElem*& elem)
+    {
+      elem--;
+      if (is_first_block_elem(elem))
+      {
+        elem = get_block(elem)->prev.hole_ptr;
+      }
+    }
+
+    static MaybeElem* next_non_empty(MaybeElem* elem)
+    {
+      while ((elem != Bag::null_index) &&
+             ((uintptr_t)elem->hole_ptr & EMPTY_MASK))
+      {
+        step(elem);
+      }
+      return elem;
+    }
+
+  public:
+    class iterator
+    {
+      friend class Bag;
+
+    public:
+      iterator(Bag<T, U, Alloc>* bag) : bag(bag)
+      {
+        ptr = bag->next_non_empty(bag->index);
+      }
+
+      iterator(Bag<T, U, Alloc>* bag, MaybeElem* p) : bag(bag), ptr(p) {}
+
+      iterator operator++()
+      {
+        step(ptr);
+        ptr = next_non_empty(ptr);
+        assert(
+          (ptr == Bag::null_index) ||
+          (((uintptr_t)ptr->hole_ptr & EMPTY_MASK) == 0));
+
+        return *this;
+      }
+
+      inline bool operator!=(const iterator& other) const
+      {
+        return ptr != other.ptr;
+      }
+
+      inline bool operator==(const iterator& other) const
+      {
+        return ptr == other.ptr;
+      }
+
+      inline Elem* operator*() const
+      {
+        return &(ptr->item);
+      }
+      inline iterator begin()
+      {
+        return {bag};
+      }
+
+      inline iterator end()
+      {
+        return {bag, Bag::null_index};
+      }
+
+    private:
+      Bag<T, U, Alloc>* bag;
+      MaybeElem* ptr;
+    };
+  };
+} // namespace verona::rt

--- a/src/rt/test/func/bag/bag.cc
+++ b/src/rt/test/func/bag/bag.cc
@@ -1,0 +1,122 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+#include "ds/bag.h"
+
+#include "test/harness.h"
+#include "test/log.h"
+#include "unordered_set"
+#include "verona.h"
+
+using namespace snmalloc;
+using namespace verona::rt;
+
+using B = Bag<uintptr_t, uintptr_t, Alloc>;
+using E = B::Elem*;
+
+void test_iter()
+{
+  auto& alloc = ThreadAlloc::get();
+
+  B bag;
+  B::iterator iter(&bag);
+
+  for (auto entry : iter)
+  {
+    UNUSED(entry);
+    check(false);
+  }
+
+  auto item = bag.insert({nullptr, 123}, alloc);
+
+  // Check that iter is setup correctly when the index points to a hole.
+  auto item2 = bag.insert({nullptr, 456}, alloc);
+  bag.remove(item2);
+
+  for (auto entry : iter)
+  {
+    check(entry == item);
+  }
+  bag.dealloc(alloc);
+}
+
+void test_iter_advanced()
+{
+  auto& alloc = ThreadAlloc::get();
+
+  B bag;
+
+  const int NUM_OBJECTS = 127;
+
+  // Allocate a bunch of objects so that the region vector uses many
+  // allocation blocks to track each object in the region.
+  for (uintptr_t i = 0; i < NUM_OBJECTS; i++)
+  {
+    bag.insert({nullptr, i}, alloc);
+  }
+
+  // Iterate through the bag and make sure that all the
+  // entries make sense.
+  B::iterator iter(&bag);
+
+  E rm1 = nullptr;
+  E rm2 = nullptr;
+  E rm3 = nullptr;
+
+  uintptr_t count = 0;
+  for (auto entry : iter)
+  {
+    check(entry->metadata == (NUM_OBJECTS - count - 1));
+
+    if (count == 5)
+      rm1 = entry;
+
+    if (count == 40)
+      rm2 = entry;
+
+    if (count == 100)
+      rm3 = entry;
+    count++;
+  }
+
+  check(count == NUM_OBJECTS);
+
+  std::unordered_set<uintptr_t> removed = {
+    (uintptr_t)rm1, (uintptr_t)rm2, (uintptr_t)rm3};
+
+  bag.remove(rm1);
+  bag.remove(rm2);
+  bag.remove(rm3);
+
+  // Check that the iterator skips over holes left in the region vector
+  count = 0;
+  for (auto item : iter)
+  {
+    UNUSED(item);
+    count++;
+  }
+  assert(count == NUM_OBJECTS - 3);
+
+  // Check that the freelist is used to fill existing holes before bump
+  // allocation.
+  auto idx1 = bag.insert({nullptr, 123}, alloc);
+  check(removed.count((uintptr_t)idx1));
+
+  auto idx2 = bag.insert({nullptr, 456}, alloc);
+  check(removed.count((uintptr_t)idx2));
+
+  auto idx3 = bag.insert({nullptr, 789}, alloc);
+  check(removed.count((uintptr_t)idx3));
+
+  // And that new allocations go back to bump allocation
+  auto idx4 = bag.insert({nullptr, 10}, alloc);
+  check(!removed.count((uintptr_t)idx4));
+
+  bag.dealloc(alloc);
+}
+
+int main(int, char**)
+{
+  test_iter();
+  test_iter_advanced();
+  return 0;
+}


### PR DESCRIPTION
A bag is an vector-like data structure using aligned block which is optimised for constant time insertion and removal.

Removal is O(1) because a removed item will leave a hole in the bag rather than shifting remaining items down like in a bag. To reduce fragmentation which can occur with deallocation churn, the bag maintains a freelist which is threaded through the holes left in the bag. Insertion of new items will first query the freelist to see if a hole can be reused, otherwise items are bump allocated.

This data structure is useful for tracking objects in regions -- such as one which uses reference counting -- where efficient alloc/dealloc is necessary.