### PR TITLE
Make unpause signal safe

### DIFF
--- a/src/rt/CMakeLists.txt
+++ b/src/rt/CMakeLists.txt
@@ -65,7 +65,7 @@ target_include_directories(verona_rt INTERFACE .)
 
 if(MSVC)
   target_compile_definitions(verona_rt INTERFACE -D__EXCEPTIONS)
-  target_compile_options(verona_rt INTERFACE /std:c++latest /permissive-)
+  target_compile_options(verona_rt INTERFACE /permissive-)
   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Zi")
   set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /DEBUG")
 else()

--- a/src/rt/pal/semaphore.h
+++ b/src/rt/pal/semaphore.h
@@ -1,0 +1,153 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+/**
+ * This constructs a platform specific semaphore.
+ */
+#if __has_include(<semaphore>)
+#  include <semaphore>
+#endif
+#if defined(__cpp_lib_semaphore)
+namespace verona::rt::pal
+{
+  class Semaphore
+  {
+    std::binary_semaphore semaphore_{0};
+
+  public:
+    void release()
+    {
+      semaphore_.release();
+    }
+
+    void acquire()
+    {
+      semaphore_.acquire();
+    }
+  };
+} // namespace verona::rt::pal
+#elif defined(__APPLE__)
+#  include <dispatch/dispatch.h>
+namespace verona::rt::pal
+{
+  class Semaphore
+  {
+    dispatch_semaphore_t semaphore_;
+
+  public:
+    Semaphore()
+    {
+      semaphore_ = dispatch_semaphore_create(0);
+    }
+
+    ~Semaphore()
+    {
+      dispatch_release(semaphore_);
+    }
+
+    void release()
+    {
+      dispatch_semaphore_signal(semaphore_);
+    }
+
+    void acquire()
+    {
+      dispatch_semaphore_wait(semaphore_, DISPATCH_TIME_FOREVER);
+    }
+  };
+} // namespace verona::rt::pal
+#elif defined(WIN32)
+#  include <windows.h>
+namespace verona::rt::pal
+{
+  class Semaphore
+  {
+    HANDLE semaphore_;
+
+  public:
+    Semaphore()
+    {
+      semaphore_ = CreateSemaphore(NULL, 0, LONG_MAX, NULL);
+    }
+
+    ~Semaphore()
+    {
+      CloseHandle(semaphore_);
+    }
+
+    void release()
+    {
+      ReleaseSemaphore(semaphore_, 1, NULL);
+    }
+
+    void acquire()
+    {
+      WaitForSingleObject(semaphore_, INFINITE);
+    }
+  };
+} // namespace verona::rt::pal
+#elif __has_include(<semaphore.h>)
+// Use Posix semaphores
+#  include <semaphore.h>
+namespace verona::rt::pal
+{
+  class Semaphore
+  {
+    sem_t semaphore_;
+
+  public:
+    Semaphore()
+    {
+      auto err = sem_init(&semaphore_, 0, 0);
+      if (err != 0)
+      {
+        // Failed to initialize semaphore.
+        abort();
+      }
+    }
+
+    Semaphore(const Semaphore&) = delete;
+    Semaphore& operator=(const Semaphore&) = delete;
+
+    ~Semaphore()
+    {
+      sem_destroy(&semaphore_);
+    }
+
+    void release()
+    {
+      auto res = sem_post(&semaphore_);
+      if (res != 0)
+      {
+        // Failed to release semaphore.
+        abort();
+      }
+    }
+
+    void acquire()
+    {
+      while (true)
+      {
+        auto err = sem_wait(&semaphore_);
+        if (err == 0)
+        {
+          return;
+        }
+        else if (err == EINTR)
+        {
+          // Interrupted by a signal.
+          continue;
+        }
+        else
+        {
+          // Failed to acquire semaphore.
+          abort();
+        }
+      }
+    }
+  };
+} // namespace verona::rt::pal
+#else
+#  error "No semaphore implementation available"
+#endif

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -33,7 +33,6 @@ namespace verona::rt
   public:
     /// Friendly thread identifier for logging information.
     size_t systematic_id = 0;
-    size_t systematic_speed_mask = 1;
 
   private:
     using Scheduler = ThreadPool<SchedulerThread<T>>;
@@ -59,6 +58,9 @@ namespace verona::rt
 
     /// How many uninterrupted steps this threads has been selected to run for.
     size_t steps = 0;
+
+    /// Alters distribution of steps taken in systematic testing.
+    size_t systematic_speed_mask = 1;
 #else
     friend class ThreadSync<SchedulerThread>;
     LocalSync local_sync{};

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -48,19 +48,7 @@ namespace verona::rt
 
 #ifdef USE_SYSTEMATIC_TESTING
     friend class ThreadSyncSystematic<SchedulerThread>;
-    /// Used by systematic testing to implement the condition variable,
-    /// and thread termination.
-    SystematicState systematic_state = SystematicState::Active;
-
-    /// Used to specify a condition when this thread should/could make
-    /// progress.  It is used to implement condition variables.
-    snmalloc::function_ref<bool()> guard = true_thunk;
-
-    /// How many uninterrupted steps this threads has been selected to run for.
-    size_t steps = 0;
-
-    /// Alters distribution of steps taken in systematic testing.
-    size_t systematic_speed_mask = 1;
+    LocalSync local_sync{};
 #else
     friend class ThreadSync<SchedulerThread>;
     LocalSync local_sync{};
@@ -70,7 +58,6 @@ namespace verona::rt
     Alloc* alloc = nullptr;
     SchedulerThread<T>* next = nullptr;
     SchedulerThread<T>* victim = nullptr;
-    std::condition_variable cv;
 
     bool running = true;
 

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -59,6 +59,9 @@ namespace verona::rt
 
     /// How many uninterrupted steps this threads has been selected to run for.
     size_t steps = 0;
+#else
+    friend class ThreadSync<SchedulerThread>;
+    LocalSync local_sync{};
 #endif
 
     MPMCQ<T> q;

--- a/src/rt/sched/threadpool.h
+++ b/src/rt/sched/threadpool.h
@@ -301,7 +301,7 @@ namespace verona::rt
       {
         t->systematic_id = count;
 #ifdef USE_SYSTEMATIC_TESTING
-        t->systematic_speed_mask =
+        t->local_sync.systematic_speed_mask =
           (8ULL << (Systematic::get_prng_next() % 4)) - 1;
 #endif
         if (count > 1)

--- a/src/rt/sched/threadpool.h
+++ b/src/rt/sched/threadpool.h
@@ -512,7 +512,8 @@ namespace verona::rt
       {
         // This grabs the scheduler lock to ensure threads have seen CAS before
         // we notify.
-        sync.handle(local()).unpause_all();
+        Systematic::cout() << "Wake all threads" << Systematic::endl;
+        sync.unpause_all(local());
         return true;
       }
       // Another thread won the CAS race, and is responsible for waking up.

--- a/src/rt/sched/threadsync.h
+++ b/src/rt/sched/threadsync.h
@@ -2,10 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
-#include "test/systematic.h"
-
 #include "../pal/semaphore.h"
-#include <mutex>
+#include "test/systematic.h"
 
 /**
  * This file contains the synchronisation implementation for suspending
@@ -17,35 +15,130 @@
  */
 namespace verona::rt
 {
+  /**
+   * This class is a custom spin lock for handling thread pausing and unpausing.
+   *
+   * It uses three states:
+   *  - Unlocked: No thread is currently holding the lock.
+   *  - Locked: A thread is holding the lock, and is processing its
+   *    pause/unpause request
+   *  - LockedUnpauseNeeded: A thread is holding the lock, and another thread
+   *    has attempted to lock for unpause. Rather than waiting for the lock to
+   *    become available, the thread currently holding the lock takes
+   *    responsibility for unpausing the other threads.
+   */
+  class SchedulerLock
+  {
+    enum State
+    {
+      Unlocked,
+      Locked,
+      LockedUnpauseNeeded
+    };
+
+    std::atomic<State> state{Unlocked};
+
+  public:
+    /**
+     * Acquires the lock. Spins waiting for it to be available.
+     */
+    void lock()
+    {
+      Systematic::cout() << "Locking Scheduler." << Systematic::endl;
+      auto u = Unlocked;
+      while (!state.compare_exchange_strong(u, Locked))
+      {
+        // Have to reset u, as compare exchange gives it the current value.
+        u = Unlocked;
+        while (state.load(std::memory_order_acquire) != Unlocked)
+        {
+          snmalloc::Aal::pause();
+        }
+      }
+      Systematic::cout() << "Locking Scheduler done" << Systematic::endl;
+    }
+
+    /**
+     * Attempts to release the lock.  If the lock has received an unpause
+     * request, then will return false, and continues to hold the lock.
+     * Otherwise, will return true, and the lock is actually released.
+     */
+    bool unlock()
+    {
+      assert(state.load(std::memory_order_relaxed) != Unlocked);
+      auto l = Locked;
+      return state.compare_exchange_strong(l, Unlocked);
+    }
+
+    /**
+     * Releases the lock ignoring any unpause requests.
+     */
+    void unlock_unpause()
+    {
+      assert(state.load(std::memory_order_relaxed) == LockedUnpauseNeeded);
+      state.store(Unlocked);
+    }
+
+    /**
+     * Attempt to acquire the lock to unpause threads.
+     * Returns true, if it acquires the lock, and false if it
+     * notified the thread currently holding the thread to wake up waiters.
+     */
+    bool lock_for_unpause()
+    {
+      return state.exchange(LockedUnpauseNeeded) == Unlocked;
+    }
+  };
+
   struct LocalSync
   {
     pal::Semaphore sem;
     LocalSync* next{nullptr};
   };
-  
+
   template<class T>
   class ThreadSync
   {
-    std::mutex m;
+    SchedulerLock lock;
     LocalSync* waiters = nullptr;
 
-    void unpause_all()
+    void unlock()
     {
-      auto* curr = waiters;
-      while (curr != nullptr)
+      Systematic::cout() << "Unlock Scheduler lock" << Systematic::endl;
+
+      // Releasing the lock can pickup an unpause request
+      if (!lock.unlock())
       {
-        curr->sem.release();
-        curr = curr->next;
+        Systematic::cout() << "Pending unpause" << Systematic::endl;
+
+        auto* curr = waiters;
+        waiters = nullptr;
+        // Subsequent unpause requests can be ignored as there are no more
+        // waiters as we have held the lock continuously.
+        lock.unlock_unpause();
+        // Don't need to hold the lock to wake up the waiters.
+        while (curr != nullptr)
+        {
+          auto next = curr->next;
+          curr->sem.release();
+          curr = next;
+        }
       }
-      waiters = nullptr;
     }
 
   public:
+    void unpause_all(T*)
+    {
+      Systematic::cout() << "Unpause all" << Systematic::endl;
+      if (lock.lock_for_unpause())
+        unlock();
+      Systematic::cout() << "Unpause all done" << Systematic::endl;
+    }
+
     class ThreadSyncHandle
-    {      
+    {
       T* thread;
       ThreadSync& sync;
-      std::unique_lock<std::mutex> lock;
       bool wake_on_exit = false;
 
     public:
@@ -67,27 +160,32 @@ namespace verona::rt
        */
       void pause()
       {
-        Systematic::cout() << "Increasing sleep count" << Systematic::endl;
+        Systematic::cout() << "Add to list of waiters" << Systematic::endl;
         thread->local_sync.next = sync.waiters;
         sync.waiters = &(thread->local_sync);
-        lock.unlock();
+        sync.unlock();
 
         Systematic::cout() << "Acquire Sem" << Systematic::endl;
         thread->local_sync.sem.acquire();
         Systematic::cout() << "Acquired Sem!" << Systematic::endl;
 
-        lock.lock();
+        sync.lock.lock();
       }
 
-      ThreadSyncHandle(T* thread, ThreadSync& sync) : thread(thread), sync(sync), lock(sync.m) {}
+      ThreadSyncHandle(T* thread, ThreadSync& sync) : thread(thread), sync(sync)
+      {
+        sync.lock.lock();
+      }
 
       ~ThreadSyncHandle()
       {
         if (wake_on_exit)
         {
-          sync.unpause_all();
-          lock.unlock();
+          // Set to the unpause state. We already hold the lock, so we
+          // know that it will return false.
+          sync.lock.lock_for_unpause();
         }
+        sync.unlock();
       }
     };
 

--- a/src/rt/sched/threadsync.h
+++ b/src/rt/sched/threadsync.h
@@ -92,7 +92,7 @@ namespace verona::rt
 
   struct LocalSync
   {
-    pal::Semaphore sem;
+    pal::SleepHandle sem;
     LocalSync* next{nullptr};
   };
 
@@ -120,7 +120,7 @@ namespace verona::rt
         while (curr != nullptr)
         {
           auto next = curr->next;
-          curr->sem.release();
+          curr->sem.wake();
           curr = next;
         }
       }
@@ -165,9 +165,9 @@ namespace verona::rt
         sync.waiters = &(thread->local_sync);
         sync.unlock();
 
-        Systematic::cout() << "Acquire Sem" << Systematic::endl;
-        thread->local_sync.sem.acquire();
-        Systematic::cout() << "Acquired Sem!" << Systematic::endl;
+        Systematic::cout() << "Sleep" << Systematic::endl;
+        thread->local_sync.sem.sleep();
+        Systematic::cout() << "Awake!" << Systematic::endl;
 
         sync.lock.lock();
       }

--- a/src/rt/sched/threadsyncsystematic.h
+++ b/src/rt/sched/threadsyncsystematic.h
@@ -24,6 +24,26 @@ namespace verona::rt
 
   inline snmalloc::function_ref<bool()> true_thunk{[]() { return true; }};
 
+  struct LocalSync
+  {
+    /// Used by systematic testing to implement the condition variable,
+    /// and thread termination.
+    SystematicState systematic_state = SystematicState::Active;
+
+    /// Used to specify a condition when this thread should/could make
+    /// progress.  It is used to implement condition variables.
+    snmalloc::function_ref<bool()> guard = true_thunk;
+
+    /// How many uninterrupted steps this threads has been selected to run for.
+    size_t steps = 0;
+
+    /// Alters distribution of steps taken in systematic testing.
+    size_t systematic_speed_mask = 1;
+
+    /// Used to hold thread asleep.
+    std::condition_variable cv;
+  };
+
   template<typename T>
   class ThreadSyncSystematic
   {
@@ -80,8 +100,8 @@ namespace verona::rt
         start = start->next;
 
       auto result = start;
-      while ((result->systematic_state != SystematicState::Active) ||
-             !result->guard())
+      while ((result->local_sync.systematic_state != SystematicState::Active) ||
+             !result->local_sync.guard())
       {
         result = result->next;
         if (result == start)
@@ -102,11 +122,11 @@ namespace verona::rt
       }
       Systematic::cout() << "Set running thread:" << result->systematic_id
                          << Systematic::endl;
-      assert(result->guard());
+      assert(result->local_sync.guard());
 
       running_thread = result;
-      assert(result->systematic_state == SystematicState::Active);
-      result->cv.notify_all();
+      assert(result->local_sync.systematic_state == SystematicState::Active);
+      result->local_sync.cv.notify_all();
     }
 
     void wait_for_my_turn_inner(std::unique_lock<std::mutex>& lock, T* me)
@@ -114,8 +134,8 @@ namespace verona::rt
       assert(lock.mutex() == &m_sys);
       Systematic::cout() << "Waiting for turn" << Systematic::endl;
       while (running_thread != me)
-        me->cv.wait(lock);
-      assert(me->systematic_state == SystematicState::Active);
+        me->local_sync.cv.wait(lock);
+      assert(me->local_sync.systematic_state == SystematicState::Active);
     }
 
     /// Must hold the systematic testing lock to call this.
@@ -127,10 +147,10 @@ namespace verona::rt
       snmalloc::function_ref<bool()> g)
     {
       assert(lock.mutex() == &m_sys);
-      me->guard = g;
+      me->local_sync.guard = g;
       choose_thread(lock, me);
       wait_for_my_turn_inner(lock, me);
-      me->guard = true_thunk;
+      me->local_sync.guard = true_thunk;
     }
 
     void acquire(T* me)
@@ -178,7 +198,7 @@ namespace verona::rt
       {
         assert(sync.m == true);
         sync.m = false;
-        assert(me->systematic_state == SystematicState::Active);
+        assert(me->local_sync.systematic_state == SystematicState::Active);
         {
           std::unique_lock<std::mutex> lock(sync.m_sys);
           auto incarnation = sync.unpause_incarnation.load();
@@ -266,8 +286,8 @@ namespace verona::rt
     void thread_finished(T* me)
     {
       std::unique_lock<std::mutex> lock(m_sys);
-      assert(me->systematic_state == SystematicState::Active);
-      me->systematic_state = SystematicState::Finished;
+      assert(me->local_sync.systematic_state == SystematicState::Active);
+      me->local_sync.systematic_state = SystematicState::Finished;
 
       assert(running_thread == me);
 
@@ -275,7 +295,7 @@ namespace verona::rt
 
       // Confirm at least one other thread is running,
       auto curr = me;
-      while (curr->systematic_state != SystematicState::Active)
+      while (curr->local_sync.systematic_state != SystematicState::Active)
       {
         curr = curr->next;
         if (curr == me)
@@ -312,15 +332,16 @@ namespace verona::rt
 
       assert(running_thread == me);
 
-      if (me->steps == 0)
+      if (me->local_sync.steps == 0)
       {
         std::unique_lock<std::mutex> lock(m_sys);
         yield_until(me, lock, true_thunk);
-        me->steps = Systematic::get_prng_next() & me->systematic_speed_mask;
+        me->local_sync.steps =
+          Systematic::get_prng_next() & me->local_sync.systematic_speed_mask;
       }
       else
       {
-        me->steps--;
+        me->local_sync.steps--;
       }
     };
 

--- a/src/rt/sched/threadsyncsystematic.h
+++ b/src/rt/sched/threadsyncsystematic.h
@@ -253,6 +253,14 @@ namespace verona::rt
     }
 
     /**
+     * This unpauses all threads.
+     */
+    void unpause_all(T* me)
+    {
+      handle(me).unpause_all();
+    }
+
+    /**
      * Call this when the thread has completed.
      */
     void thread_finished(T* me)

--- a/src/rt/test/systematic.h
+++ b/src/rt/test/systematic.h
@@ -520,6 +520,7 @@ namespace Systematic
     auto* sa = new struct sigaction;
     sa->sa_handler = SIG_DFL;
     sigaction(SIGABRT, sa, nullptr);
+    sigaction(SIGINT, sa, nullptr);
 
     // Attempt to print stack trace
     auto syms = backtrace_symbols((void* const*)stack_frames, n_frames);


### PR DESCRIPTION
Prior to this PR, `unpause` would take a lock to ensure that wake-ups weren't lost.  This is unfortunately a problem if an external signal/interrupt causes the runtime to `unpause`, while the thread it signalled/interrupted is holding the lock.

This code changes the implementation to use a custom spin lock and semaphores to enables `unpause` to not require the lock, but instead notifies the thread holding the lock that it must wake all threads up on exit from the lock. 