### PR TITLE
Optimise the RC for cown_ptr

### DIFF
--- a/src/rt/cpp/cown.h
+++ b/src/rt/cpp/cown.h
@@ -212,7 +212,7 @@ namespace verona::cpp
     ActualCown<T>& origin_cown;
 
     /// Constructor is private, as only `When` can construct one.
-    acquired_cown(ActualCown<T>* origin) : origin_cown(*origin) {}
+    acquired_cown(ActualCown<T>& origin) : origin_cown(origin) {}
 
   public:
     /// Get a handle on the underlying cown.

--- a/src/rt/cpp/cown.h
+++ b/src/rt/cpp/cown.h
@@ -35,7 +35,10 @@ namespace verona::cpp
   class cown_ptr;
 
   /**
-   * Internal Verona runtime cown for this type.
+   * Internal Verona runtime cown for the type T.
+   *
+   * This class is used to prevent access to the representation except
+   * through the correct usage of cown_ptr and when.
    */
   template<typename T>
   class ActualCown : public VCown<ActualCown<T>>
@@ -206,32 +209,32 @@ namespace verona::cpp
   private:
     /// Underlying cown that has been acquired.
     /// Runtime is actually holding this reference count.
-    ActualCown<T>* origin_cown;
+    ActualCown<T>& origin_cown;
 
     /// Constructor is private, as only `When` can construct one.
-    acquired_cown(ActualCown<T>* origin) : origin_cown(origin) {}
+    acquired_cown(ActualCown<T>* origin) : origin_cown(*origin) {}
 
   public:
     /// Get a handle on the underlying cown.
     cown_ptr<T> cown() const
     {
-      verona::rt::Cown::acquire(origin_cown);
-      return cown_ptr<T>(origin_cown);
+      verona::rt::Cown::acquire(&origin_cown);
+      return cown_ptr<T>(&origin_cown);
     }
 
     T* operator->()
     {
-      return &(origin_cown->value);
+      return &(origin_cown.value);
     }
 
     T& operator*()
     {
-      return origin_cown->value;
+      return origin_cown.value;
     }
 
     operator T&()
     {
-      return origin_cown->value;
+      return origin_cown.value;
     }
 
     /**

--- a/src/rt/cpp/cown.h
+++ b/src/rt/cpp/cown.h
@@ -31,9 +31,6 @@ namespace verona::cpp
     friend class cown_ptr;
   };
 
-  template<typename... Args>
-  class When;
-
   template<typename T>
   class cown_ptr;
 

--- a/src/rt/cpp/cown.h
+++ b/src/rt/cpp/cown.h
@@ -195,33 +195,34 @@ namespace verona::cpp
   private:
     /// Underlying cown that has been acquired.
     /// Runtime is actually holding this reference count.
-    cown_ptr<T> origin_cown;
+    typename cown_ptr<T>::ActualCown* origin_cown;
 
     /// Constructor is private, as only `When` can construct one.
-    /// TODO: Consider if we can reduce the reference count here, as the
-    /// runtime is holding references too.
-    acquired_cown(const cown_ptr<T>& origin) : origin_cown(origin) {}
+    acquired_cown(typename cown_ptr<T>::ActualCown* origin)
+    : origin_cown(origin)
+    {}
 
   public:
     /// Get a handle on the underlying cown.
     cown_ptr<T> cown() const
     {
-      return origin_cown;
+      verona::rt::Cown::acquire(origin_cown);
+      return cown_ptr<T>(origin_cown);
     }
 
     T* operator->()
     {
-      return &(origin_cown.allocated_cown->value);
+      return &(origin_cown->value);
     }
 
     T& operator*()
     {
-      return origin_cown.allocated_cown->value;
+      return origin_cown->value;
     }
 
     operator T&()
     {
-      return origin_cown.allocated_cown->value;
+      return origin_cown->value;
     }
 
     /**

--- a/src/rt/cpp/cown.h
+++ b/src/rt/cpp/cown.h
@@ -31,6 +31,9 @@ namespace verona::cpp
     friend class cown_ptr;
   };
 
+  template<typename... Args>
+  class When;
+
   /**
    * Smart pointer to represent shared access to a cown.
    * Can only be used asychronously with `when` to get
@@ -43,6 +46,13 @@ namespace verona::cpp
   class cown_ptr : cown_ptr_base
   {
   private:
+
+
+    // Note only requires friend when Args2 == Args
+    // but C++ doesn't like this.
+    template<typename... Args2>
+    friend When<Args2...> when(cown_ptr<Args2>&... args);
+
     /**
      * Internal Verona runtime cown for this type.
      */

--- a/src/rt/cpp/when.h
+++ b/src/rt/cpp/when.h
@@ -112,7 +112,7 @@ namespace verona::cpp
    * Template deduction guide for when.
    */
   template<typename... Args>
-  When(ActualCown<Args>*...)->When<Args...>; 
+  When(ActualCown<Args>*...)->When<Args...>;
 
   /**
    * Implements a Verona-like `when` statement.

--- a/src/rt/cpp/when.h
+++ b/src/rt/cpp/when.h
@@ -71,7 +71,8 @@ namespace verona::cpp
     template<typename C>
     static acquired_cown<C> actual_cown_to_acquired(ActualCown<C>* c)
     {
-      return acquired_cown<C>(c);
+      assert(c != nullptr);
+      return acquired_cown<C>(*c);
     }
 
   public:
@@ -122,9 +123,7 @@ namespace verona::cpp
    *   ((cown_ptr<A1>& | cown_ptr<A1>&&)...
    * To get the universal reference type to work, we can't
    * place this constraint on it directly, as it needs to be
-   * on a type argument.  This also requires an additional
-   * step with `mk_when` to actually infer the generics correctly
-   * as we can't apply the tight constraint.
+   * on a type argument.
    */
   template<typename... Args>
   auto when(Args&&... args)

--- a/src/rt/cpp/when.h
+++ b/src/rt/cpp/when.h
@@ -111,7 +111,7 @@ namespace verona::cpp
    * Template deduction guide for when.
    */
   template<typename... Args>
-  When(ActualCown<Args>*...) -> When<Args...>; 
+  When(ActualCown<Args>*...)->When<Args...>; 
 
   /**
    * Implements a Verona-like `when` statement.

--- a/src/rt/cpp/when.h
+++ b/src/rt/cpp/when.h
@@ -31,7 +31,7 @@ namespace verona::cpp
     // Note only requires friend when Args2 == Args
     // but C++ doesn't like this.
     template<typename... Args2>
-    friend When<Args2...> mk_when(ActualCown<Args2>*... args);
+    friend auto when(Args2&&... args);
 
     /**
      * Internally uses AcquiredCown.  The cown is only acquired after the
@@ -108,13 +108,10 @@ namespace verona::cpp
   };
 
   /**
-   * Internal: required for template inference.
+   * Template deduction guide for when.
    */
   template<typename... Args>
-  When<Args...> mk_when(ActualCown<Args>*... args)
-  {
-    return When<Args...>(args...);
-  }
+  When(ActualCown<Args>*...) -> When<Args...>; 
 
   /**
    * Implements a Verona-like `when` statement.
@@ -132,6 +129,6 @@ namespace verona::cpp
   template<typename... Args>
   auto when(Args&&... args)
   {
-    return mk_when(args.allocated_cown...);
+    return When(args.allocated_cown...);
   }
 } // namespace verona::cpp

--- a/src/rt/cpp/when.h
+++ b/src/rt/cpp/when.h
@@ -122,7 +122,7 @@ namespace verona::cpp
    * Uses `<<` to apply the closure.
    *
    * This should really take a type of
-   *   ((ActualCown<A1>& | ActualCown<A1>&&)...
+   *   ((cown_ptr<A1>& | cown_ptr<A1>&&)...
    * To get the universal reference type to work, we can't
    * place this constraint on it directly, as it needs to be
    * on a type argument.  This also requires an additional

--- a/src/rt/cpp/when.h
+++ b/src/rt/cpp/when.h
@@ -54,7 +54,7 @@ namespace verona::cpp
       }
       else
       {
-        auto& p = std::get<index>(cown_tuple);
+        auto p = std::get<index>(cown_tuple);
         array[index] = p;
         assert(array[index] != nullptr);
         array_assign<index + 1>(array);
@@ -97,8 +97,7 @@ namespace verona::cpp
           sizeof...(Args),
           cowns,
           [f = std::forward<F>(f),
-           cown_tuple = std::tuple<typename cown_ptr<Args>::ActualCown*...>(
-             cown_tuple)]() mutable {
+           cown_tuple = cown_tuple]() mutable {
             /// Effectively converts cown_ptr<T>::ActualCown... to
             /// acquired_cown... .
             auto lift_f =

--- a/src/rt/cpp/when.h
+++ b/src/rt/cpp/when.h
@@ -98,7 +98,7 @@ namespace verona::cpp
             /// acquired_cown... .
             auto lift_f =
               [f = std::forward<F>(f)](ActualCown<Args>*... args) mutable {
-                f(cown_ptr_actual_cown_to_acquired<Args>(args)...);
+                f(actual_cown_to_acquired<Args>(args)...);
               };
 
             std::apply(lift_f, cown_tuple);

--- a/src/rt/cpp/when.h
+++ b/src/rt/cpp/when.h
@@ -69,7 +69,7 @@ namespace verona::cpp
      * Needs to be a separate function for the template parameter to work.
      */
     template<typename C>
-    static acquired_cown<C> cown_ptr_actual_cown_to_acquired(ActualCown<C>* c)
+    static acquired_cown<C> actual_cown_to_acquired(ActualCown<C>* c)
     {
       return acquired_cown<C>(c);
     }

--- a/src/rt/cpp/when.h
+++ b/src/rt/cpp/when.h
@@ -61,12 +61,8 @@ namespace verona::cpp
       }
     }
 
-    template<typename... Ts>
-    When(Ts&... args) : cown_tuple(args.underlying_cown()...)
+    When(typename cown_ptr<Args>::ActualCown*... args) : cown_tuple(args...)
     {
-      static_assert(
-        std::conjunction_v<std::is_base_of<cown_ptr_base, Ts>...>,
-        "Not a cown_ptr");
     }
 
     /**
@@ -125,6 +121,6 @@ namespace verona::cpp
   template<typename... Args>
   When<Args...> when(cown_ptr<Args>&... args)
   {
-    return When<Args...>(args...);
+    return When<Args...>(args.allocated_cown...);
   }
 } // namespace verona::cpp

--- a/src/rt/test/perf/banking/verona_banks.cc
+++ b/src/rt/test/perf/banking/verona_banks.cc
@@ -100,7 +100,8 @@ void bank_job(
   {
     // Reschedule bank_job
     // bank_job(worker, l, repeats - 1);
-    when(worker.cown()) <<
+    auto w = worker.cown();
+    when(w) <<
       [=](acquired_cown<Worker> worker) { bank_job(worker, l, repeats - 1); };
   }
 }
@@ -125,7 +126,8 @@ void test_body()
   for (size_t j = 0; j < NUM_WORKERS; j++)
   {
     Logging::cout() << "Worker " << j << Logging::endl;
-    when(make_cown<Worker>(accounts, j + 1)) << [=](acquired_cown<Worker> w) {
+    auto w = make_cown<Worker>(accounts, j + 1); 
+    when(w) << [=](acquired_cown<Worker> w) {
       bank_job(w, log, TRANSACTIONS / NUM_WORKERS);
     };
   }

--- a/src/rt/test/perf/banking/verona_banks.cc
+++ b/src/rt/test/perf/banking/verona_banks.cc
@@ -100,8 +100,7 @@ void bank_job(
   {
     // Reschedule bank_job
     // bank_job(worker, l, repeats - 1);
-    auto w = worker.cown();
-    when(w) <<
+    when(worker.cown()) <<
       [=](acquired_cown<Worker> worker) { bank_job(worker, l, repeats - 1); };
   }
 }
@@ -126,8 +125,7 @@ void test_body()
   for (size_t j = 0; j < NUM_WORKERS; j++)
   {
     Logging::cout() << "Worker " << j << Logging::endl;
-    auto w = make_cown<Worker>(accounts, j + 1); 
-    when(w) << [=](acquired_cown<Worker> w) {
+    when(make_cown<Worker>(accounts, j + 1)) << [=](acquired_cown<Worker> w) {
       bank_job(w, log, TRANSACTIONS / NUM_WORKERS);
     };
   }


### PR DESCRIPTION
The previous implementation required a lot of copies of `cown_ptr` that resulted in potentially poor performance.  This implementation does not suffer from that problem as it uses a "univeral reference" for each cown to enable passing without causing decref and increfs.