### PR TITLE
Silence unused argument with UNUSED

### DIFF
--- a/src/rt/region/region_rc.h
+++ b/src/rt/region/region_rc.h
@@ -224,6 +224,7 @@ namespace verona::rt
     static void gc_cycles(Alloc& alloc, Object* o, RegionRc* reg)
     {
       assert(o->get_class() == RegionMD::OPEN_ISO);
+      UNUSED(o);
       ObjectStack jump_stack(alloc);
       while (!reg->lins_stack.empty())
       {


### PR DESCRIPTION
Some arguments are used in debug settings, others in the side-effects of
functions they're called with, others are just part of the public API
and are trully unused arguments, but we can't remove them from the
function signature.

This fixes a broken Mac build for the last week.