### PR TITLE
Atomic Enqueue - Split Execution

### DIFF
--- a/src/rt/cpp/lambdabehaviour.h
+++ b/src/rt/cpp/lambdabehaviour.h
@@ -110,6 +110,6 @@ namespace verona::rt
     ([&](auto&& input) { is_packed_args(input); }(std::forward<Args>(args)),
      ...);
 
-    Cown::schedule_many<NoTransfer>(std::forward<Args>(args)...);
+    Cown::schedule_many<transfer>(std::forward<Args>(args)...);
   }
 } // namespace verona::rt

--- a/src/rt/cpp/lambdabehaviour.h
+++ b/src/rt/cpp/lambdabehaviour.h
@@ -104,6 +104,7 @@ namespace verona::rt
     (void)args;
   }
 
+#ifdef ACQUIRE_ALL
   template<TransferOwnership transfer = NoTransfer, typename... Args>
   static void schedule_lambda_many(Args&&... args)
   {
@@ -113,4 +114,5 @@ namespace verona::rt
 
     Cown::schedule_many<transfer>(std::forward<Args>(args)...);
   }
+#endif
 } // namespace verona::rt

--- a/src/rt/cpp/lambdabehaviour.h
+++ b/src/rt/cpp/lambdabehaviour.h
@@ -65,7 +65,7 @@ namespace verona::rt
   {
     using type = LambdaBehaviour<T>;
 
-    LambdaBehaviour<T> *be;
+    LambdaBehaviour<T>* be;
     Cown** cowns;
     size_t count;
 
@@ -73,7 +73,8 @@ namespace verona::rt
     : cowns(cowns_), count(count_)
     {
       auto& alloc = ThreadAlloc::get();
-      be = new ((LambdaBehaviour<T>*)alloc.alloc<sizeof(LambdaBehaviour<T>)>()) LambdaBehaviour<T>(std::move(fn));
+      be = new ((LambdaBehaviour<T>*)alloc.alloc<sizeof(LambdaBehaviour<T>)>())
+        LambdaBehaviour<T>(std::move(fn));
     }
   };
 

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -829,6 +829,18 @@ namespace verona::rt
       fast_send(body, epoch);
     }
 
+    template<
+      TransferOwnership transfer = NoTransfer,
+      typename... Args>
+    static void schedule_many(Args&&... args)
+    {
+      std::cout << "Schedule many hello!" << std::endl;
+      ([&] (auto && input)
+       {
+       std::cout << "cown count " << input.count << std::endl;
+       } (std::forward<Args>(args)), ...);
+    }
+
     /**
      * This processes a batch of messages on a cown.
      *

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -612,6 +612,7 @@ namespace verona::rt
       return needs_scheduling;
     }
 
+#ifdef ACQUIRE_ALL
     static void fast_send_many(
       MultiMessage::MultiMessageBody** bodies,
       size_t body_count,
@@ -707,6 +708,7 @@ namespace verona::rt
 
       alloc.dealloc(bodies, body_count * sizeof(MessageBody*));
     }
+#endif
 
     /**
      * Execute the behaviour of the given multi-message.
@@ -925,6 +927,7 @@ namespace verona::rt
       fast_send(body, epoch);
     }
 
+#ifdef ACQUIRE_ALL
     template<TransferOwnership transfer = NoTransfer, typename... Args>
     static void schedule_many(Args&&... args)
     {
@@ -962,6 +965,7 @@ namespace verona::rt
       // starting from the beginning.
       fast_send_many(bodies, body_count, epoch);
     }
+#endif
 
     /**
      * This processes a batch of messages on a cown.

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -699,6 +699,8 @@ namespace verona::rt
           UNUSED(m2);
         }
       }
+
+      alloc.dealloc(bodies, body_count * sizeof(MessageBody*));
     }
 
     /**

--- a/src/rt/test/func/split_exec/split_exec.cc
+++ b/src/rt/test/func/split_exec/split_exec.cc
@@ -1,0 +1,38 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include <test/harness.h>
+
+using namespace std;
+
+struct TestCown : public VCown<TestCown>
+{};
+
+template<typename T>
+struct foo
+{
+  size_t count;
+  T* items;
+};
+
+void split_exec()
+{
+  //foo<int> f;
+  //f.count = 42;
+
+  Cown *cowns[2];
+  auto& alloc = ThreadAlloc::get();
+  cowns[0] = new (alloc) TestCown;
+  cowns[1] = new (alloc) TestCown;
+  
+  schedule_lambda_many(LambdaBehaviourPackedArgs([](){cout << "hello1";}, cowns, 1));
+}
+
+int main(int argc, char** argv)
+{
+  SystematicTestHarness harness(argc, argv);
+
+  harness.run(split_exec);
+
+  return 0;
+}

--- a/src/rt/test/func/split_exec/split_exec.cc
+++ b/src/rt/test/func/split_exec/split_exec.cc
@@ -17,15 +17,17 @@ struct foo
 
 void split_exec()
 {
-  //foo<int> f;
-  //f.count = 42;
+  // foo<int> f;
+  // f.count = 42;
 
-  Cown *cowns[2];
+  Cown* cowns[2];
   auto& alloc = ThreadAlloc::get();
   cowns[0] = new (alloc) TestCown;
   cowns[1] = new (alloc) TestCown;
-  
-  schedule_lambda_many(LambdaBehaviourPackedArgs([](){cout << "hello1";}, cowns, 1));
+
+  schedule_lambda_many<YesTransfer>(
+    LambdaBehaviourPackedArgs([]() { cout << "hello1\n"; }, cowns, 1),
+    LambdaBehaviourPackedArgs([]() { cout << "hello2\n"; }, &cowns[1], 1));
 }
 
 int main(int argc, char** argv)

--- a/src/rt/test/func/split_exec/split_exec.cc
+++ b/src/rt/test/func/split_exec/split_exec.cc
@@ -17,6 +17,7 @@ struct foo
 
 void split_exec()
 {
+#ifdef ACQUIRE_ALL
   // foo<int> f;
   // f.count = 42;
 
@@ -28,6 +29,7 @@ void split_exec()
   schedule_lambda_many<YesTransfer>(
     LambdaBehaviourPackedArgs([]() { cout << "hello1\n"; }, cowns, 1),
     LambdaBehaviourPackedArgs([]() { cout << "hello2\n"; }, &cowns[1], 1));
+#endif
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
This PR builds on top of the acquire-all semantics and enables enqueueing multiple behaviours atomically while their execution can still happen in parallel.