### PR TITLE
Add basic support for a reference counted region

### DIFF
--- a/src/rt/ds/bag.h
+++ b/src/rt/ds/bag.h
@@ -233,13 +233,12 @@ namespace verona::rt
 
     inline iterator begin()
     {
-        return {this};
+      return {this};
     }
 
     inline iterator end()
     {
-        return {this, Bag::null_index};
+      return {this, Bag::null_index};
     }
-
   };
 } // namespace verona::rt

--- a/src/rt/region/region.h
+++ b/src/rt/region/region.h
@@ -5,6 +5,7 @@
 #include "../object/object.h"
 #include "region_arena.h"
 #include "region_base.h"
+#include "region_rc.h"
 #include "region_trace.h"
 
 namespace verona::rt
@@ -84,6 +85,12 @@ namespace verona::rt
     using T = RegionArena;
   };
 
+  template<>
+  struct RegionType_to_class<RegionType::Rc>
+  {
+    using T = RegionRc;
+  };
+
   class Region
   {
   public:
@@ -99,6 +106,8 @@ namespace verona::rt
         return RegionType::Trace;
       else if (RegionArena::is_arena_region(o))
         return RegionType::Arena;
+      else if (RegionRc::is_rc_region(o))
+        return RegionType::Rc;
 
       abort();
     }
@@ -121,6 +130,8 @@ namespace verona::rt
           return RegionTrace::alloc<size>(alloc, in, desc);
         case RegionType::Arena:
           return RegionArena::alloc<size>(alloc, in, desc);
+        case RegionType::Rc:
+          return RegionRc::alloc<size>(alloc, in, desc);
         default:
           abort();
       }
@@ -218,6 +229,13 @@ namespace verona::rt
             count++;
           }
           return count;
+        case RegionType::Rc:
+          for (auto p : *((RegionRc*)r))
+          {
+            UNUSED(p);
+            count++;
+          }
+          return count;
         default:
           abort();
       }
@@ -310,6 +328,9 @@ namespace verona::rt
           return;
         case RegionType::Arena:
           ((RegionArena*)r)->release_internal(alloc, o, collect);
+          return;
+        case RegionType::Rc:
+          ((RegionRc*)r)->release_internal(alloc, o, collect);
           return;
         default:
           abort();

--- a/src/rt/region/region_arena.h
+++ b/src/rt/region/region_arena.h
@@ -49,6 +49,7 @@ namespace verona::rt
   private:
     friend class Region;
     friend class RegionTrace;
+    friend class RegionRc;
 
     /**
      * An Arena is a large block of pre-allocated memory. It has an overhead of

--- a/src/rt/region/region_base.h
+++ b/src/rt/region/region_base.h
@@ -23,6 +23,7 @@ namespace verona::rt
   {
     Trace,
     Arena,
+    Rc,
   };
 
   class RegionBase : public Object,
@@ -32,6 +33,7 @@ namespace verona::rt
     friend class Freeze;
     friend class RegionTrace;
     friend class RegionArena;
+    friend class RegionRc;
 
   public:
     enum IteratorType

--- a/src/rt/region/region_rc.h
+++ b/src/rt/region/region_rc.h
@@ -1,0 +1,428 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "../object/object.h"
+#include "region_arena.h"
+#include "region_base.h"
+#include "region_trace.h"
+
+namespace verona::rt
+{
+  using namespace snmalloc;
+
+  /**
+   * Please see region.h for the full documentation.
+   *
+   * This is a concrete implementation of a region, specifically one with
+   * reference counting. This class inherits from RegionBase, but it cannot call
+   * any of the static methods in Region.
+   *
+   * In a rc region, all objects are tracked using a bag; where each element
+   * contains a pointer to the object and its current reference count. The bag
+   * is updated each time an object is allocated or deallacted.
+   *
+   * The RegionRc uses a spare bit in each object pointer in the bag
+   * (`FINALIZER_MASK`) to quickly deduce whether an object is trivial or
+   * non-trivial.
+   *
+   **/
+  class RegionRc : public RegionBase
+  {
+    friend class Freeze;
+    friend class Region;
+    friend class RegionTrace;
+
+  private:
+    static constexpr uintptr_t FINALISER_MASK = 1 << 1;
+
+    RefCounts counts{};
+
+    RefCount* entry_point_count = nullptr;
+
+    // Memory usage in the region.
+    size_t current_memory_used = 0;
+
+    RegionRc() : RegionBase() {}
+
+    static const Descriptor* desc()
+    {
+      static constexpr Descriptor desc = {
+        vsizeof<RegionRc>, nullptr, nullptr, nullptr};
+
+      return &desc;
+    }
+
+  public:
+    inline static RegionRc* get(Object* o)
+    {
+      assert(o->debug_is_iso());
+      assert(is_rc_region(o->get_region()));
+      return (RegionRc*)o->get_region();
+    }
+
+    inline static bool is_rc_region(Object* o)
+    {
+      return o->is_type(desc());
+    }
+
+    /**
+     * Creates a new rc region by allocating Object `o` of type `desc`. The
+     * object is initialised as the Iso object for that region, and points to a
+     * newly created Region metadata object. Returns a pointer to `o`.
+     *
+     * The default template parameter `size = 0` is to avoid writing two
+     * definitions which differ only in one line. This overload works because
+     * every object must contain a descriptor, so 0 is not a valid size.
+     **/
+    template<size_t size = 0>
+    static Object* create(Alloc& alloc, const Descriptor* desc)
+    {
+      void* p = alloc.alloc<vsizeof<RegionRc>>();
+      Object* o = Object::register_object(p, RegionRc::desc());
+      auto reg = new (o) RegionRc();
+      reg->use_memory(desc->size);
+
+      if constexpr (size == 0)
+        p = alloc.alloc(desc->size);
+      else
+        p = alloc.alloc<size>();
+      o = Object::register_object(p, desc);
+
+      reg->init_next(o);
+      o->init_iso();
+      o->set_region(reg);
+
+      auto rc = reg->track_object(o, alloc);
+      reg->entry_point_count = rc;
+
+      assert(Object::debug_is_aligned(o));
+      return o;
+    }
+
+    /**
+     * Allocates an object `o` of type `desc` in the region represented by the
+     * Iso object `in`. Returns a pointer to `o`.
+     *
+     * The default template parameter `size = 0` is to avoid writing two
+     * definitions which differ only in one line. This overload works because
+     * every object must contain a descriptor, so 0 is not a valid size.
+     **/
+    template<size_t size = 0>
+    static Object* alloc(Alloc& alloc, Object* in, const Descriptor* desc)
+    {
+      assert((size == 0) || (size == desc->size));
+      RegionRc* reg = get(in);
+
+      assert(reg != nullptr);
+
+      void* p = nullptr;
+      if constexpr (size == 0)
+        p = alloc.alloc(desc->size);
+      else
+        p = alloc.alloc<size>();
+
+      auto o = (Object*)Object::register_object(p, desc);
+      assert(Object::debug_is_aligned(o));
+
+      o->set_ref_count(reg->track_object(o, alloc));
+
+      // GC heuristics.
+      reg->use_memory(desc->size);
+      return o;
+    }
+
+    /// Increments the reference count of `o`. The object `in` is the entry
+    /// point to the region that contains `o`.
+    static void incref(Object* o, Object* in)
+    {
+      // FIXME: An extra branch is needed here because the first field in the
+      // RegionMD of an ISO holds a pointer to the region description, so we
+      // can't quickly access the refcount as we would an ordinary object.
+      if (o == in)
+      {
+        RegionRc* reg = get(in);
+        reg->entry_point_count->metadata += 1;
+        return;
+      }
+      RefCount* rc = o->get_ref_count();
+      rc->metadata += 1;
+    }
+
+    /// Decrements the reference count of `o`. The object `in` is the entry
+    /// point to the region that contains `o`. If `decref` is called on an
+    /// object with only one reference, then the object will be deallocated.
+    static bool decref(Alloc& alloc, Object* o, Object* in)
+    {
+      if (o == in)
+      {
+        RegionRc* reg = get(in);
+        reg->entry_point_count->metadata -= 1;
+        return false;
+      }
+      if (decref_inner(o))
+      {
+        dealloc_object(alloc, o, in);
+        return true;
+      }
+      return false;
+    }
+
+    /// Get the reference count of `o`. The object `in` is the entry point to
+    /// the region that contains `o`.
+    static uintptr_t get_ref_count(Object* o, Object* in)
+    {
+      if (o == in)
+      {
+        RegionRc* reg = get(in);
+        return reg->entry_point_count->metadata;
+      }
+      RefCount* rc = o->get_ref_count();
+      return rc->metadata;
+    }
+
+  private:
+    inline static bool decref_inner(Object* o)
+    {
+      RefCount* rc = o->get_ref_count();
+      if (rc->metadata == 1)
+      {
+        return true;
+      }
+      rc->metadata -= 1;
+      return false;
+    }
+
+    static void dealloc_object(Alloc& alloc, Object* o, Object* in)
+    {
+      // We first need to decref -- and potentially deallocate -- any object
+      // pointed to through `o`'s fields.
+      ObjectStack dfs(alloc);
+      ObjectStack sub_regions(alloc);
+      o->trace(dfs);
+      ObjectStack fin_q(alloc);
+
+      RegionRc* reg = get(in);
+
+      fin_q.push(o);
+
+      while (!dfs.empty())
+      {
+        Object* p = dfs.pop();
+        switch (p->get_class())
+        {
+          case Object::ISO:
+            if (p == in)
+            {
+              reg->entry_point_count->metadata -= 1;
+            }
+            else
+            {
+              sub_regions.push(p);
+            }
+            break;
+          case Object::MARKED:
+          case Object::UNMARKED:
+            if (decref_inner(p))
+            {
+              fin_q.push(p);
+              p->trace(dfs);
+            }
+            break;
+          case Object::SCC_PTR:
+            p->immutable();
+            p->decref();
+            break;
+          case Object::RC:
+            p->decref();
+            break;
+          case Object::COWN:
+            p->decref_cown();
+            break;
+          default:
+            assert(0);
+        }
+      }
+
+      while (!fin_q.empty())
+      {
+        auto p = fin_q.pop();
+        RefCount* rc = p->get_ref_count();
+        reg->counts.remove(rc);
+        if (!p->is_trivial())
+        {
+          p->finalise(in, sub_regions);
+        }
+        // Unlike traced regions, we can deallocate this immediately after
+        // finalization.
+        p->destructor();
+        p->dealloc(alloc);
+      }
+
+      // Finally, we release any regions which were held by ISO pointers from
+      // this object.
+      while (!sub_regions.empty())
+      {
+        o = sub_regions.pop();
+        assert(o->debug_is_iso());
+        Systematic::cout() << "Region RC: releasing unreachable subregion: "
+                           << o << Systematic::endl;
+
+        // Note that we need to dispatch because `r` is a different region
+        // metadata object.
+        RegionBase* r = o->get_region();
+        assert(r != in);
+
+        // Unfortunately, we can't use Region::release_internal because of a
+        // circular dependency between header files.
+        if (RegionTrace::is_trace_region(r))
+          ((RegionTrace*)r)->release_internal(alloc, o, sub_regions);
+        else if (RegionArena::is_arena_region(r))
+          ((RegionArena*)r)->release_internal(alloc, o, sub_regions);
+        else if (RegionRc::is_rc_region(r))
+          ((RegionRc*)r)->release_internal(alloc, o, sub_regions);
+        else
+          abort();
+      }
+    }
+
+    /**
+     * Release and deallocate all objects within the region represented by the
+     * Iso Object `o`.
+     *
+     * Note: this does not release subregions. Use Region::release instead.
+     **/
+    void release_internal(Alloc& alloc, Object* o, ObjectStack& collect)
+    {
+      assert(o->debug_is_iso());
+
+      // Finalize the non-trivial objects
+      for (auto rc : counts)
+      {
+        auto p = (uintptr_t)rc->object;
+        if ((p & FINALISER_MASK) == FINALISER_MASK)
+        {
+          auto untagged = (Object*)((uintptr_t)p & ~FINALISER_MASK);
+          untagged->finalise(o, collect);
+        }
+      }
+
+      // Note: it is safe to iterate the bag to deallocate objects since
+      // the bag only stores a pointer to the objects.
+      for (auto rc : counts)
+      {
+        auto untagged = (Object*)(((uintptr_t)rc->object) & ~FINALISER_MASK);
+        untagged->destructor();
+        untagged->dealloc(alloc);
+      }
+
+      counts.dealloc(alloc);
+      dealloc(alloc);
+    }
+
+  public:
+    template<IteratorType type = AllObjects>
+    class iterator
+    {
+      friend class RegionRc;
+
+      static_assert(
+        type == Trivial || type == NonTrivial || type == AllObjects);
+
+      iterator(RegionRc* r, RefCounts::iterator counts) : reg(r), counts(counts)
+      {
+        counts = r->counts.begin();
+        ptr = (*counts)->object;
+        next();
+      }
+
+      iterator(RegionRc* r, RefCounts::iterator counts, Object* p)
+      : reg(r), counts(counts), ptr(p)
+      {}
+
+    private:
+      RegionRc* reg;
+      RefCounts::iterator counts;
+      Object* ptr;
+
+      void step()
+      {
+        ++counts;
+        ptr = (*counts)->object;
+      }
+
+      void next()
+      {
+        if constexpr (type == AllObjects)
+        {
+          ptr = (*counts)->object;
+          return;
+        }
+        else if constexpr (type == NonTrivial)
+        {
+          while ((counts != counts.end()) && !((uintptr_t)ptr & FINALISER_MASK))
+          {
+            step();
+          }
+          ptr = (*counts)->object;
+          return;
+        }
+        else
+        {
+          while ((counts != counts.end()) && ((uintptr_t)ptr & FINALISER_MASK))
+          {
+            step();
+          }
+          ptr = (*counts)->object;
+          return;
+        }
+      }
+
+    public:
+      iterator operator++()
+      {
+        step();
+        next();
+        return *this;
+      }
+
+      inline bool operator!=(const iterator& other) const
+      {
+        assert(reg == other.reg);
+        return ptr != other.ptr;
+      }
+
+      inline Object* operator*() const
+      {
+        return ptr;
+      }
+    };
+
+    template<IteratorType type = AllObjects>
+    inline iterator<type> begin()
+    {
+      return {this, counts.begin()};
+    }
+
+    template<IteratorType type = AllObjects>
+    inline iterator<type> end()
+    {
+      return {this, counts.end(), nullptr};
+    }
+
+  private:
+    void use_memory(size_t size)
+    {
+      current_memory_used += size;
+    }
+
+    RefCount* track_object(Object* o, Alloc& alloc)
+    {
+      auto tagged = (uintptr_t)o;
+      if (!(o->is_trivial()))
+        tagged |= FINALISER_MASK;
+      return counts.insert({(Object*)tagged, 1}, alloc);
+    }
+  };
+
+} // namespace verona::rt

--- a/src/rt/region/region_trace.h
+++ b/src/rt/region/region_trace.h
@@ -49,6 +49,7 @@ namespace verona::rt
   {
     friend class Freeze;
     friend class Region;
+    friend class RegionRc;
 
   private:
     enum RingKind

--- a/src/rt/test/func/memory/memory.cc
+++ b/src/rt/test/func/memory/memory.cc
@@ -6,6 +6,7 @@
 #include "memory_gc.h"
 #include "memory_iterator.h"
 #include "memory_merge.h"
+#include "memory_rc.h"
 #include "memory_subregion.h"
 #include "memory_swap_root.h"
 
@@ -57,6 +58,7 @@ int main(int argc, char** argv)
   memory_swap_root::run_test();
   memory_merge::run_test();
   memory_gc::run_test();
+  memory_rc::run_test();
   memory_subregion::run_test();
 
   test_dealloc();

--- a/src/rt/test/func/memory/memory_alloc.h
+++ b/src/rt/test/func/memory/memory_alloc.h
@@ -146,6 +146,16 @@ namespace memory_alloc
       // 3rd arena: MC MC C C
       test_alloc_helper<MC, MF, C, F, MF, MC, F, F, MC, MC, C, C>();
     }
+    else if constexpr (region_type == RegionType::Rc)
+    {
+      // Region contains only the iso object.
+      test_alloc_helper<C>();
+
+      test_alloc_helper<C, C, C>();
+      test_alloc_helper<F, F, F>();
+      test_alloc_helper<C, C, F, F>();
+      test_alloc_helper<F, F, C, C>();
+    }
   }
 
   void run_test()

--- a/src/rt/test/func/memory/memory_rc.h
+++ b/src/rt/test/func/memory/memory_rc.h
@@ -1,0 +1,184 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "memory.h"
+
+namespace memory_rc
+{
+  constexpr auto region_type = RegionType::Rc;
+  using C = C1<region_type>;
+  using F = F1<region_type>;
+  using MC = MediumC2<region_type>;
+  using MF = MediumF2<region_type>;
+  using LC = LargeC2<region_type>;
+  using LF = LargeF2<region_type>;
+  using XC = XLargeC2<region_type>;
+  using XF = XLargeF2<region_type>;
+
+  using Cx = C3<region_type>;
+  using Fx = F3<region_type>;
+
+  template<class... T>
+  uintptr_t alloc_garbage_helper(Alloc& alloc, Object* o, uintptr_t count)
+  {
+    alloc_in_region<T...>(alloc, o);
+    auto ds = Region::debug_size(o);
+    uintptr_t new_count = sizeof...(T) + count;
+    check(ds == new_count); // o + T...
+    return new_count;
+  }
+
+  /**
+   * A few basic tests to start:
+   *   - allocating unreachable objects, and then releasing the region to ensure
+   *   they are all deallocated.
+   *   - allocating objects and making them all reachable, but then decrefing
+   *   objects to 0 to make sure that deallocation is recursive.
+   **/
+  void test_basic()
+  {
+    // Allocate a lot of garbage.
+    {
+      auto& alloc = ThreadAlloc::get();
+      auto* o = new (alloc) C;
+
+      uintptr_t obj_count = 1;
+
+      obj_count =
+        alloc_garbage_helper<C, F, MC, MF, LC, LF, XC, XF>(alloc, o, obj_count);
+      obj_count = alloc_garbage_helper<C, C, C, XF, XF, MC, LC, LF, F, F, XC>(
+        alloc, o, obj_count);
+      obj_count = alloc_garbage_helper<C, C, C, XF, XF, MC, LC, LF, F, F, XC>(
+        alloc, o, obj_count);
+      obj_count = alloc_garbage_helper<XC, XC, XC, XF, MC>(alloc, o, obj_count);
+      obj_count =
+        alloc_garbage_helper<F, F, F, C, C, C, C, F>(alloc, o, obj_count);
+
+      Region::release(alloc, o);
+      snmalloc::debug_check_empty<snmalloc::Alloc::StateHandle>();
+    }
+
+    // Allocate a lot of objects that are all connected.
+    // Then decref the root and see if children are deallocated.
+    {
+      auto& alloc = ThreadAlloc::get();
+      auto* o = new (alloc) C;
+
+      auto* o1 = new (alloc, o) C;
+      auto* o2 = new (alloc, o) C;
+      auto* o3 = new (alloc, o) C;
+      auto* o4 = new (alloc, o) C;
+      auto* o5 = new (alloc, o) C;
+      auto* o6 = new (alloc, o) C;
+      auto* o7 = new (alloc, o) C;
+
+      // Link them up
+      o1->f1 = o2;
+      o1->f2 = o4;
+      o2->f1 = o3;
+      o2->f2 = o4;
+      RegionRc::incref(o4, o);
+
+      o4->f1 = o5;
+      RegionRc::incref(o5, o);
+      o5->f1 = o6;
+      o5->f2 = o7;
+
+      check(Region::debug_size(o) == 8);
+      check(RegionRc::get_ref_count(o1, o) == 1);
+      check(RegionRc::get_ref_count(o2, o) == 1);
+      check(RegionRc::get_ref_count(o3, o) == 1);
+      check(RegionRc::get_ref_count(o4, o) == 2);
+      check(RegionRc::get_ref_count(o5, o) == 2);
+      check(RegionRc::get_ref_count(o6, o) == 1);
+      check(RegionRc::get_ref_count(o7, o) == 1);
+
+      // Decref'ing o1 to 0 should trigger a deallocation.
+      RegionRc::decref(alloc, o1, o);
+
+      check(Region::debug_size(o) == 4);
+
+      Region::release(alloc, o);
+      snmalloc::debug_check_empty<snmalloc::Alloc::StateHandle>();
+    }
+
+    // Allocate objects which link to subregions and check that decrefing ISOs
+    // has the correct behaviour.
+    {
+      auto& alloc = ThreadAlloc::get();
+      auto* o = new (alloc) C;
+
+      auto* sub1 = new (alloc) C;
+      auto* sub2 = new (alloc) C;
+
+      auto* o1 = new (alloc, o) C;
+      auto* o2 = new (alloc, o) C;
+
+      // Link them up
+      o1->f1 = o2;
+      o1->f2 = o;
+      RegionRc::incref(o, o);
+      o2->f1 = sub1;
+      o2->f2 = sub2;
+
+      check(Region::debug_size(o) == 3);
+      check(RegionRc::get_ref_count(o, o) == 2);
+      check(RegionRc::get_ref_count(o1, o) == 1);
+      check(RegionRc::get_ref_count(o2, o) == 1);
+
+      RegionRc::decref(alloc, o1, o);
+
+      check(RegionRc::get_ref_count(o, o) == 1);
+
+      check(Region::debug_size(o) == 1);
+
+      Region::release(alloc, o);
+      snmalloc::debug_check_empty<snmalloc::Alloc::StateHandle>();
+    }
+  }
+
+  /**
+   * Show that basic reference counting can't handle cycles.
+   **/
+  void test_cycles()
+  {
+    auto& alloc = ThreadAlloc::get();
+    auto* o = new (alloc) C;
+
+    // Allocate some reachable objects.
+    auto* o1 = new (alloc, o) C;
+    auto* o2 = new (alloc, o) C;
+    auto* o3 = new (alloc, o) C;
+    auto* o4 = new (alloc, o) C;
+    auto* o5 = new (alloc, o) C;
+
+    // cycle: o1 -> o2 -> o3 -> o4 -> o5 -> o1
+    o1->f1 = o2;
+    o2->f1 = o3;
+    o3->f1 = o4;
+    o4->f1 = o5;
+    RegionRc::incref(o1, o);
+    o5->f1 = o1;
+
+    check(Region::debug_size(o) == 6);
+    o5->f1 = nullptr;
+    RegionRc::decref(alloc, o1, o);
+    check(Region::debug_size(o) == 6);
+    // When cycle detection exists. This should dealloc the objects.
+    // check(Region::debug_size(o) == 0);
+
+    // Break the cycle
+    RegionRc::decref(alloc, o1, o);
+    check(Region::debug_size(o) == 1);
+
+    Region::release(alloc, o);
+    snmalloc::debug_check_empty<snmalloc::Alloc::StateHandle>();
+  }
+
+  void run_test()
+  {
+    test_basic();
+    test_cycles();
+  }
+}

--- a/src/rt/test/func/memory/memory_subregion.h
+++ b/src/rt/test/func/memory/memory_subregion.h
@@ -344,9 +344,11 @@ namespace memory_subregion
   {
     test_subregion_singleton<RegionType::Trace>();
     test_subregion_singleton<RegionType::Arena>();
+    test_subregion_singleton<RegionType::Rc>();
 
     test_subregion_basic<RegionType::Trace>();
     test_subregion_basic<RegionType::Arena>();
+    test_subregion_basic<RegionType::Rc>();
 
     test_subregion_mix();
 


### PR DESCRIPTION
This includes: allocation, deallocation, and finalisation of objects in the reference counted region; incref, and decref methods; and support for releasing the entire region (and its subregions).

Merging, root swapping, and reclamation of cyclic data structures are not yet implemented.

A fundamental property of reference counting is deterministic destruction: once an object is decrefed to zero, it is finalized and deallocated immediately. Using a singly linked list 'ring' similar to the traced region would not be efficient here, since an O(n) scan over the region would be needed on each removal.

Instead, the rc region keeps track of its objects using the bag data structure [1]. Each element in the bag contain a pointer to each object in the region, along with its reference count. A spare bit in the object pointer is used to quickly deduce whether an object is trivial or non-trivial.

[1]: https://github.com/microsoft/verona/pull/512
