### PR TITLE
Fix the last known security issue in the process-sandbox code.

### DIFF
--- a/experiments/process_sandbox/README.md
+++ b/experiments/process_sandbox/README.md
@@ -61,16 +61,6 @@ The attacker must not be able to:
  - Cause the parent to stop executing (denial of service) in any thread, except for the time that the parent allows for a call into the child to execute.
  - Access any global namespace (filesystem, network, and so on) except as explicitly permitted by the parent.
 
-### Known issues
-
-The current implementation assumes that the snmalloc `Alloc` instance at the boundary of the sandbox validates all pointers that it follows within the sandbox.
-This is a trivial check to add (a simple range check), but is not currently implemented.
-As such, an attacker can corrupt allocator metadata in such a way that causes snmalloc in the parent to corrupt arbitrary memory.
-
-The original design assumed that the child cannot modify the shared pagemap page.
-In the Capsicum implementation, the child does not have the capability to map the shared pagemap page read-write and so this is safe.
-This is not true in the seccomp-bpf version currently, though it can be addressed by reopening the file descriptor read-only via fdfs.
-
 ### Unknown issues
 
 This is experimental code and has not yet been audited for security.

--- a/experiments/process_sandbox/tests/CMakeLists.txt
+++ b/experiments/process_sandbox/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SANDBOX_TESTS
 	fake-open
 	callback-basic
 	callback-recursive
+	modify-pagemap
 	zlib
 	)
 

--- a/experiments/process_sandbox/tests/sandbox-modify-pagemap.cc
+++ b/experiments/process_sandbox/tests/sandbox-modify-pagemap.cc
@@ -1,0 +1,39 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include "process_sandbox/cxxsandbox.h"
+#include "process_sandbox/sandbox.h"
+
+#include <limits.h>
+#include <stdio.h>
+
+using namespace sandbox;
+
+/**
+ * Function that will try to escape from the sandbox.  Returns the result of
+ * trying to make the shared pagemap read-write.
+ */
+int attack();
+
+/**
+ * The structure that represents an instance of the sandbox.
+ */
+struct BadSandbox
+{
+  /**
+   * The library that defines the functions exposed by this sandbox.
+   */
+  Library lib = {SANDBOX_LIBRARY};
+#define EXPORTED_FUNCTION(name) \
+  decltype(make_sandboxed_function<decltype(::name)>(lib)) name = \
+    make_sandboxed_function<decltype(::name)>(lib);
+  EXPORTED_FUNCTION(attack)
+};
+
+int main()
+{
+  BadSandbox sandbox;
+  // attack() will try to make the pagemap read-write.
+  SANDBOX_INVARIANT(sandbox.attack() != 0, "Sandbox attack failed");
+  return 0;
+}

--- a/experiments/process_sandbox/tests/sandboxlib-modify-pagemap.cc
+++ b/experiments/process_sandbox/tests/sandboxlib-modify-pagemap.cc
@@ -1,0 +1,32 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include "process_sandbox/cxxsandbox.h"
+#include "process_sandbox/sandbox.h"
+
+#include <dlfcn.h>
+#include <stdio.h>
+
+int attack()
+{
+  // Find the symbol from the library runner that contains the pagemap
+  // address and load it.
+  void* pagemap_base = *reinterpret_cast<void**>(
+    dlsym(RTLD_DEFAULT, "_ZN7sandbox15SnmallocGlobals7Pagemap7pagemapE"));
+  SANDBOX_INVARIANT(
+    pagemap_base != nullptr,
+    "The mangled name or the visibility of the child's sandbox has changed.  "
+    "This test must be updated");
+  fprintf(stderr, "Found pagemap base %p\n", pagemap_base);
+  // Try to make the pagemap read-write.
+  int ret =
+    mprotect(pagemap_base, snmalloc::Pal::page_size, PROT_READ | PROT_WRITE);
+  fprintf(stderr, "mprotect returned %d (%s)", ret, strerror(errno));
+  // If we could, return 0, otherwise return the errno value.
+  return ret == 0 ? 0 : errno;
+}
+
+extern "C" void sandbox_init()
+{
+  sandbox::ExportedLibrary::export_function(::attack);
+}


### PR DESCRIPTION
On Linux, where you don't have Capsicum or anything usefully equivalent,
you can't drop write permissions on a file.  We can fudge this using
fdfs to reopen the shared memory region in read-only mode before we mmap
it.  This prevents the attacker from being able to mprotect the shared
pagemap read-write.

There's now a test that checks for this.  This fixes the last known
security vulnerability, just in time for Saar to find some new ones next
week.