### PR TITLE
Acquire all cowns at the beginning

### DIFF
--- a/src/rt/CMakeLists.txt
+++ b/src/rt/CMakeLists.txt
@@ -79,7 +79,9 @@ endif()
 
 target_compile_definitions(verona_rt INTERFACE -DSNMALLOC_CHEAP_CHECKS)
 
-target_compile_definitions(verona_rt INTERFACE -DACQUIRE_ALL)
+if(ACQUIRE_ALL)
+  target_compile_definitions(verona_rt INTERFACE -DACQUIRE_ALL)
+endif()
 
 set(CMAKE_CXX_STANDARD 17)
 

--- a/src/rt/CMakeLists.txt
+++ b/src/rt/CMakeLists.txt
@@ -79,6 +79,8 @@ endif()
 
 target_compile_definitions(verona_rt INTERFACE -DSNMALLOC_CHEAP_CHECKS)
 
+target_compile_definitions(verona_rt INTERFACE -DACQUIRE_ALL)
+
 set(CMAKE_CXX_STANDARD 17)
 
 

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -624,10 +624,13 @@ namespace verona::rt
     {
       MultiMessage::MultiMessageBody& body = *(m->get_body());
       Alloc& alloc = ThreadAlloc::get();
-#ifndef ACQUIRE_ALL
       size_t last = body.count - 1;
-#endif
-      auto cown = body.cowns[m->get_body()->index];
+      Cown *cown;
+
+      if (body.index <= last)
+        cown = body.cowns[m->get_body()->index];
+      else
+        cown = body.cowns[last];
 
       EpochMark e = m->get_epoch();
 

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -534,11 +534,11 @@ namespace verona::rt
         for (size_t i = 0; i < body->count; i++)
         {
           auto* next = body->cowns[i];
-          Systematic::cout()
-            << "Will try to acquire lock " << next << Systematic::endl;
+          Logging::cout()
+            << "Will try to acquire lock " << next << Logging::endl;
           next->enqueue_lock.lock();
           yield();
-          Systematic::cout() << "Acquired lock " << next << Systematic::endl;
+          Logging::cout() << "Acquired lock " << next << Logging::endl;
         }
       }
 
@@ -564,7 +564,7 @@ namespace verona::rt
           continue;
         }
 
-        Systematic::cout() << "Will schedule cown " << next << Systematic::endl;
+        Logging::cout() << "Will schedule cown " << next << Logging::endl;
         if (i == last)
         {
           next->schedule();
@@ -588,9 +588,9 @@ namespace verona::rt
       {
         auto m = MultiMessage::make_message(alloc, body, epoch);
         auto* next = body->cowns[body->index];
-        Systematic::cout() << "MultiMessage " << m << ": fast requesting "
+        Logging::cout() << "MultiMessage " << m << ": fast requesting "
                            << next << ", index " << body->index
-                           << Systematic::endl;
+                           << Logging::endl;
 
         if (body->index > 0)
         {
@@ -664,9 +664,9 @@ namespace verona::rt
 #endif
       Logging::cout() << "Enqueue MultiMessage " << m << Logging::endl;
       bool needs_scheduling = queue.enqueue(m);
-      Systematic::cout() << "Enqueued MultiMessage " << m
+      Logging::cout() << "Enqueued MultiMessage " << m
                          << " needs scheduling? " << needs_scheduling
-                         << Systematic::endl;
+                         << Logging::endl;
       yield();
       if (needs_scheduling)
       {

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -1289,8 +1289,8 @@ namespace verona::rt
           return false;
 
         (void)epoch;
-        //if (apply_backpressure(alloc, epoch, senders, senders_count))
-        //  return false;
+        if (apply_backpressure(alloc, epoch, senders, senders_count))
+          return false;
 
         // Reschedule the other cowns.
         for (size_t s = 0; s < senders_count; s++)

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -534,8 +534,8 @@ namespace verona::rt
         for (size_t i = 0; i < body->count; i++)
         {
           auto* next = body->cowns[i];
-          Logging::cout()
-            << "Will try to acquire lock " << next << Logging::endl;
+          Logging::cout() << "Will try to acquire lock " << next
+                          << Logging::endl;
           next->enqueue_lock.lock();
           yield();
           Logging::cout() << "Acquired lock " << next << Logging::endl;
@@ -547,10 +547,9 @@ namespace verona::rt
       {
         auto m = MultiMessage::make_message(alloc, body, epoch);
         auto* next = body->cowns[i];
-        Logging::cout() << "MultiMessage " << m << ": fast requesting "
-                        << next << ", index " << i << " behaviour "
-                        << body->behaviour << " loop end " << loop_end
-                        << Logging::endl;
+        Logging::cout() << "MultiMessage " << m << ": fast requesting " << next
+                        << ", index " << i << " behaviour " << body->behaviour
+                        << " loop end " << loop_end << Logging::endl;
 
         auto needs_sched = next->try_fast_send(m);
         if (loop_end > 1)
@@ -558,9 +557,9 @@ namespace verona::rt
 
         if (!needs_sched)
         {
-          Logging::cout()
-            << "try fast send found busy cown " << body << " loop iteration "
-            << i << " cown " << next << Logging::endl;
+          Logging::cout() << "try fast send found busy cown " << body
+                          << " loop iteration " << i << " cown " << next
+                          << Logging::endl;
           continue;
         }
 
@@ -588,9 +587,8 @@ namespace verona::rt
       {
         auto m = MultiMessage::make_message(alloc, body, epoch);
         auto* next = body->cowns[body->index];
-        Logging::cout() << "MultiMessage " << m << ": fast requesting "
-                           << next << ", index " << body->index
-                           << Logging::endl;
+        Logging::cout() << "MultiMessage " << m << ": fast requesting " << next
+                        << ", index " << body->index << Logging::endl;
 
         if (body->index > 0)
         {
@@ -664,9 +662,8 @@ namespace verona::rt
 #endif
       Logging::cout() << "Enqueue MultiMessage " << m << Logging::endl;
       bool needs_scheduling = queue.enqueue(m);
-      Logging::cout() << "Enqueued MultiMessage " << m
-                         << " needs scheduling? " << needs_scheduling
-                         << Logging::endl;
+      Logging::cout() << "Enqueued MultiMessage " << m << " needs scheduling? "
+                      << needs_scheduling << Logging::endl;
       yield();
       if (needs_scheduling)
       {
@@ -722,8 +719,9 @@ namespace verona::rt
         // The following code is isolating cases where a message was sent
         // before the leak detector began, and is now about to be forwarded
         // after the leak detector has started.  This means the messages must
-        // now be counted for termination of the scan phase of the leak detector.
-        // This is not required in the ACQUIRE_ALL case as messages are not forwarded.
+        // now be counted for termination of the scan phase of the leak
+        // detector. This is not required in the ACQUIRE_ALL case as messages
+        // are not forwarded.
         if (e != Scheduler::local()->send_epoch)
         {
           Logging::cout() << "Message not in current epoch" << Logging::endl;

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -718,6 +718,12 @@ namespace verona::rt
       if (body.index < last)
 #endif
       {
+#ifndef ACQUIRE_ALL
+        // The following code is isolating cases where a message was sent
+        // before the leak detector began, and is now about to be forwarded
+        // after the leak detector has started.  This means the messages must
+        // now be counted for termination of the scan phase of the leak detector.
+        // This is not required in the ACQUIRE_ALL case as messages are not forwarded.
         if (e != Scheduler::local()->send_epoch)
         {
           Logging::cout() << "Message not in current epoch" << Logging::endl;
@@ -754,7 +760,6 @@ namespace verona::rt
           }
         }
 
-#ifndef ACQUIRE_ALL
         // Try to acquire as many cowns as possible without rescheduling,
         // starting from the next cown.
         body.index++;

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -1237,9 +1237,9 @@ namespace verona::rt
           return false;
 
         // Reschedule the other cowns.
-        for (size_t s = 0; s < (senders_count - 1); s++)
+        for (size_t s = 0; s < senders_count; s++)
         {
-          if (senders[s])
+          if ((senders[s]) && (senders[s] != this))
             senders[s]->schedule();
         }
 

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -501,20 +501,14 @@ namespace verona::rt
 
 #ifdef ACQUIRE_ALL
       UNUSED(high_priority);
-      // First acquire all the locks
       // FIXME: Bad implementation for testing purposes
-      for (size_t i=0;i<body->count;i++)
+      auto* first = body->cowns[0];
+      Systematic::cout() << "Will try to acquire lock " << first << Systematic::endl;
+      auto u = false;
+      while(!first->queue_locked.compare_exchange_strong(u, true))
       {
-        auto* next = body->cowns[i];
-        Systematic::cout() << "Will try to acquire lock " << next << Systematic::endl;
-        auto u = false;
-        while(!next->queue_locked.compare_exchange_strong(u, true))
-        {
-          u = false;
-          yield();
-        }
+        u = false;
         yield();
-        Systematic::cout() << "Acquired lock " << next << Systematic::endl;
       }
 
       size_t loop_end = body->count;
@@ -527,7 +521,21 @@ namespace verona::rt
                            << Logging::endl;
 
         auto needs_sched = next->try_fast_send(m);
-        // Release all the locks now. Is it too early?
+
+        // acquire next lock
+        if (i < loop_end - 1)
+        {
+          auto* to_get = body->cowns[i+1];
+          Systematic::cout() << "Will try to acquire lock " << to_get << Systematic::endl;
+          auto u = false;
+          while(!to_get->queue_locked.compare_exchange_strong(u, true))
+          {
+            u = false;
+            yield();
+          }
+        }
+
+        // Release the lock
         assert(next->queue_locked == true);
         next->queue_locked = false;
 

--- a/src/rt/sched/multimessage.h
+++ b/src/rt/sched/multimessage.h
@@ -19,6 +19,7 @@ namespace verona::rt
       size_t index;
       size_t count;
       Cown** cowns;
+      std::atomic<size_t> exec_count_down;
       Behaviour* behaviour;
     };
 
@@ -71,7 +72,7 @@ namespace verona::rt
     make_body(Alloc& alloc, size_t count, Cown** cowns, Behaviour* behaviour)
     {
       return new (alloc.alloc<sizeof(MultiMessageBody)>())
-        MultiMessageBody{0, count, cowns, behaviour};
+        MultiMessageBody{0, count, cowns, count, behaviour};
     }
 
     static MultiMessage*

--- a/src/rt/sched/threadpool.h
+++ b/src/rt/sched/threadpool.h
@@ -277,12 +277,10 @@ namespace verona::rt
 
     static void want_ld()
     {
-#ifndef ACQUIRE_ALL
       T* t = local();
 
       if (t != nullptr)
         t->want_ld();
-#endif
     }
 
     void init(size_t count)

--- a/src/rt/sched/threadpool.h
+++ b/src/rt/sched/threadpool.h
@@ -277,10 +277,12 @@ namespace verona::rt
 
     static void want_ld()
     {
+#ifndef ACQUIRE_ALL
       T* t = local();
 
       if (t != nullptr)
         t->want_ld();
+#endif
     }
 
     void init(size_t count)

--- a/src/rt/sched/threadsync.h
+++ b/src/rt/sched/threadsync.h
@@ -200,32 +200,4 @@ namespace verona::rt
       return ThreadSyncHandle(t, *this);
     }
   };
-
-#ifdef ACQUIRE_ALL
-  // struct __attribute__((aligned (64))) EnqueueLock
-  struct EnqueueLock
-  {
-    std::atomic<bool> locked = false;
-    // char padding[64 - sizeof(std::atomic<bool>)];
-
-    void lock()
-    {
-      auto u = false;
-      while (!locked.compare_exchange_strong(u, true))
-      {
-        u = false;
-        while (locked)
-        {
-          yield();
-        }
-      }
-    }
-
-    void unlock()
-    {
-      locked.store(false, std::memory_order_release);
-    }
-  };
-  // static_assert(sizeof(EnqueueLock) == 64);
-#endif
 }

--- a/src/rt/sched/threadsync.h
+++ b/src/rt/sched/threadsync.h
@@ -200,4 +200,32 @@ namespace verona::rt
       return ThreadSyncHandle(t, *this);
     }
   };
+
+#ifdef ACQUIRE_ALL
+  // struct __attribute__((aligned (64))) EnqueueLock
+  struct EnqueueLock
+  {
+    std::atomic<bool> locked = false;
+    // char padding[64 - sizeof(std::atomic<bool>)];
+
+    void lock()
+    {
+      auto u = false;
+      while (!locked.compare_exchange_strong(u, true))
+      {
+        u = false;
+        while (locked)
+        {
+          yield();
+        }
+      }
+    }
+
+    void unlock()
+    {
+      locked.store(false, std::memory_order_release);
+    }
+  };
+  // static_assert(sizeof(EnqueueLock) == 64);
+#endif
 }


### PR DESCRIPTION
This PR changes the way the verona runtime acquires cowns. When scheduling a behaviour, the runtime acquires all the idle cowns and enqueues the multimessage on the queues of the busy ones. The multimessage has an atomic counter that gets decrement every time a new cown is available. The scheduler thread that last decrements this counter in run_step() also executes the behaviour. 