### PR TITLE
Fix DoS from the sandbox.

### DIFF
--- a/experiments/process_sandbox/include/process_sandbox/platform/child_process_pdfork.h
+++ b/experiments/process_sandbox/include/process_sandbox/platform/child_process_pdfork.h
@@ -117,6 +117,14 @@ namespace sandbox
       {
         return wait_for_exit(nullptr);
       }
+
+      /**
+       * Forcibly kill the child.
+       */
+      void terminate()
+      {
+        pdkill(proc.fd, SIGKILL);
+      }
     };
   }
 }

--- a/experiments/process_sandbox/include/process_sandbox/platform/child_process_vfork.h
+++ b/experiments/process_sandbox/include/process_sandbox/platform/child_process_vfork.h
@@ -3,7 +3,7 @@
 #ifdef __unix__
 #  include <err.h>
 #  include <errno.h>
-#  include <sys/signal.h>
+#  include <signal.h>
 #  include <sys/types.h>
 #  include <sys/wait.h>
 #  if __has_include(<sys/procctl.h>)
@@ -117,6 +117,14 @@ namespace sandbox
       ExitStatus wait_for_exit()
       {
         return waitpid();
+      }
+
+      /**
+       * Forcibly kill the child.
+       */
+      void terminate()
+      {
+        kill(pid, SIGKILL);
       }
     };
   }

--- a/experiments/process_sandbox/include/process_sandbox/sandbox.h
+++ b/experiments/process_sandbox/include/process_sandbox/sandbox.h
@@ -524,11 +524,7 @@ namespace sandbox
      * functions.
      */
     int last_vtable_entry = 1;
-    /**
-     * A flag indicating whether the child has exited.  This is updated when a
-     * message send fails.
-     */
-    bool child_exited = false;
+
     /**
      * The exit code of the child.  This is set when the child process exits.
      */
@@ -780,6 +776,17 @@ namespace sandbox
      * exited immediately after the call.
      */
     bool has_child_exited();
+
+    /**
+     * Forcibly terminate the child.
+     */
+    void terminate();
+
+    /**
+     * MemoryServiceProvider manages memory for sandboxes and must be able to
+     * access this class's memory provider.
+     */
+    friend class MemoryServiceProvider;
   };
 
   /**

--- a/experiments/process_sandbox/tests/CMakeLists.txt
+++ b/experiments/process_sandbox/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SANDBOX_TESTS
 	modify-pagemap
 	network
 	rpc-bounds
+	rpc-deadlock
 	zlib
 	)
 

--- a/experiments/process_sandbox/tests/sandbox-rpc-deadlock.cc
+++ b/experiments/process_sandbox/tests/sandbox-rpc-deadlock.cc
@@ -1,0 +1,63 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include "process_sandbox/cxxsandbox.h"
+#include "process_sandbox/sandbox.h"
+
+#include <limits.h>
+#include <stdio.h>
+
+using namespace sandbox;
+
+void attack();
+void attack2();
+
+/**
+ * The structure that represents an instance of the sandbox.
+ */
+struct EvilSandbox
+{
+  /**
+   * The library that defines the functions exposed by this sandbox.
+   */
+  Library lib = {SANDBOX_LIBRARY};
+#define EXPORTED_FUNCTION(public_name, private_name) \
+  decltype(make_sandboxed_function<decltype(private_name)>(lib)) public_name = \
+    make_sandboxed_function<decltype(private_name)>(lib);
+  EXPORTED_FUNCTION(attack, ::attack)
+  EXPORTED_FUNCTION(attack2, ::attack2)
+};
+
+void attack()
+{
+  EvilSandbox sandbox;
+  try
+  {
+    sandbox.attack();
+  }
+  catch (...)
+  {
+    return;
+  }
+  SANDBOX_INVARIANT(0, "First attack succeeded");
+}
+
+void attack2()
+{
+  EvilSandbox sandbox;
+  try
+  {
+    sandbox.attack2();
+  }
+  catch (...)
+  {
+    return;
+  }
+  SANDBOX_INVARIANT(0, "Second attack succeeded");
+}
+
+int main()
+{
+  attack();
+  attack2();
+}

--- a/experiments/process_sandbox/tests/sandboxlib-rpc-deadlock.cc
+++ b/experiments/process_sandbox/tests/sandboxlib-rpc-deadlock.cc
@@ -1,0 +1,42 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include "../src/host_service_calls.h"
+#include "process_sandbox/cxxsandbox.h"
+#include "process_sandbox/sandbox.h"
+#include "process_sandbox/shared_memory_region.h"
+
+#include <limits>
+#include <stdio.h>
+
+using namespace sandbox;
+
+void attack()
+{
+  HostServiceRequest req{AllocChunk, {0, 0, 0}};
+
+  // Keep writing nonsense values, without reading.  This should fill up the
+  // response buffer in the kernel and cause writes from the parent to fail.
+  // This sandbox should be terminated if that happens.
+  for (int i = 0; i < 1000000; i++)
+  {
+    write(PageMapUpdates, &req, sizeof(req));
+  }
+}
+
+void attack2()
+{
+  // Try slowly writing individual bytes.  This should cause the parent to
+  // detect partial messages and kill the sandbox.
+  for (int i = 0; i < 100; i++)
+  {
+    write(PageMapUpdates, "\0", 1);
+    usleep(10000);
+  }
+}
+
+extern "C" void sandbox_init()
+{
+  sandbox::ExportedLibrary::export_function(::attack);
+  sandbox::ExportedLibrary::export_function(::attack2);
+}


### PR DESCRIPTION
If the sandbox tried writing incomplete messages to the parent, or
not reading responses, it was possible to end up with a blocking read or
write call and either an infinite loop or the parent crashing.

Fixes #566