### PR TITLE
Consolidate allocation of message body

### DIFF
--- a/src/rt/cpp/lambdabehaviour.h
+++ b/src/rt/cpp/lambdabehaviour.h
@@ -17,6 +17,7 @@ namespace verona::rt
   class LambdaBehaviour : public Behaviour
   {
     friend class Cown;
+    friend class MultiMessage;
 
   private:
     T fn;

--- a/src/rt/cpp/vbehaviour.h
+++ b/src/rt/cpp/vbehaviour.h
@@ -25,6 +25,7 @@ namespace verona::rt
   class VBehaviour : public Behaviour
   {
     friend class Cown;
+    friend class MultiMessage;
 
   private:
     static void gc_trace(const Behaviour* msg, ObjectStack& st)

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -656,8 +656,6 @@ namespace verona::rt
       Logging::cout() << "MultiMessage " << m << " completed and running on "
                       << this << Logging::endl;
 
-      alloc.dealloc(m->get_body());
-
       return true;
     }
 
@@ -843,6 +841,8 @@ namespace verona::rt
           if ((senders[s]) && (senders[s] != this))
             senders[s]->schedule();
         }
+
+        alloc.dealloc(body);
 
       } while ((curr != until) && (batch_size < batch_limit));
 

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -25,8 +25,6 @@ namespace verona::rt
     Systematic::yield();
   }
 
-  static Behaviour unmute_behaviour{Behaviour::Descriptor::empty()};
-
   struct EnqueueLock
   {
     std::atomic<bool> locked = false;
@@ -1020,19 +1018,6 @@ namespace verona::rt
     static MultiMessage* stub_msg(Alloc& alloc)
     {
       return MultiMessage::make_message(alloc, nullptr, EpochMark::EPOCH_NONE);
-    }
-
-    /**
-     * Create an unmute message using an empty behaviour. The given array of
-     * cowns may be null terminated, but the count must always be count of
-     * pointers that indicates the size of the allocation.
-     */
-    static MultiMessage*
-    unmute_msg(Alloc& alloc, size_t count, Cown** cowns, EpochMark epoch)
-    {
-      auto* body =
-        MultiMessage::make_body(alloc, count, cowns, &unmute_behaviour);
-      return MultiMessage::make_message(alloc, body, epoch);
     }
   };
 

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -632,7 +632,7 @@ namespace verona::rt
 
           // Scan closure
           ObjectStack f(alloc);
-          body.get_behaviour()->trace(f);
+          body.get_behaviour().trace(f);
           scan_stack(alloc, Scheduler::local()->send_epoch, f);
         }
         else
@@ -645,7 +645,7 @@ namespace verona::rt
       Scheduler::local()->message_body = &body;
 
       // Run the behaviour.
-      body.get_behaviour()->f();
+      body.get_behaviour().f();
 
       for (size_t i = 0; i < body.count; i++)
       {
@@ -691,10 +691,8 @@ namespace verona::rt
 
       auto& alloc = ThreadAlloc::get();
 
-      auto body = MultiMessage::Body::make(alloc, count, sizeof(Be));
-
-      // Initialised the behaviour.
-      new ((Be*)body->get_behaviour()) Be(std::forward<Args>(args)...);
+      auto body =
+        MultiMessage::Body::make<Be>(alloc, count, std::forward<Args>(args)...);
 
       auto** sort = body->get_cowns_array();
       memcpy(sort, cowns, count * sizeof(Cown*));

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -490,7 +490,6 @@ namespace verona::rt
     {
       auto& alloc = ThreadAlloc::get();
       const auto last = body->count - 1;
-      assert(body->index <= last);
 
       // First acquire all the locks if a multimessage
       if (body->count > 1)
@@ -588,9 +587,8 @@ namespace verona::rt
 
       EpochMark e = m->get_epoch();
 
-      Logging::cout() << "MultiMessage " << m << " index " << body.index
-                      << " acquired " << this << " epoch " << e
-                      << Logging::endl;
+      Logging::cout() << "MultiMessage " << m << " acquired " << this
+                      << " epoch " << e << Logging::endl;
 
       // If we are in should_scan, and we observe a message in this epoch,
       // then all future messages must have been sent while in pre-scan or

--- a/src/rt/sched/multimessage.h
+++ b/src/rt/sched/multimessage.h
@@ -60,8 +60,10 @@ namespace verona::rt
         auto body = new (alloc.alloc(size)) Body(count);
         new ((Be*)&(body->get_behaviour())) Be(std::forward<Args>(args)...);
 
-        static_assert(alignof(Be) <= sizeof(void*), "Alignment not supported, yet!");
-        static_assert(sizeof(Body) % alignof(Be) == 0, "Alignment not supported, yet!");
+        static_assert(
+          alignof(Be) <= sizeof(void*), "Alignment not supported, yet!");
+        static_assert(
+          sizeof(Body) % alignof(Be) == 0, "Alignment not supported, yet!");
 
         return body;
       }

--- a/src/rt/sched/multimessage.h
+++ b/src/rt/sched/multimessage.h
@@ -48,9 +48,10 @@ namespace verona::rt
 
       /**
        * Allocates a message body with sufficient space for the
-       * cowns_array and the behaviour.  This does not initialise the cowns array.
+       * cowns_array and the behaviour.  This does not initialise the cowns
+       * array.
        */
-      template <typename Be, typename... Args>
+      template<typename Be, typename... Args>
       static Body* make(Alloc& alloc, size_t count, Args... args)
       {
         size_t size = sizeof(Body) + (sizeof(Cown*) * count) + sizeof(Be);
@@ -58,6 +59,9 @@ namespace verona::rt
         // Create behaviour
         auto body = new (alloc.alloc(size)) Body(count);
         new ((Be*)&(body->get_behaviour())) Be(std::forward<Args>(args)...);
+
+        static_assert(alignof(Be) <= sizeof(void*), "Alignment not supported, yet!");
+        static_assert(sizeof(Body) % alignof(Be) == 0, "Alignment not supported, yet!");
 
         return body;
       }

--- a/src/rt/sched/multimessage.h
+++ b/src/rt/sched/multimessage.h
@@ -16,7 +16,6 @@ namespace verona::rt
   {
     struct MultiMessageBody
     {
-      size_t index;
       size_t count;
       Cown** cowns;
       std::atomic<size_t> exec_count_down;
@@ -72,7 +71,7 @@ namespace verona::rt
     make_body(Alloc& alloc, size_t count, Cown** cowns, Behaviour* behaviour)
     {
       return new (alloc.alloc<sizeof(MultiMessageBody)>())
-        MultiMessageBody{0, count, cowns, count, behaviour};
+        MultiMessageBody{count, cowns, count, behaviour};
     }
 
     static MultiMessage*


### PR DESCRIPTION
Prior to this commit the multimessage was composed of three allocations, the body, the cowns array and the behaviour/closure to execute.  This PR merges the three structures into a single more complex allocation. On @theodus's perf-con-ubench, we see an 18% improvement in message flow.  

It also includes two small code tidies.

