### PR TITLE
Fix cown freeing policy

### DIFF
--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -41,6 +41,7 @@ namespace verona::rt
     template<typename Owner>
     friend class Noticeboard;
 
+    static constexpr uint64_t FREE_COWNS_THRESHOLD = 100;
     static constexpr uint64_t TSC_QUIESCENCE_TIMEOUT = 1'000'000;
 
     T* token_cown = nullptr;
@@ -162,7 +163,7 @@ namespace verona::rt
       while (true)
       {
         if (
-          (total_cowns < (free_cowns << 1))
+          (free_cowns > FREE_COWNS_THRESHOLD)
 #ifdef USE_SYSTEMATIC_TESTING
           || Systematic::coin()
 #endif


### PR DESCRIPTION
Currently the scheduler thread collects cown stubs (frees them) whenever
the number of freed but uncollected cowns reaches the total number of
ever allocated cowns divided by two. As total_cowns is strictly
increasing, the system can reach a point where total_cowns is so big
that cowns don't get freed before the system falls out of memory.

This commit introduces a fixed threshold of freed but uncollected cowns,
`FREE_COWNS_THRESHOLD`, with a default of 100, after which these cowns
are systematically collected. The value of 100 is arbitrary and has been
validated in a performance setting and did not result in any negative
performance difference compared to the previous setting.

Signed-off-by: Hugo Lefeuvre <t-hlefeuvre@microsoft.com>