### PR TITLE
Fix unused variable warning in release mode

### DIFF
--- a/src/rt/region/region_rc.h
+++ b/src/rt/region/region_rc.h
@@ -120,6 +120,7 @@ namespace verona::rt
     static Object* alloc(Alloc& alloc, Object* in, const Descriptor* desc)
     {
       assert((size == 0) || (size == desc->size));
+      (void)in; // asserts aren't compiled in release mode and this goes unused
       assert(in->get_class() == RegionMD::OPEN_ISO);
       RegionRc* reg = (RegionRc*)opened_region();
 


### PR DESCRIPTION
Our nightly builds have been failing on MacOS release and this is the error. I'm not sure why other release builds in Linux and Windows are not picking this up.

https://dev.azure.com/ProjectVeronaCI/Project%20Verona/_build/results?buildId=3462&view=logs&j=27c02e5f-1e08-5ff5-4535-96d1b952e7df&t=27fecc53-61b6-5aa3-75d5-66d0e428ef1b&l=34