### PR TITLE
Ensure Thread Pool does not have a guard.

### DIFF
--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -109,25 +109,25 @@ namespace verona::rt
     union
     {
       std::atomic<Cown*> next_in_queue;
-      uint64_t epoch_when_popped = NO_EPOCH_SET;
+      uint64_t epoch_when_popped{NO_EPOCH_SET};
     };
 
     // Seven pointer overhead compared to an object.
-    verona::rt::MPSCQ<MultiMessage> queue;
+    verona::rt::MPSCQ<MultiMessage> queue{};
 
     // Used for garbage collection of cyclic cowns only.
     // Uses the bottom bit to indicate the cown has been collected
     // If the object is collected by the leak detector, we should not
     // collect again when the weak reference count hits 0.
-    std::atomic<uintptr_t> thread_status;
-    Cown* next;
+    std::atomic<uintptr_t> thread_status{0};
+    Cown* next{nullptr};
 
     /**
      * Cown's weak reference count.  This keeps the cown itself alive, but not
      * the data it can reach.  Weak reference can be promoted to strong, if a
      * strong reference still exists.
      **/
-    std::atomic<size_t> weak_count = 1;
+    std::atomic<size_t> weak_count{1};
 
     std::atomic<BPState> bp_state{};
 

--- a/src/rt/sched/priority.h
+++ b/src/rt/sched/priority.h
@@ -46,7 +46,7 @@ namespace verona::rt
       All = (HasToken << 1) - 1,
     };
 
-    BPState() noexcept {}
+    constexpr BPState() noexcept {}
 
     Cown* blocker() const
     {

--- a/src/rt/sched/threadpool.h
+++ b/src/rt/sched/threadpool.h
@@ -85,7 +85,7 @@ namespace verona::rt
   public:
     static ThreadPool<T>& get()
     {
-      static ThreadPool<T> global_thread_pool;
+      SNMALLOC_REQUIRE_CONSTINIT static ThreadPool<T> global_thread_pool;
       return global_thread_pool;
     }
 

--- a/src/rt/sched/threadstate.h
+++ b/src/rt/sched/threadstate.h
@@ -108,15 +108,12 @@ namespace verona::rt
     };
 
   private:
-    State state;
-    bool retracted;
-    std::atomic<size_t> vote_yes;
+    State state{NotInLD};
+    bool retracted{false};
+    std::atomic<size_t> vote_yes{0};
 
   public:
-    ThreadState()
-    {
-      reset<NotInLD>();
-    }
+    constexpr ThreadState() = default;
 
     State get_state()
     {


### PR DESCRIPTION
Fix a few initialisers to ensure that we can constinit the thread pool.  This removes some C++ guard checks from fast paths.