### PR TITLE
Fix missing check for path canonicalisation.

### DIFF
--- a/experiments/process_sandbox/include/process_sandbox/path.h
+++ b/experiments/process_sandbox/include/process_sandbox/path.h
@@ -182,7 +182,7 @@ namespace sandbox
      * Returns true on success, false otherwise.  This function can fail if
      * there are too many `..` elements in the path.
      */
-    bool canonicalise()
+    [[nodiscard]] bool canonicalise()
     {
       remove_empty();
       return remove_dotdot();

--- a/experiments/process_sandbox/src/libsandbox.cc
+++ b/experiments/process_sandbox/src/libsandbox.cc
@@ -354,7 +354,10 @@ namespace sandbox
         return {-EINVAL};
       }
       Path path{raw_path.get()};
-      path.canonicalise();
+      if (!path.canonicalise())
+      {
+        return {-EINVAL};
+      }
       auto allowed = vfs.lookup_file(path);
       if (!allowed.has_value())
       {

--- a/experiments/process_sandbox/tests/path.cc
+++ b/experiments/process_sandbox/tests/path.cc
@@ -17,7 +17,7 @@ namespace
   void check_canonicalisation(std::string_view path, std::string_view expected)
   {
     Path p = get(path);
-    p.canonicalise();
+    snmalloc::UNUSED(p.canonicalise());
     SANDBOX_INVARIANT(
       p.str() == expected,
       "{} canonicalised as {}, expected {}",
@@ -40,7 +40,7 @@ int main()
   {
     Path p = get("/foo/../bar");
     SANDBOX_INVARIANT(p.is_absolute(), "{} is an absolute path.", p.str());
-    p.canonicalise();
+    snmalloc::UNUSED(p.canonicalise());
     expect(p, "/bar");
   }
 
@@ -49,7 +49,7 @@ int main()
   {
     Path p = get("foo/../bar");
     SANDBOX_INVARIANT(!p.is_absolute(), "{} is not an absolute path.", p.str());
-    p.canonicalise();
+    snmalloc::UNUSED(p.canonicalise());
     SANDBOX_INVARIANT(
       p.str() == "bar", "Canonicalised incorrectly as {}.", p.str());
 
@@ -69,7 +69,7 @@ int main()
     Path base = get("/1/2/3/4");
     p.make_absolute(base);
     SANDBOX_INVARIANT(p.is_absolute(), "{} is not an absolute path.", p.str());
-    p.canonicalise();
+    snmalloc::UNUSED(p.canonicalise());
     expect(p, "/1/2/foo");
   }
 


### PR DESCRIPTION
bug found by @saaramar.

This is not exploitable, because the `/..` doesn't exist, but it may
hide other bugs.