### PR TITLE
Improved API for CPP

### DIFF
--- a/src/rt/cpp/cown.h
+++ b/src/rt/cpp/cown.h
@@ -6,199 +6,221 @@
 #include <utility>
 #include <verona.h>
 
-/**
- * Used in static asserts to check passed values are cown_ptr types.
- *
- * This class is used so a single simple check can be used
- *   std::is_base_of<cown_ptr_base, T>
- * To check T is a cown_ptr.
- */
-class cown_ptr_base
+namespace verona::cpp
 {
-private:
-  cown_ptr_base() {}
+  using namespace verona::rt;
 
   /**
-   * Only cown_ptr can construct one of these,
-   * so anything that has this base class will be a cown_ptr.
+   * Used in static asserts to check passed values are cown_ptr types.
+   *
+   * This class is used so a single simple check can be used
+   *   std::is_base_of<cown_ptr_base, T>
+   * To check T is a cown_ptr.
    */
-  template<typename T>
-  friend class cown_ptr;
-};
-
-/**
- * Smart pointer to represent shared access to a cown.
- * Can only be used asychronously with `when` to get
- * underlying access.
- *
- * Note using lower case name to match C++ std library
- * as this is one of the exposed types.
- */
-template<typename T>
-class cown_ptr : cown_ptr_base
-{
-private:
-  /**
-   * Internal Verona runtime cown for this type.
-   */
-  class ActualCown : public VCown<ActualCown>
+  class cown_ptr_base
   {
   private:
-    T value;
+    cown_ptr_base() {}
 
-  public:
-    template<typename... Args>
-    ActualCown(Args&&... ts) : value(std::forward<Args>(ts)...)
-    {}
-
-    template<typename TT>
-    friend class acquired_cown;
+    /**
+     * Only cown_ptr can construct one of these,
+     * so anything that has this base class will be a cown_ptr.
+     */
+    template<typename T>
+    friend class cown_ptr;
   };
 
   /**
-   * Internal Verona runtime cown for this type.
-   */
-  ActualCown* allocated_cown = nullptr;
-
-  /**
-   * Accesses the internal Verona runtime cown for this handle.
-   */
-  Cown* underlying_cown()
-  {
-    return allocated_cown;
-  }
-
-  /**
-   * Construct a new cown ptr object, actually allocates a runtime cown.
+   * Smart pointer to represent shared access to a cown.
+   * Can only be used asychronously with `when` to get
+   * underlying access.
    *
-   * This is internal, and the `make_cown` below is the public interface,
-   * which has better behaviour for implicit template arguments.
+   * Note using lower case name to match C++ std library
+   * as this is one of the exposed types.
    */
-  cown_ptr(ActualCown* cown) : allocated_cown(cown) {}
-
-public:
-  /**
-   * Copy an existing cown ptr.  Shares the underlying cown.
-   */
-  cown_ptr(const cown_ptr& other)
+  template<typename T>
+  class cown_ptr : cown_ptr_base
   {
-    allocated_cown = other.allocated_cown;
-    verona::rt::Cown::acquire(allocated_cown);
-  }
-
-  cown_ptr& operator=(cown_ptr&& other)
-  {
-    allocated_cown = other.allocated_cown;
-    verona::rt::Cown::acquire(allocated_cown);
-    return *this;
-  }
-
-  /**
-   * Move an existing cown ptr.  Does not create a new cown,
-   * and is more efficient than copying, as it does not need
-   * to perform reference count operations.
-   */
-  cown_ptr(cown_ptr&& other)
-  {
-    allocated_cown = other.allocated_cown;
-    other.allocated_cown = nullptr;
-  }
-
-  ~cown_ptr()
-  {
-    // Condition to handle moved cown ptrs.
-    if (allocated_cown != nullptr)
+  private:
+    /**
+     * Internal Verona runtime cown for this type.
+     */
+    class ActualCown : public VCown<ActualCown>
     {
-      auto& alloc = verona::rt::ThreadAlloc::get();
-      verona::rt::Cown::release(alloc, allocated_cown);
+    private:
+      T value;
+
+    public:
+      template<typename... Args>
+      ActualCown(Args&&... ts) : value(std::forward<Args>(ts)...)
+      {}
+
+      template<typename TT>
+      friend class acquired_cown;
+    };
+
+    /**
+     * Internal Verona runtime cown for this type.
+     */
+    ActualCown* allocated_cown{nullptr};
+
+    /**
+     * Accesses the internal Verona runtime cown for this handle.
+     */
+    Cown* underlying_cown()
+    {
+      return allocated_cown;
     }
-  }
 
-  // Required as acquired_cown has to reach inside.
-  // Note only requires friend when implicit typename is T
-  // but C++ doesn't like this.
-  template<typename>
-  friend class acquired_cown;
+    /**
+     * Construct a new cown ptr object, actually allocates a runtime cown.
+     *
+     * This is internal, and the `make_cown` below is the public interface,
+     * which has better behaviour for implicit template arguments.
+     */
+    cown_ptr(ActualCown* cown) : allocated_cown(cown) {}
 
-  // Note only requires friend when TT is T
-  // but C++ doesn't like this.
-  template<typename TT, typename... Args>
-  friend cown_ptr<TT> make_cown(Args&&...);
+  public:
+    constexpr cown_ptr() = default;
 
-  template<typename...>
-  friend class When;
-};
+    /**
+     * Copy an existing cown ptr.  Shares the underlying cown.
+     */
+    cown_ptr(const cown_ptr& other)
+    {
+      allocated_cown = other.allocated_cown;
+      verona::rt::Cown::acquire(allocated_cown);
+    }
 
-/**
- * Used to construct a new cown_ptr.
- *
- * Forwards arguments to construct the underlying data contained in the cown.
- */
-template<typename T, typename... Args>
-cown_ptr<T> make_cown(Args&&... ts)
-{
-  return cown_ptr<T>(
-    new typename cown_ptr<T>::ActualCown(std::forward<Args>(ts)...));
-}
+    /**
+     * Copy an existing cown ptr.  Shares the underlying cown.
+     */
+    cown_ptr& operator=(const cown_ptr& other)
+    {
+      allocated_cown = other.allocated_cown;
+      verona::rt::Cown::acquire(allocated_cown);
+      return *this;
+    }
 
-/**
- * Represents a cown that has been acquired in a `when` clause.
- *
- * Can only be constructed by a `when`.
- *
- * The acquired_cown should not be persisted beyond the lifetime of the `when`
- *
- * Note using lower case name to match C++ std library
- * as this is one of the exposed types.
- */
-template<typename T>
-class acquired_cown
-{
-  /// Needed to build one from inside a `when`
-  template<typename...>
-  friend class When;
+    /**
+     * Move an existing cown ptr.  Does not create a new cown,
+     * and is more efficient than copying, as it does not need
+     * to perform reference count operations.
+     */
+    cown_ptr(cown_ptr&& other)
+    {
+      allocated_cown = other.allocated_cown;
+      other.allocated_cown = nullptr;
+    }
 
-private:
-  /// Underlying cown that has been acquired.
-  /// Runtime is actually holding this reference count.
-  cown_ptr<T> origin_cown;
+    /**
+     * Move an existing cown ptr.  Does not create a new cown,
+     * and is more efficient than copying, as it does not need
+     * to perform reference count operations.
+     */
+    cown_ptr& operator=(cown_ptr&& other)
+    {
+      allocated_cown = other.allocated_cown;
+      other.allocated_cown = nullptr;
+      return *this;
+    }
 
-  /// Constructor is private, as only `When` can construct one.
-  /// TODO: Consider if we can reduce the reference count here, as the
-  /// runtime is holding references too.
-  acquired_cown(const cown_ptr<T>& origin) : origin_cown(origin) {}
+    ~cown_ptr()
+    {
+      // Condition to handle moved cown ptrs.
+      if (allocated_cown != nullptr)
+      {
+        auto& alloc = verona::rt::ThreadAlloc::get();
+        verona::rt::Cown::release(alloc, allocated_cown);
+      }
+    }
 
-public:
-  /// Get a handle on the underlying cown.
-  cown_ptr<T> cown() const
+    // Required as acquired_cown has to reach inside.
+    // Note only requires friend when implicit typename is T
+    // but C++ doesn't like this.
+    template<typename>
+    friend class acquired_cown;
+
+    // Note only requires friend when TT is T
+    // but C++ doesn't like this.
+    template<typename TT, typename... Args>
+    friend cown_ptr<TT> make_cown(Args&&...);
+
+    template<typename...>
+    friend class When;
+  };
+
+  /**
+   * Used to construct a new cown_ptr.
+   *
+   * Forwards arguments to construct the underlying data contained in the cown.
+   */
+  template<typename T, typename... Args>
+  cown_ptr<T> make_cown(Args&&... ts)
   {
-    return origin_cown;
-  }
-
-  T* operator->()
-  {
-    return &(origin_cown.allocated_cown->value);
-  }
-
-  T& operator*()
-  {
-    return origin_cown.allocated_cown->value;
-  }
-
-  operator T&()
-  {
-    return origin_cown.allocated_cown->value;
+    return cown_ptr<T>(
+      new typename cown_ptr<T>::ActualCown(std::forward<Args>(ts)...));
   }
 
   /**
-   * Deleted to prevent accidental copying or
-   * moving.  The lifetime is tied to the `when`,
-   * so the cown should not be put somewhere else.
-   * @{
+   * Represents a cown that has been acquired in a `when` clause.
+   *
+   * Can only be constructed by a `when`.
+   *
+   * The acquired_cown should not be persisted beyond the lifetime of the `when`
+   *
+   * Note using lower case name to match C++ std library
+   * as this is one of the exposed types.
    */
-  acquired_cown(acquired_cown&&) = delete;
-  acquired_cown& operator=(acquired_cown&&) = delete;
-  acquired_cown(const acquired_cown&) = delete;
-  acquired_cown& operator=(const acquired_cown&) = delete;
-  /// @}
-};
+  template<typename T>
+  class acquired_cown
+  {
+    /// Needed to build one from inside a `when`
+    template<typename...>
+    friend class When;
+
+  private:
+    /// Underlying cown that has been acquired.
+    /// Runtime is actually holding this reference count.
+    cown_ptr<T> origin_cown;
+
+    /// Constructor is private, as only `When` can construct one.
+    /// TODO: Consider if we can reduce the reference count here, as the
+    /// runtime is holding references too.
+    acquired_cown(const cown_ptr<T>& origin) : origin_cown(origin) {}
+
+  public:
+    /// Get a handle on the underlying cown.
+    cown_ptr<T> cown() const
+    {
+      return origin_cown;
+    }
+
+    T* operator->()
+    {
+      return &(origin_cown.allocated_cown->value);
+    }
+
+    T& operator*()
+    {
+      return origin_cown.allocated_cown->value;
+    }
+
+    operator T&()
+    {
+      return origin_cown.allocated_cown->value;
+    }
+
+    /**
+     * Deleted to prevent accidental copying or
+     * moving.  The lifetime is tied to the `when`,
+     * so the cown should not be put somewhere else.
+     * @{
+     */
+    acquired_cown(acquired_cown&&) = delete;
+    acquired_cown& operator=(acquired_cown&&) = delete;
+    acquired_cown(const acquired_cown&) = delete;
+    acquired_cown& operator=(const acquired_cown&) = delete;
+    /// @}
+  };
+} // namespace verona::rt

--- a/src/rt/cpp/when.h
+++ b/src/rt/cpp/when.h
@@ -8,111 +8,116 @@
 #include <utility>
 #include <verona.h>
 
-/**
- * Class for staging the when creation.
- *
- * Do not call directly use `when`
- *
- * This provides an operator << to apply the closure.  This allows the
- * argument order to be more sensible, as variadic arguments have to be last.
- *
- *   when (cown1, ..., cownn) << closure;
- *
- * Allows the variadic number of cowns to occur before the closure.
- */
-template<typename... Args>
-class When
+namespace verona::cpp
 {
-  // Note only requires friend when Args2 == Args
-  // but C++ doesn't like this.
-  template<typename... Args2>
-  friend When<Args2...> when(Args2... args);
+  using namespace verona::rt;
 
   /**
-   * Internally uses AcquiredCown.  The cown is only acquired after the
-   * behaviour is scheduled.
-   */
-  std::tuple<Args...> cown_tuple;
-
-  /**
-   * This uses template programming to turn the std::tuple into a C style
-   * stack allocated array.
-   * The index template parameter is used to perform each the assignment for
-   * each index.
-   */
-  template<size_t index = 0>
-  void array_assign(Cown** array)
-  {
-    if constexpr (index >= sizeof...(Args))
-    {
-      return;
-    }
-    else
-    {
-      auto p = std::get<index>(cown_tuple);
-      array[index] = p.underlying_cown();
-      assert(array[index] != nullptr);
-      array_assign<index + 1>(array);
-    }
-  }
-
-  template<typename... Ts>
-  When(Ts... args) : cown_tuple(args...)
-  {
-    static_assert(
-      std::conjunction_v<std::is_base_of<cown_ptr_base, Ts>...>,
-      "Not a cown_ptr");
-  }
-
-  /**
-   * Converts a single `cown_ptr` into a `acquired_cown`.
+   * Class for staging the when creation.
    *
-   * Needs to be a separate function for the template parameter to work.
+   * Do not call directly use `when`
+   *
+   * This provides an operator << to apply the closure.  This allows the
+   * argument order to be more sensible, as variadic arguments have to be last.
+   *
+   *   when (cown1, ..., cownn) << closure;
+   *
+   * Allows the variadic number of cowns to occur before the closure.
    */
-  template<typename C>
-  static acquired_cown<C> cown_ptr_to_acquired(cown_ptr<C> c)
+  template<typename... Args>
+  class When
   {
-    return acquired_cown<C>(c);
-  }
+    // Note only requires friend when Args2 == Args
+    // but C++ doesn't like this.
+    template<typename... Args2>
+    friend When<Args2...> when(Args2... args);
 
-public:
+    /**
+     * Internally uses AcquiredCown.  The cown is only acquired after the
+     * behaviour is scheduled.
+     */
+    std::tuple<Args...> cown_tuple;
+
+    /**
+     * This uses template programming to turn the std::tuple into a C style
+     * stack allocated array.
+     * The index template parameter is used to perform each the assignment for
+     * each index.
+     */
+    template<size_t index = 0>
+    void array_assign(Cown** array)
+    {
+      if constexpr (index >= sizeof...(Args))
+      {
+        return;
+      }
+      else
+      {
+        auto p = std::get<index>(cown_tuple);
+        array[index] = p.underlying_cown();
+        assert(array[index] != nullptr);
+        array_assign<index + 1>(array);
+      }
+    }
+
+    template<typename... Ts>
+    When(Ts... args) : cown_tuple(args...)
+    {
+      static_assert(
+        std::conjunction_v<std::is_base_of<cown_ptr_base, Ts>...>,
+        "Not a cown_ptr");
+    }
+
+    /**
+     * Converts a single `cown_ptr` into a `acquired_cown`.
+     *
+     * Needs to be a separate function for the template parameter to work.
+     */
+    template<typename C>
+    static acquired_cown<C> cown_ptr_to_acquired(cown_ptr<C> c)
+    {
+      return acquired_cown<C>(c);
+    }
+
+  public:
+    /**
+     * Applies the closure to schedule the behaviour on the set of cowns.
+     */
+    template<typename F>
+    void operator<<(F&& f)
+    {
+      if constexpr (sizeof...(Args) == 0)
+      {
+        verona::rt::schedule_lambda(std::forward<F>(f));
+      }
+      else
+      {
+        verona::rt::Cown* cowns[sizeof...(Args)];
+        array_assign(cowns);
+
+        verona::rt::schedule_lambda(
+          sizeof...(Args),
+          cowns,
+          [f = std::forward<F>(f), cown_tuple = cown_tuple]() mutable {
+            /// Effectively converts cown_ptr... to acquired_cown... .
+            auto lift_f = [f = std::forward<F>(f)](Args... args) mutable {
+              f(cown_ptr_to_acquired(args)...);
+            };
+
+            std::apply(lift_f, cown_tuple);
+          });
+      }
+    }
+  };
+
   /**
-   * Applies the closure to schedule the behaviour on the set of cowns.
+   * Implements a Verona-like `when` statement.
+   *
+   * Uses `<<` to apply the closure.
    */
-  template<typename F>
-  void operator<<(F&& f)
+  template<typename... Args>
+  When<Args...> when(Args... args)
   {
-    if constexpr (sizeof...(Args) == 0)
-    {
-      verona::rt::schedule_lambda(std::forward<F>(f));
-    }
-    else
-    {
-      verona::rt::Cown* cowns[sizeof...(Args)];
-      array_assign(cowns);
-
-      verona::rt::schedule_lambda(
-        sizeof...(Args),
-        cowns,
-        [f = std::forward<F>(f), cown_tuple = cown_tuple]() mutable {
-          /// Effectively converts cown_ptr... to acquired_cown... .
-          auto lift_f = [f = std::forward<F>(f)](Args... args) mutable {
-            f(cown_ptr_to_acquired(args)...);
-          };
-
-          std::apply(lift_f, cown_tuple);
-        });
-    }
+    return When<Args...>(args...);
   }
-};
-
-/**
- * Implements a Verona-like `when` statement.
- *
- * Uses `<<` to apply the closure.
- */
-template<typename... Args>
-When<Args...> when(Args... args)
-{
-  return When<Args...>(args...);
-}
+} // namespace verona::cpp

--- a/src/rt/test/perf/banking/verona_banks.cc
+++ b/src/rt/test/perf/banking/verona_banks.cc
@@ -7,6 +7,8 @@
 #include <memory>
 #include <test/harness.h>
 
+using namespace verona::cpp;
+
 /**
  * This file implements an example of a set of Workers
  * creating transactions.  The transactions use Accounts,

--- a/src/rt/test/perf/dining_phil/verona_dining_phil.cc
+++ b/src/rt/test/perf/dining_phil/verona_dining_phil.cc
@@ -6,6 +6,8 @@
 #include <memory>
 #include <test/harness.h>
 
+using namespace verona::cpp;
+
 struct Fork
 {
   size_t uses{0};

--- a/src/rt/test/perf/dining_phil/verona_dining_phil.cc
+++ b/src/rt/test/perf/dining_phil/verona_dining_phil.cc
@@ -19,10 +19,7 @@ struct Fork
 
   ~Fork()
   {
-    // Contains the uses == 0 case, due to copies during
-    // setup needing to be destroyed.
-    // Should look to make example copy free.
-    check(((HUNGER * 2) == uses) || (uses == 0));
+    check((HUNGER * 2) == uses);
   }
 };
 


### PR DESCRIPTION
This introduces a namespace for the verona C++ api:
  verona::cpp

It also fixes a couple of move/copy constructor/operators.