### PR TITLE
Fix Topology to work with repeated runtime starts

### DIFF
--- a/src/rt/pal/threadpoolbuilder.h
+++ b/src/rt/pal/threadpoolbuilder.h
@@ -13,7 +13,7 @@ namespace verona::rt
 {
   class ThreadPoolBuilder
   {
-    Topology topology;
+    inline static Singleton<Topology, &Topology::init> topology;
     std::list<PlatformThread> threads;
     size_t thread_count;
     size_t index = 0;
@@ -43,7 +43,6 @@ namespace verona::rt
     ThreadPoolBuilder(size_t thread_count)
     {
       this->thread_count = thread_count - 1;
-      topology.acquire();
     }
 
     /**
@@ -58,7 +57,8 @@ namespace verona::rt
       // thread to a core we massively increase contention.
       add_thread_impl(body, args...);
 #else
-      add_thread_impl(&run_with_affinity, topology.get(index), body, args...);
+      add_thread_impl(
+        &run_with_affinity, topology.get().get(index), body, args...);
 #endif
       index++;
     }
@@ -80,8 +80,6 @@ namespace verona::rt
         thread.join();
         threads.pop_front();
       }
-
-      topology.release();
     }
   };
 }

--- a/src/rt/test/func/external_threading/verona_external_threading.h
+++ b/src/rt/test/func/external_threading/verona_external_threading.h
@@ -20,13 +20,7 @@ namespace verona::rt
      * Signals the the start of the Topology usage.
      * No calls should be made to Topology::get before calling this method.
      */
-    void acquire() {}
-
-    /**
-     * Signals that no futher calls will be made to Topology::get until another
-     * call is made to Topology::acquire.
-     */
-    void release() {}
+    static void init(Topology*) noexcept {}
 
     /**
      * Assigns a CPU ID to a scheduler thread specified as the argument.


### PR DESCRIPTION
The topology was not working correctly if it was run twice.  This change
makes it static, and thus does not need to query the CPUs repeatedly.

While writing some new tests I observed that after the first run, when the
runtime restarted, all the threads had been affinitized to a single core. This
makes the topology static, and just initialises it on first use.

I also made the vector an embedded field for simpler memory/lifetime
management.