### PR TITLE
Add network support to sandboxes.

### DIFF
--- a/experiments/process_sandbox/CMakeLists.txt
+++ b/experiments/process_sandbox/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
 project(sandbox C CXX)
 
-INCLUDE (CheckCXXSourceCompiles)
+include(CheckCXXSourceCompiles)
+include(FindPkgConfig)
 
 set(CHILD_SOURCES src/library_runner.cc)
 set(LIBSANDBOX_SOURCES src/libsandbox.cc)
@@ -69,8 +70,12 @@ target_link_libraries(sandbox fmt::fmt)
 target_link_options(library_runner PRIVATE -Wl,-export-dynamic)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-	target_link_libraries(library_runner -ldl -lbsd -lrt)
-	target_link_libraries(sandbox -ldl -lbsd -lrt)
+	# Unconditionally link libbsd to everything on Linux so we have a useful
+	# set of libc functions.
+	pkg_check_modules(libbsd REQUIRED IMPORTED_TARGET libbsd-overlay)
+	link_libraries(PkgConfig::libbsd)
+	target_link_libraries(library_runner -ldl -lrt)
+	target_link_libraries(sandbox -ldl -lrt)
 endif()
 
 if (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")

--- a/experiments/process_sandbox/include/process_sandbox/callback_numbers.h
+++ b/experiments/process_sandbox/include/process_sandbox/callback_numbers.h
@@ -1,0 +1,78 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+/**
+ * This file contains the callback numbers for callbacks from the sandbox.
+ */
+namespace sandbox
+{
+  /**
+   * The kind of callback.  This is used to dispatch the callback to the
+   * correct handler.
+   *
+   * This enumeration starts from 0 then contains all of the system calls that
+   * we emulate, then libc functions, and then provides a marker for
+   * dynamically added callbacks.  New system calls should be added before
+   * `SyscallCallbackCount`.  Entries in this enumeration must not be reordered
+   * without updating all of the structures that are indexed on it.
+   */
+  enum CallbackKind
+  {
+    /**
+     * Marker for the first callback that implements a system call.
+     */
+    FirstSyscall = 0,
+    /**
+     * Proxying an `open` system call.
+     */
+    Open = FirstSyscall,
+    /**
+     * Proxying a `stat` system call.
+     */
+    Stat,
+    /**
+     * Proxying an `access` system call.
+     */
+    Access,
+    /**
+     * Proxying an `openat` system call.
+     */
+    OpenAt,
+    /**
+     * Proxying a `bind` system call.
+     */
+    Bind,
+    /**
+     * Proxying an `connect` system call.
+     */
+    Connect,
+
+    /**
+     * The number of system-call callbacks.
+     */
+    SyscallCallbackCount,
+    /**
+     * Marker for the first built-in callback that represents a libc function.
+     */
+    FirstLibCCall = SyscallCallbackCount,
+    /**
+     * Proxying a `getaddrinfo` libc call.
+     */
+    GetAddrInfo = FirstLibCCall,
+    /**
+     * Marker for the last built-in callback that represents a libc function.
+     */
+    LastLibCCall = GetAddrInfo,
+    /**
+     * Total number of built-in callback kinds.
+     */
+    BuiltInCallbackKindCount,
+    /**
+     * User-defined callback numbers start here.  User for callbacks from the
+     * sandbox into Verona code and will itself be multiplexed.
+     */
+    FirstUserFunction = BuiltInCallbackKindCount,
+  };
+}

--- a/experiments/process_sandbox/include/process_sandbox/netpolicy.h
+++ b/experiments/process_sandbox/include/process_sandbox/netpolicy.h
@@ -1,0 +1,245 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+/**
+ * This file contains the abstractions required for granting network access in
+ * a sandbox.  Sandboxes are not permitted to do anything directly that touches
+ * a global namespace and so may not connect or bind sockets.  Any attempt to
+ * use the network must be proxied.
+ */
+
+#pragma once
+#include <netdb.h>
+#include <optional>
+#include <string>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <tuple>
+#include <type_traits>
+#include <unordered_map>
+#include <variant>
+
+namespace sandbox
+{
+  /**
+   * Class encapsulating a network access policy for a sandbox.  This allows
+   * specific access to some network resources to be granted to a sandbox.
+   */
+  class NetworkPolicy
+  {
+    /**
+     * C++17 made noexcept part of the type system, so `R(Args...) noexcept` is
+     * not the same as `R(Args...)`.  Unfortunately, `std::function` remains
+     * specialised only for `R(Args...)` and so you cannot create a
+     * `std::function<R(Args...) noexcept>`.  Fortunately, the `noexcept`
+     * version is a subtype of the potentially throwing version (throwing 0
+     * exceptions is a stronger constraint than throwing 0 or more exceptions)
+     * and so we can just strip `noexcept` from the types.
+     *
+     * This helper provides a mechanism for stripping the `noexcept` qualifier
+     * from a function type.
+     */
+    template<typename Res, typename... ArgTypes>
+    struct remove_noexcept
+    {};
+
+    /**
+     * Specialisation for types that are already not-`noexcept`, just forwards
+     * the type.
+     */
+    template<typename Res, typename... ArgTypes>
+    struct remove_noexcept<Res(ArgTypes...)>
+    {
+      /**
+       * The type (already) without `noexcept`.
+       */
+      using type = Res(ArgTypes...);
+    };
+
+    /**
+     * Specialisation for types that are `noexcept`, forwards the type without
+     * `noexcept`.
+     */
+    template<typename Res, typename... ArgTypes>
+    struct remove_noexcept<Res(ArgTypes...) noexcept>
+    {
+      /**
+       * The type without `noexcept`.
+       */
+      using type = Res(ArgTypes...);
+    };
+
+    /**
+     * Helper for avoiding the need to write `::type` after every use of
+     * `remove_noexcept`.
+     */
+    template<typename Res, typename... ArgTypes>
+    using remove_noexcept_t = typename remove_noexcept<Res, ArgTypes...>::type;
+
+  public:
+    /**
+     * Enumeration describing the set of network operations that may be
+     * controlled by this policy.
+     */
+    enum class NetOperation
+    {
+      /**
+       * The `bind` function.  Assigns a local address to the socket, so
+       * requires authorisation to access the global namespace.
+       */
+      Bind,
+      /**
+       * The `getaddrinfo` function.  Theoretically this does not require
+       * access to the global namespace but in implementation it usually
+       * requires the ability ot query DNS or similar.
+       */
+      GetAddrInfo,
+      /**
+       * Connect a socket to a remote address.  Requires access to the global
+       * namespace to be authorised to connect to the specific remote address.
+       */
+      Connect
+    };
+
+  private:
+    /**
+     * Enumeration describing a simple deny-all or allow-all policy.
+     */
+    enum SimplePolicy
+    {
+      /**
+       * Deny this operation.  This is 0 so that default initialisation gives a
+       * default-deny policy.
+       */
+      Deny = 0,
+      /**
+       * Permit this operation, forwarding directly to the system
+       * implementation.
+       */
+      Allow
+    };
+
+    /**
+     * A policy.  This is either allow-all, deny-all, or invoke a callback to
+     * handle each specific case.  The arguments to these functions are copied
+     * before the callback is invoked, so the callback does not have to worry
+     * about TOCTOU bugs.
+     */
+    template<typename Callback>
+    using Policy =
+      std::variant<SimplePolicy, std::function<remove_noexcept_t<Callback>>>;
+
+    /**
+     * The set of default implementations for each of the functions.
+     */
+    constexpr static std::tuple systemImplementations = {
+      &bind, &getaddrinfo, &connect};
+
+    /**
+     * Helper to map from the `NetOperation` enumeration to the type of the
+     * function required to implement it.
+     */
+    template<NetOperation Op>
+    using NetOpFnType =
+      typename std::remove_pointer_t<std::remove_reference_t<decltype(
+        std::get<static_cast<int>(Op)>(systemImplementations))>>;
+
+    /**
+     * Helper that defines a `std::function` type matching one of the network
+     * operations that can access the global namespace.
+     */
+    template<NetOperation Op>
+    using NetOpCallbackType = std::function<remove_noexcept_t<NetOpFnType<Op>>>;
+
+    /**
+     * Policies for various network operations, indexed by `NetOperation`.
+     */
+    std::tuple<
+      Policy<NetOpFnType<NetOperation::Bind>>,
+      Policy<NetOpFnType<NetOperation::GetAddrInfo>>,
+      Policy<NetOpFnType<NetOperation::Connect>>>
+      policies;
+
+  public:
+    /**
+     * Function used to free the return from any explicit `getaddrinfo`
+     * handler.  This must be set if the handler returns anything other than
+     * the result from the system's `getaddrinfo`.
+     */
+    std::function<remove_noexcept_t<decltype(::freeaddrinfo)>> freeaddrinfo{
+      ::freeaddrinfo};
+
+    /**
+     * Get the policy for a given operation.
+     *
+     * Note: The return type uses `NetOpFnType` explicitly rather than `auto`
+     * so that if the order of `NetOperation` and `policies` are out of sync we
+     * will get a compile error.
+     */
+    template<NetOperation Op>
+    Policy<NetOpFnType<Op>>& getPolicy()
+    {
+      return std::get<static_cast<int>(Op)>(policies);
+    }
+
+    /**
+     * Deny the sandbox the ability to perform the operation specified by `Op`.
+     */
+    template<NetOperation Op>
+    void deny()
+    {
+      getPolicy<Op>() = Deny;
+    }
+
+    /**
+     * Allow the sandbox the ability to perform the operation specified by `Op`
+     * with no additional checks.
+     */
+    template<NetOperation Op>
+    void allow()
+    {
+      getPolicy<Op>() = Allow;
+    }
+
+    /**
+     * Register a handler for the operation specified by `Op`.  This must have
+     * the same signature as the underlying system function and may be used to
+     * enforce arbitrary policy decisions.
+     */
+    template<NetOperation Op>
+    void register_handler(NetOpCallbackType<Op> callback)
+    {
+      getPolicy<Op>() = callback;
+    }
+
+    /**
+     * Invoke the socket API call with the given arguments, enforcing the
+     * registered policy.  This does *not* check that the arguments are valid,
+     * the caller is responsible for any checks and must copy arguments.
+     */
+    template<NetOperation Op, typename... Args>
+    int invoke(Args... args)
+    {
+      auto& policy = getPolicy<Op>();
+      return std::visit(
+        [&](auto& v) {
+          using T = std::decay_t<decltype(v)>;
+          if constexpr (std::is_same_v<T, SimplePolicy>)
+          {
+            if (v == Deny)
+            {
+              errno = ENOSYS;
+              return -1;
+            }
+            return std::get<static_cast<int>(Op)>(systemImplementations)(
+              std::forward<Args>(args)...);
+          }
+          else
+          {
+            return v(std::forward<Args>(args)...);
+          }
+        },
+        policy);
+    }
+  };
+}

--- a/experiments/process_sandbox/include/process_sandbox/platform/sandbox_capsicum.h
+++ b/experiments/process_sandbox/include/process_sandbox/platform/sandbox_capsicum.h
@@ -87,7 +87,8 @@ namespace sandbox::platform
       }
       int arg = PROC_TRAPCAP_CTL_ENABLE;
       int ret = procctl(P_PID, getpid(), PROC_TRAPCAP_CTL, &arg);
-      assert(ret == 0);
+      SANDBOX_INVARIANT(
+        ret == 0, "Failed to register for traps on Capsicum violations");
       std::array<const char*, EnvSize + 1> env;
       std::copy(envp.begin(), envp.end(), env.begin());
       env.at(EnvSize - 1) = "LD_LIBRARY_PATH_FDS=8:9:10";

--- a/experiments/process_sandbox/include/process_sandbox/sandbox.h
+++ b/experiments/process_sandbox/include/process_sandbox/sandbox.h
@@ -16,6 +16,7 @@
 #endif
 
 #include "helpers.h"
+#include "netpolicy.h"
 #include "platform/platform.h"
 #include "sandbox_fd_numbers.h"
 
@@ -604,6 +605,11 @@ namespace sandbox
      * Returns the filesystem abstraction exported to this sandbox.
      */
     ExportedFileTree& filetree();
+
+    /**
+     * Returns the network access policy for this sandbox.
+     */
+    NetworkPolicy& network_policy();
 
     /**
      * Register a handler for a callback from this sandbox.  The return value

--- a/experiments/process_sandbox/tests/CMakeLists.txt
+++ b/experiments/process_sandbox/tests/CMakeLists.txt
@@ -17,10 +17,16 @@ set(SANDBOX_TESTS
 	callback-basic
 	callback-recursive
 	modify-pagemap
+	network
 	zlib
 	)
 
 find_package(Threads REQUIRED)
+
+find_package(CURL)
+if (${CURL_FOUND})
+	list(APPEND SANDBOX_TESTS curl)
+endif()
 
 function(setup_sandbox_test_properties TEST_NAME)
 	set_target_properties(${TEST_NAME} PROPERTIES
@@ -56,3 +62,7 @@ foreach(TEST_NAME ${SANDBOX_TESTS})
 	add_test(${TEST_NAME} ${TEST_NAME})
 	target_compile_definitions(${TEST_NAME} PRIVATE SANDBOX_LIBRARY=\"${CMAKE_CURRENT_BINARY_DIR}/${TEST_LIB_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}\")
 endforeach()
+
+if (${CURL_FOUND})
+	target_link_libraries(sandboxed-curl CURL::libcurl)
+endif()

--- a/experiments/process_sandbox/tests/net-test-helpers.h
+++ b/experiments/process_sandbox/tests/net-test-helpers.h
@@ -1,0 +1,31 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+bool test_network();
+bool test_bind(bool, short);
+bool test_connect(bool, short);
+bool test_send();
+void test_listen();
+char* test_receive(size_t);
+
+/**
+ * Helper to set up a loopback IPv4 address for a specific port.
+ */
+static sockaddr_in loopback_for_port(short port)
+{
+  sockaddr_in addr;
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(0x7f000001);
+  addr.sin_port = htons(port);
+  return addr;
+}
+
+/**
+ * Test message to send over a socket.
+ */
+const char msg[] = "Hello World!";

--- a/experiments/process_sandbox/tests/sandbox-curl.cc
+++ b/experiments/process_sandbox/tests/sandbox-curl.cc
@@ -1,0 +1,116 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include "process_sandbox/cxxsandbox.h"
+#include "process_sandbox/sandbox.h"
+
+#include <limits.h>
+#include <limits>
+#include <stdio.h>
+#include <thread>
+#include <unistd.h>
+
+using namespace sandbox;
+/**
+ * Sandboxed function that fetches the contents of a URL.
+ */
+std::pair<char*, size_t> fetch(char* url);
+
+/**
+ * The structure that represents an instance of the sandbox.
+ */
+struct CurlSandbox
+{
+  /**
+   * The library that defines the functions exposed by this sandbox.
+   */
+  Library lib = {SANDBOX_LIBRARY};
+#define EXPORTED_FUNCTION(public_name, private_name) \
+  decltype(make_sandboxed_function<decltype(private_name)>(lib)) public_name = \
+    make_sandboxed_function<decltype(private_name)>(lib);
+  EXPORTED_FUNCTION(fetch, ::fetch)
+};
+
+/**
+ * Vector of variable-sized sockaddr values.  These are captured when the
+ * sandbox calls `getaddrinfo` and then used when the sandbox calls `connect`
+ * to ensure that the sandbox can connect only to addresses that are valid for
+ * the desired target.
+ */
+std::vector<std::vector<char>> valid_addrs;
+
+/**
+ * Allow the sandbox to perform lookups on http://example.com but no other
+ * service / domain combination.
+ */
+int auth_getaddrinfo(
+  const char* hostname,
+  const char* servname,
+  const addrinfo* hints,
+  addrinfo** res)
+{
+  fprintf(stderr, "host: %s, service: %s\n", hostname, servname);
+  if (
+    (strcmp(hostname, "example.com") != 0) ||
+    ((strcmp(servname, "http") != 0) && (strcmp(servname, "80") != 0)))
+  {
+    return EAI_FAIL;
+  }
+  auto ret = getaddrinfo(hostname, servname, hints, res);
+  if (ret == 0)
+  {
+    for (addrinfo* ai = *res; ai != nullptr; ai = ai->ai_next)
+    {
+      char* bytes = reinterpret_cast<char*>(ai->ai_addr);
+      valid_addrs.emplace_back(bytes, bytes + ai->ai_addrlen);
+    }
+  }
+  return ret;
+}
+
+/**
+ * Allow the sandbox to connect to any of the addresses that the `getaddrinfo`
+ * call returned, but no others.
+ */
+int auth_connect(int s, const sockaddr* addr, socklen_t addrlen)
+{
+  for (auto& sa : valid_addrs)
+  {
+    if ((sa.size() == addrlen) && (memcmp(sa.data(), addr, addrlen) == 0))
+    {
+      fprintf(stderr, "Allowing connection to previously authorised address\n");
+      connect(s, addr, addrlen);
+      return 0;
+    }
+  }
+  errno = EADDRNOTAVAIL;
+  return -1;
+}
+
+int main()
+{
+  // Create the sandbox
+  CurlSandbox curl;
+  // Allow it restricted network access
+  curl.lib.network_policy()
+    .register_handler<NetworkPolicy::NetOperation::GetAddrInfo>(
+      auth_getaddrinfo);
+  curl.lib.network_policy()
+    .register_handler<NetworkPolicy::NetOperation::Connect>(auth_connect);
+  // Copy the URL into the sandbox.
+  auto url = curl.lib.strdup("http://example.com");
+  // Fetch the contents of the URL
+  auto res = curl.fetch(url);
+  // Free the copy of the URL in the sandbox
+  curl.lib.free(url);
+  fprintf(stderr, "Fetched %zd bytes:\n", res.second);
+  // Check that we received something plausible
+  SANDBOX_INVARIANT(
+    curl.lib.contains(res.first, res.second), "Return value not in sandbox");
+  SANDBOX_INVARIANT(
+    strnstr(res.first, "Example Domain", res.second) != nullptr,
+    "example.com did not return expected result");
+  // Write the received text to the standard error for debugging
+  write(STDERR_FILENO, res.first, res.second);
+  return 0;
+}

--- a/experiments/process_sandbox/tests/sandbox-network.cc
+++ b/experiments/process_sandbox/tests/sandbox-network.cc
@@ -1,0 +1,175 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include "net-test-helpers.h"
+#include "process_sandbox/cxxsandbox.h"
+#include "process_sandbox/sandbox.h"
+
+#include <limits.h>
+#include <limits>
+#include <stdio.h>
+#include <thread>
+
+using namespace sandbox;
+/**
+ * The structure that represents an instance of the sandbox.
+ */
+struct NetSandbox
+{
+  /**
+   * The library that defines the functions exposed by this sandbox.
+   */
+  Library lib = {SANDBOX_LIBRARY};
+#define EXPORTED_FUNCTION(public_name, private_name) \
+  decltype(make_sandboxed_function<decltype(private_name)>(lib)) public_name = \
+    make_sandboxed_function<decltype(private_name)>(lib);
+  EXPORTED_FUNCTION(test_network, ::test_network)
+  EXPORTED_FUNCTION(test_bind, ::test_bind)
+  EXPORTED_FUNCTION(test_connect, ::test_connect)
+  EXPORTED_FUNCTION(test_listen, ::test_listen)
+  EXPORTED_FUNCTION(test_receive, ::test_receive)
+};
+
+/**
+ * The number of times `bind` was called by a sandbox.
+ */
+int bind_calls;
+
+/**
+ * The number of times that `connect` was called by a sandbox.
+ */
+int connect_calls;
+
+/**
+ * The port number to use.  We will start here and try higher ones until we
+ * find an unused one.
+ */
+short port = 1024;
+
+/**
+ * Check that the address that the sandbox is trying to use is the one that we
+ * expect (127.0.0.1, with the port from `port`).
+ */
+bool check_addr(const sockaddr* addr, socklen_t addrlen)
+{
+  auto addr_in = reinterpret_cast<const sockaddr_in*>(addr);
+  if (
+    (addrlen != sizeof(sockaddr_in)) || (ntohs(addr_in->sin_port) != port) ||
+    (htonl(addr_in->sin_addr.s_addr) != 0x7f000001))
+  {
+    errno = EINVAL;
+    return false;
+  }
+  return true;
+};
+
+/**
+ * Allow binding to a single address.
+ */
+int auth_bind(int s, const sockaddr* addr, socklen_t addrlen)
+{
+  bind_calls++;
+  if (!check_addr(addr, addrlen))
+  {
+    return -1;
+  }
+  int ret = -1;
+  // If you run this test rapidly, the OS may not have made the port available
+  // again yet, so try a different one.  The sandbox doesn't have to know...
+  for (; port < std::numeric_limits<short>::max(); port++)
+  {
+    sockaddr_in addr_in = loopback_for_port(port);
+    if ((ret = bind(s, reinterpret_cast<sockaddr*>(&addr_in), addrlen)) == 0)
+    {
+      break;
+    }
+  }
+  return ret;
+}
+
+/**
+ * Allow connecting to a single address.
+ */
+int auth_connect(int s, const sockaddr* addr, socklen_t addrlen)
+{
+  connect_calls++;
+  if (!check_addr(addr, addrlen))
+  {
+    return -1;
+  }
+  connect(s, addr, addrlen);
+  return 0;
+}
+
+int main()
+{
+  // Create a sandbox that can do networking.
+  NetSandbox serverBox;
+  // Allow it to do getaddrinfo to any adderss
+  serverBox.lib.network_policy()
+    .allow<NetworkPolicy::NetOperation::GetAddrInfo>();
+  // Check that it can look up microsoft.com.
+  fprintf(stderr, "Testing getaddrinfo\n");
+  serverBox.test_network();
+
+  // Check that it can't do bind (default deny):
+  fprintf(stderr, "Testing bind\n");
+  serverBox.test_bind(true, port);
+
+  // Allow it to do bind and then check that it does:
+  serverBox.lib.network_policy()
+    .register_handler<NetworkPolicy::NetOperation::Bind>(auth_bind);
+  serverBox.test_bind(false, port);
+
+  // Make the sandbox listen on the socket.
+  serverBox.test_listen();
+
+  // In a background thread, ask the sandbox to accept two connections, each of
+  // which should send it the contents of `msg`.  Return a buffer with each in
+  // it.
+  std::thread t{[&]() {
+    for (int i = 0; i < 2; i++)
+    {
+      char* recvbuf = serverBox.test_receive(sizeof(msg));
+      // Make sure that the received buffer is in the sandbox!
+      SANDBOX_INVARIANT(
+        serverBox.lib.contains(recvbuf, sizeof(msg)),
+        "Return from receive is not in sandbox {:p}",
+        recvbuf);
+      SANDBOX_INVARIANT(
+        memcmp(recvbuf, msg, sizeof(msg)) == 0,
+        "Return from receive is not the correct value.");
+      serverBox.lib.free(recvbuf);
+    }
+  }};
+
+  // Try sending a message to the socket from the parent:
+  int s = socket(AF_INET, SOCK_STREAM, 0);
+  SANDBOX_INVARIANT(s >= 0, "Socket failed");
+  sockaddr_in addr = loopback_for_port(port);
+  int ret = connect(s, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
+  SANDBOX_INVARIANT(ret == 0, "Connect failed");
+  send(s, msg, sizeof(msg), 0);
+
+  // Create another sandbox to act as a network client.
+  NetSandbox clientBox;
+  // Make sure that it can't connect until we authorise it to
+  clientBox.test_connect(true, port);
+  // Allow it to connect to a specific address.
+  clientBox.lib.network_policy()
+    .register_handler<NetworkPolicy::NetOperation::Connect>(auth_connect);
+  // Check that it can connect and send a message to the server sandbox.
+  clientBox.test_connect(false, port);
+
+  SANDBOX_INVARIANT(
+    bind_calls == 1,
+    "bind should have been called once was called {} times",
+    bind_calls);
+  SANDBOX_INVARIANT(
+    connect_calls == 1,
+    "connect should have been called once was called {} times",
+    connect_calls);
+  t.join();
+  fprintf(stderr, "Test done\n");
+  return 0;
+}

--- a/experiments/process_sandbox/tests/sandboxlib-curl.cc
+++ b/experiments/process_sandbox/tests/sandboxlib-curl.cc
@@ -1,0 +1,61 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include "process_sandbox/cxxsandbox.h"
+#include "process_sandbox/sandbox.h"
+
+#include <curl/curl.h>
+#include <stdio.h>
+
+namespace
+{
+  /**
+   * Buffer containing the fetched URL.
+   */
+  std::vector<char> buffer;
+
+  /**
+   * Callback used by curl when data are received.
+   */
+  size_t write_callback(char* ptr, size_t size, size_t nmemb, void*)
+  {
+    size_t bytes = size * nmemb;
+    fprintf(stderr, "Curl received %zd bytes\n", bytes);
+    buffer.insert(buffer.end(), ptr, ptr + bytes);
+    return bytes;
+  }
+
+  /**
+   * Fetch a URL in a sandbox, returning the result.
+   */
+  std::pair<char*, size_t> fetch(char* url)
+  {
+    buffer.clear();
+    CURL* easy_handle = curl_easy_init();
+    fprintf(stderr, "Sandbox fetching %s\n", url);
+    auto err = [](CURLcode err, const char* msg) {
+      if (err == CURLE_OK)
+      {
+        fprintf(stderr, "%s succeeded\n", msg);
+      }
+      else
+      {
+        fprintf(stderr, "%s failed: %s\n", msg, curl_easy_strerror(err));
+      }
+    };
+
+    auto res = curl_easy_setopt(easy_handle, CURLOPT_URL, url);
+    err(res, "curl_easy_setopt(CURLOPT_URL)");
+    res = curl_easy_setopt(easy_handle, CURLOPT_WRITEFUNCTION, write_callback);
+    err(res, "curl_easy_setopt(CURLOPT_WRITEFUNCTION)");
+    res = curl_easy_perform(easy_handle);
+    err(res, "curl_easy_perform");
+    return {buffer.data(), buffer.size()};
+  }
+
+}
+
+extern "C" void sandbox_init()
+{
+  sandbox::ExportedLibrary::export_function(::fetch);
+}

--- a/experiments/process_sandbox/tests/sandboxlib-fake-open.cc
+++ b/experiments/process_sandbox/tests/sandboxlib-fake-open.cc
@@ -1,6 +1,7 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
 
+#include "process_sandbox/callback_numbers.h"
 #include "process_sandbox/cxxsandbox.h"
 #include "process_sandbox/platform/platform.h"
 #include "process_sandbox/sandbox.h"
@@ -21,9 +22,11 @@ int test(bool raw_syscall)
 #endif
   const char* path = "/foo";
   int x;
-  if (raw_syscall && (SyscallFrame::Open != -1))
+  constexpr int OpenSyscallNo =
+    SyscallFrame::syscall_number<sandbox::CallbackKind::Open>();
+  if (raw_syscall && (OpenSyscallNo != -1))
   {
-    x = syscall(SyscallFrame::Open, path, O_RDWR);
+    x = syscall(OpenSyscallNo, path, O_RDWR);
   }
   else
   {

--- a/experiments/process_sandbox/tests/sandboxlib-network.cc
+++ b/experiments/process_sandbox/tests/sandboxlib-network.cc
@@ -1,0 +1,130 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include "net-test-helpers.h"
+#include "process_sandbox/cxxsandbox.h"
+#include "process_sandbox/sandbox.h"
+
+#include <stdio.h>
+
+/**
+ * Test that getaddrinfo works inside a network-enabled sandbox.
+ */
+bool test_network()
+{
+  addrinfo* res;
+  addrinfo hints;
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_INET;
+  hints.ai_socktype = SOCK_STREAM;
+  fprintf(stderr, "Looking up host\n");
+  int ret = getaddrinfo("microsoft.com", "http", &hints, &res);
+  SANDBOX_INVARIANT(ret == 0, "getaddrinfo returned {}", gai_strerror(ret));
+  auto port = ((sockaddr_in*)res->ai_addr)->sin_port;
+  SANDBOX_INVARIANT(
+    port == htons(80), "HTTP should be port 80, was {}", ntohs(port));
+  int s = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+  SANDBOX_INVARIANT(s >= 0, "Failed to create socket {}", strerror(errno));
+  ret = connect(s, res->ai_addr, res->ai_addrlen);
+  SANDBOX_INVARIANT(
+    ret == -1,
+    "connect() returned {}, the policy should have blocked it and generated a "
+    "-1 return value",
+    ret);
+  return ret == 0;
+}
+
+/**
+ * Socket.  This sandbox uses global (sandbox-local) state to store the socket
+ * that it uses for testing.
+ */
+int s;
+
+/**
+ * Try to bind a socket to a specific port.  If `expectFailure` is true then
+ * this tests that it *can't* bind the socket (i.e. when the sandbox policy
+ * does not allow it).
+ */
+bool test_bind(bool expectFailure, short port)
+{
+  s = socket(AF_INET, SOCK_STREAM, 0);
+  SANDBOX_INVARIANT(s >= 0, "Failed to create socket {}", strerror(errno));
+  sockaddr_in addr = loopback_for_port(port);
+  int ret = bind(s, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
+  if (expectFailure)
+  {
+    SANDBOX_INVARIANT(
+      ret == -1, "bind succeeded when it should have been blocked");
+  }
+  else
+  {
+    SANDBOX_INVARIANT(ret == 0, "bind failed {}", strerror(errno));
+  }
+  return true;
+}
+
+/**
+ * Try to connect a socket to a specific remote address and port and send it a
+ * message.  If `expectFailure` is true then this tests that it *can't* connect
+ * the socket (i.e. when the sandbox policy does not allow it).
+ */
+bool test_connect(bool expectFailure, short port)
+{
+  s = socket(AF_INET, SOCK_STREAM, 0);
+  SANDBOX_INVARIANT(s >= 0, "Failed to create socket {}", strerror(errno));
+  sockaddr_in addr = loopback_for_port(port);
+  int ret = connect(s, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
+  if (expectFailure)
+  {
+    SANDBOX_INVARIANT(
+      ret == -1, "connect succeeded when it should have been blocked");
+  }
+  else
+  {
+    SANDBOX_INVARIANT(ret == 0, "connect failed {}", strerror(errno));
+    send(s, msg, sizeof(msg), 0);
+    close(s);
+  }
+  return true;
+}
+
+/**
+ * Test that we can listen.  Listening does not affect a global namespace and
+ * so the sandbox policy *should* allow this unconditionally.
+ */
+void test_listen()
+{
+  int ret = listen(s, 2);
+  SANDBOX_INVARIANT(ret == 0, "listen returned failure: {}", strerror(errno));
+}
+
+/**
+ * Test accepting a connection and receiving a message.  These operations do
+ * not manipulate a global namespace and so should all work unconditionally, as
+ * long as the previous steps were authorised.
+ */
+char* test_receive(size_t size)
+{
+  char* buf = new char[size]();
+  fprintf(stderr, "Sandbox blocking on accept\n");
+  int conn = accept(s, nullptr, nullptr);
+  fprintf(stderr, "Sandbox accepted connection\n");
+  SANDBOX_INVARIANT(conn >= 0, "accept failed: {}", strerror(errno));
+  auto ret = recv(conn, buf, size, MSG_WAITALL);
+  SANDBOX_INVARIANT(
+    ret == static_cast<ssize_t>(size),
+    "recv returned {} (expected {}), errno: {}",
+    ret,
+    size,
+    strerror(errno));
+  return buf;
+}
+
+extern "C" void sandbox_init()
+{
+  sandbox::ExportedLibrary::export_function(::test_network);
+  sandbox::ExportedLibrary::export_function(::test_bind);
+  sandbox::ExportedLibrary::export_function(::test_connect);
+  sandbox::ExportedLibrary::export_function(::test_listen);
+  sandbox::ExportedLibrary::export_function(::test_receive);
+}


### PR DESCRIPTION
This proxies the three POSIX socket functions that access the global
namespace:

 - bind
 - connect
 - getaddrinfo (which could be used to implement the legact IPv4
   interfaces)

These are passed through a policy layer that allows sandbox consumers to
either:

 - Block them unconditionally.
 - Allow them to work with any address.
 - Add an interposer that implements the function based on some custom
   policy.

This makes it possible to enforce policies such as 'this sandbox may
establish outbound connections to microsoft.com:80 but nothing else' by
interposing on the `getaddrinfo` call to record the valid addresses for
this address / service combination and allowing `connect` only for those
addresses.

The callback infrastructure was starting to be a bit unwieldy, so this
has been refactored to use tuples indexed by the callback kind and do
compile-time checks if entries are missing.  The system call entries now
map from callback kind to system call number (with a compile-time check
that there is an entry for every callback kind that represents a system
call and that the entries are in the correct order) and the dispatch is
done via a recursive template instantiation rather than by copying and
pasting code.  This makes it impossible to forget to implement syscall
callbacks on either side of the interface.  These compile-time checks
showed some bugs, which are now fixed.

The callback interface now has to be able to take a `Handle` in either
direction.  This was already supported by the transport but not used by
anything and so not exposed higher up.  Both `connect` and `bind` need
to pass a socket to the parent and have the parent modify it.  This is
now exposed generically.

Sometimes, if the tests crash they can leave orphan sandbox processes
running indefinitely.  This is now fixed on FreeBSD when using vfork (it
was already fixed with `pdfork`.  It is, unfortunately, not possible yet
to fix on Linux because the Linux `pdfork` analog does not have
kill-on-close behaviour and Linux's parent-death signal is triggered
when the *thread* that created the child process exits, not when the
*process* exits and so cannot be safely used within a library.