### PR TITLE
Decoupling SchedulerThreads & Cown queues

### DIFF
--- a/src/rt/ds/dllist.h
+++ b/src/rt/ds/dllist.h
@@ -1,0 +1,197 @@
+#pragma once
+
+#include <cassert>
+#include <type_traits>
+
+// Inspired by the snmalloc implementation of a double linked list.
+namespace verona::rt
+{
+  template<
+    class T,
+    class Terminator = std::nullptr_t,
+    bool delete_on_clear = false>
+  class DLList final
+  {
+  private:
+    static_assert(
+      std::is_same<decltype(T::prev), T*>::value, "T->prev must be a T*");
+    static_assert(
+      std::is_same<decltype(T::next), T*>::value, "T->next must be a T*");
+
+    T* head = Terminator();
+    T* tail = Terminator();
+
+  public:
+    ~DLList()
+    {
+      clear();
+    }
+
+    DLList() = default;
+
+    DLList(DLList&& o) noexcept
+    {
+      head = o.head;
+      tail = o.tail;
+
+      o.head = nullptr;
+      o.tail = nullptr;
+    }
+
+    DLList& operator=(DLList&& o) noexcept
+    {
+      head = o.head;
+      tail = o.tail;
+
+      o.head = nullptr;
+      o.tail = nullptr;
+      return *this;
+    }
+
+    bool is_empty()
+    {
+      return head == Terminator();
+    }
+
+    T* get_head()
+    {
+      return head;
+    }
+
+    T* get_tail()
+    {
+      return tail;
+    }
+
+    T* pop()
+    {
+      T* item = head;
+      if (item != Terminator())
+        remove(item);
+
+      return item;
+    }
+
+    T* pop_tail()
+    {
+      T* item = tail;
+      if (item != Terminator())
+        remove(item);
+      return item;
+    }
+
+    void insert(T* item)
+    {
+#ifndef NDEBUG
+      debug_check_not_contains(item);
+#endif
+      item->next = head;
+      item->prev = Terminator();
+      if (head != Terminator())
+        head->prev = item;
+      else
+        tail = item;
+      head = item;
+#ifndef NDEBUG
+      debug_check();
+#endif
+    }
+
+    void insert_back(T* item)
+    {
+#ifndef NDEBUG
+      debug_check_not_contains(item);
+#endif
+      item->prev = tail;
+      item->next = Terminator();
+
+      if (tail != Terminator())
+        tail->next = item;
+      else
+        head = item;
+      tail = item;
+#ifndef NDEBUG
+      debug_check();
+#endif
+    }
+
+    void remove(T* item)
+    {
+#ifndef NDEBUG
+      debug_check_contains(item);
+#endif
+      if (item->next != Terminator())
+        item->next->prev = item->prev;
+      else
+        tail = item->prev;
+
+      if (item->prev != Terminator())
+        item->prev->next = item->next;
+      else
+        head = item->next;
+#ifndef NDEBUG
+      debug_check();
+#endif
+    }
+    
+    void clear()
+    {
+      while (head != nullptr)
+      {
+        auto c = head;
+        remove(c);
+        if (delete_on_clear)
+        {
+          delete c;
+        }
+      }
+    }
+
+    void debug_check_contains(T* item)
+    {
+#ifndef NDEBUG
+      debug_check();
+      T* curr = head;
+
+      while (curr != item)
+      {
+        assert(curr != Terminator());
+        curr = curr->next;
+      }
+#else
+      UNUSED(item);
+#endif
+    }
+
+    void debug_check_not_contains(T* item)
+    {
+#ifndef NDEBUG
+      debug_check();
+      T* curr = head;
+
+      while (curr != Terminator())
+      {
+        assert(curr != item);
+        curr = curr->next;
+      }
+#else
+      UNUSED(item);
+#endif
+    }
+
+    void debug_check()
+    {
+#ifndef NDEBUG
+      T* item = head;
+      T* prev = Terminator();
+
+      while (item != Terminator())
+      {
+        assert(item->prev == prev);
+        prev = item;
+        item = item->next;
+      }
+#endif
+    }
+  };
+} // namespace verona::rt

--- a/src/rt/ds/dllist.h
+++ b/src/rt/ds/dllist.h
@@ -1,3 +1,5 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include <cassert>

--- a/src/rt/ds/dllist.h
+++ b/src/rt/ds/dllist.h
@@ -29,7 +29,7 @@ namespace verona::rt
       clear();
     }
 
-    DLList() = default;
+    constexpr DLList() = default;
 
     DLList(DLList&& o) noexcept
     {

--- a/src/rt/ds/dllist.h
+++ b/src/rt/ds/dllist.h
@@ -133,7 +133,7 @@ namespace verona::rt
       debug_check();
 #endif
     }
-    
+
     void clear()
     {
       while (head != nullptr)

--- a/src/rt/pal/threadpoolbuilder.h
+++ b/src/rt/pal/threadpoolbuilder.h
@@ -13,7 +13,6 @@ namespace verona::rt
 {
   class ThreadPoolBuilder
   {
-    inline static Singleton<Topology, &Topology::init> topology;
     std::list<PlatformThread> threads;
     size_t thread_count;
     size_t index = 0;
@@ -50,18 +49,25 @@ namespace verona::rt
      * Add a thread to run in this thread pool.
      */
     template<typename... Args>
-    void add_thread(void (*body)(Args...), Args... args)
+    void add_thread(size_t affinity, void (*body)(Args...), Args... args)
     {
 #ifdef USE_SYSTEMATIC_TESTING
       // Don't use affinity with systematic testing.  We're only ever running
       // one thread at a time in systematic testing mode and by pinning each
       // thread to a core we massively increase contention.
+      UNUSED(affinity);
       add_thread_impl(body, args...);
 #else
       add_thread_impl(
-        &run_with_affinity, topology.get().get(index), body, args...);
+        &run_with_affinity, affinity, body, args...);
 #endif
       index++;
+    }
+
+    template<typename... Args>
+    void add_extra_thread(void (*body)(Args...), Args... args)
+    {
+      threads.emplace_back(body, args...);
     }
 
     /**
@@ -74,7 +80,7 @@ namespace verona::rt
     ~ThreadPoolBuilder()
     {
       assert(index == thread_count + 1);
-
+      
       while (!threads.empty())
       {
         auto& thread = threads.front();

--- a/src/rt/pal/threadpoolbuilder.h
+++ b/src/rt/pal/threadpoolbuilder.h
@@ -58,8 +58,7 @@ namespace verona::rt
       UNUSED(affinity);
       add_thread_impl(body, args...);
 #else
-      add_thread_impl(
-        &run_with_affinity, affinity, body, args...);
+      add_thread_impl(&run_with_affinity, affinity, body, args...);
 #endif
       index++;
     }
@@ -80,7 +79,7 @@ namespace verona::rt
     ~ThreadPoolBuilder()
     {
       assert(index == thread_count + 1);
-      
+
       while (!threads.empty())
       {
         auto& thread = threads.front();

--- a/src/rt/pal/threadpoolbuilder.h
+++ b/src/rt/pal/threadpoolbuilder.h
@@ -20,7 +20,7 @@ namespace verona::rt
     template<typename... Args>
     void add_thread_impl(void (*body)(Args...), Args... args)
     {
-      if (index < thread_count)
+      if (index != thread_count)
       {
         threads.emplace_back(body, args...);
       }
@@ -61,12 +61,6 @@ namespace verona::rt
       add_thread_impl(&run_with_affinity, affinity, body, args...);
 #endif
       index++;
-    }
-
-    template<typename... Args>
-    void add_extra_thread(void (*body)(Args...), Args... args)
-    {
-      threads.emplace_back(body, args...);
     }
 
     /**

--- a/src/rt/sched/base_noticeboard.h
+++ b/src/rt/sched/base_noticeboard.h
@@ -14,7 +14,7 @@ namespace verona::rt
 {
   class Cown;
   using CownThread = SchedulerThread<Cown>;
-  using Scheduler = ThreadPool<CownThread>;
+  using Scheduler = ThreadPool<CownThread, Cown>;
 
   class BaseNoticeboard
   {

--- a/src/rt/sched/core.h
+++ b/src/rt/sched/core.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <atomic>
+
+#include "mpmcq.h"
+#include "schedulerstats.h"
+
+namespace verona::rt
+{
+  template<class T>
+    class Core
+    {
+      public:
+        size_t affinity = 0;
+        T* token_cown = nullptr;
+        MPMCQ<T> q;
+        std::atomic<Core<T>*> next = nullptr;
+
+        /// Progress and synchronization between the threads.
+        //  These counters represent progress on a CPU core, not necessarily on
+        //  the core's queue. This is necessary to take into account core-stealing
+        //  to avoid spawning many threads on a core hogged by a long running
+        //  behaviour but with an empty cown queue.
+        std::atomic<std::size_t> progress_counter = 0;
+        std::atomic<std::size_t> servicing_threads = 0;
+        std::atomic<std::size_t> last_worker = 0;
+
+        
+				// The number of cowns in the per-thread list `list`.
+				std::atomic<size_t> total_cowns = 0;
+
+				// The number of cowns that have been collected in the per-thread list
+				// `list`. This is atomic as other threads can collect the body of the
+				// cown managed from this thread.  They cannot collect the actual cown
+				// allocation.  The ratio of free_cowns to total_cowns is used to
+				// determine when to walk the `list` to collect the stubs.
+				std::atomic<size_t> free_cowns = 0;
+						SchedulerStats stats;
+
+
+      public:
+        Core() : token_cown{T::create_token_cown()}, q{token_cown}
+        {
+          // Let the thread set the owning core.
+        }
+
+        ~Core() {}
+    };
+}

--- a/src/rt/sched/core.h
+++ b/src/rt/sched/core.h
@@ -36,6 +36,7 @@ namespace verona::rt
     // allocation.  The ratio of free_cowns to total_cowns is used to
     // determine when to walk the `list` to collect the stubs.
     std::atomic<size_t> free_cowns = 0;
+
     SchedulerStats stats;
 
   public:

--- a/src/rt/sched/core.h
+++ b/src/rt/sched/core.h
@@ -28,7 +28,7 @@ namespace verona::rt
     std::atomic<std::size_t> servicing_threads = 0;
     std::atomic<std::size_t> last_worker = 0;
 
-    // The number of cowns in the per-thread list `list`.
+    // The number of cowns in the per-core list `list`.
     std::atomic<size_t> total_cowns = 0;
 
     // The number of cowns that have been collected in the per-thread list

--- a/src/rt/sched/core.h
+++ b/src/rt/sched/core.h
@@ -1,49 +1,47 @@
 #pragma once
 
-#include <atomic>
-
 #include "mpmcq.h"
 #include "schedulerstats.h"
+
+#include <atomic>
 
 namespace verona::rt
 {
   template<class T>
-    class Core
+  class Core
+  {
+  public:
+    size_t affinity = 0;
+    T* token_cown = nullptr;
+    MPMCQ<T> q;
+    std::atomic<Core<T>*> next = nullptr;
+
+    /// Progress and synchronization between the threads.
+    //  These counters represent progress on a CPU core, not necessarily on
+    //  the core's queue. This is necessary to take into account core-stealing
+    //  to avoid spawning many threads on a core hogged by a long running
+    //  behaviour but with an empty cown queue.
+    std::atomic<std::size_t> progress_counter = 0;
+    std::atomic<std::size_t> servicing_threads = 0;
+    std::atomic<std::size_t> last_worker = 0;
+
+    // The number of cowns in the per-thread list `list`.
+    std::atomic<size_t> total_cowns = 0;
+
+    // The number of cowns that have been collected in the per-thread list
+    // `list`. This is atomic as other threads can collect the body of the
+    // cown managed from this thread.  They cannot collect the actual cown
+    // allocation.  The ratio of free_cowns to total_cowns is used to
+    // determine when to walk the `list` to collect the stubs.
+    std::atomic<size_t> free_cowns = 0;
+    SchedulerStats stats;
+
+  public:
+    Core() : token_cown{T::create_token_cown()}, q{token_cown}
     {
-      public:
-        size_t affinity = 0;
-        T* token_cown = nullptr;
-        MPMCQ<T> q;
-        std::atomic<Core<T>*> next = nullptr;
+      // Let the thread set the owning core.
+    }
 
-        /// Progress and synchronization between the threads.
-        //  These counters represent progress on a CPU core, not necessarily on
-        //  the core's queue. This is necessary to take into account core-stealing
-        //  to avoid spawning many threads on a core hogged by a long running
-        //  behaviour but with an empty cown queue.
-        std::atomic<std::size_t> progress_counter = 0;
-        std::atomic<std::size_t> servicing_threads = 0;
-        std::atomic<std::size_t> last_worker = 0;
-
-        
-				// The number of cowns in the per-thread list `list`.
-				std::atomic<size_t> total_cowns = 0;
-
-				// The number of cowns that have been collected in the per-thread list
-				// `list`. This is atomic as other threads can collect the body of the
-				// cown managed from this thread.  They cannot collect the actual cown
-				// allocation.  The ratio of free_cowns to total_cowns is used to
-				// determine when to walk the `list` to collect the stubs.
-				std::atomic<size_t> free_cowns = 0;
-						SchedulerStats stats;
-
-
-      public:
-        Core() : token_cown{T::create_token_cown()}, q{token_cown}
-        {
-          // Let the thread set the owning core.
-        }
-
-        ~Core() {}
-    };
+    ~Core() {}
+  };
 }

--- a/src/rt/sched/core.h
+++ b/src/rt/sched/core.h
@@ -1,3 +1,5 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "mpmcq.h"

--- a/src/rt/sched/core.h
+++ b/src/rt/sched/core.h
@@ -39,7 +39,7 @@ namespace verona::rt
   public:
     Core() : token_cown{T::create_token_cown()}, q{token_cown}
     {
-      // Let the thread set the owning core.
+      token_cown->set_owning_core(this);
     }
 
     ~Core() {}

--- a/src/rt/sched/core.h
+++ b/src/rt/sched/core.h
@@ -6,6 +6,7 @@
 #include "schedulerstats.h"
 
 #include <atomic>
+#include <snmalloc/snmalloc.h>
 
 namespace verona::rt
 {
@@ -39,6 +40,8 @@ namespace verona::rt
 
     SchedulerStats stats;
 
+    std::atomic<T*> list = nullptr;
+
   public:
     Core() : token_cown{T::create_token_cown()}, q{token_cown}
     {
@@ -46,5 +49,86 @@ namespace verona::rt
     }
 
     ~Core() {}
+
+    void collect(Alloc& alloc)
+    {
+      T* head = list.exchange(nullptr);
+      T* tail = head;
+      T* cown = head;
+      while (cown != nullptr)
+      {
+        if (!cown->is_collected())
+          cown->collect(alloc);
+        tail = cown;
+        cown = cown->next;
+      }
+      if (tail != nullptr)
+        add_cowns(head, tail);
+    }
+
+    void try_collect(Alloc& alloc, EpochMark epoch)
+    {
+      T* head = list.exchange(nullptr);
+      T* tail = head;
+      T* cown = head;
+      while (cown != nullptr)
+      {
+        T* n = cown->next;
+        cown->try_collect(alloc, epoch);
+        tail = cown;
+        cown = n;
+      }
+      if (tail != nullptr)
+        add_cowns(head, tail);
+    }
+
+    void scan()
+    {
+      T* head = list.exchange(nullptr);
+      T* tail = head;
+      T* p = head;
+      while (p != nullptr)
+      {
+        if (p->can_lifo_schedule())
+          p->reschedule();
+        tail = p;
+        p = p->next;
+      }
+      if (tail != nullptr)
+        add_cowns(head, tail);
+    }
+
+    /**
+     * Atomically add a single cown to the list.
+     */
+    void add_cown(T* cown)
+    {
+      cown->next = list;
+      while (!list.compare_exchange_weak(cown->next, cown))
+      {
+        cown->next = list;
+      }
+    }
+
+    /*
+     * Atomically add an entire list to the core list.
+     * l*/
+    void add_cowns(T* head, T* tail)
+    {
+      assert(head != nullptr && tail != nullptr);
+      tail->next = list;
+      while (!list.compare_exchange_weak(tail->next, head))
+      {
+        tail->next = list;
+      }
+    }
+
+    /*
+     * Take ownership of the entire content of the list.
+     * */
+    T* drain()
+    {
+      return list.exchange(nullptr);
+    }
   };
 }

--- a/src/rt/sched/corepool.h
+++ b/src/rt/sched/corepool.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "core.h"
+#include "pal/threading.h"
+
+#ifdef USE_SYSTEM_MONITOR
+#include "sysmonitor.h"
+#endif
+
+#include <vector>
+
+namespace verona::rt
+{
+  template<class P, class T>
+  class CorePool
+  {
+    private:
+      friend P;
+
+#ifdef USE_SYSTEM_MONITOR
+      friend SysMonitor<P>;
+#endif
+
+      inline static Singleton<Topology, &Topology::init> topology;
+      Core<T>* first_core = nullptr;
+      size_t core_count = 0;
+      std::vector<Core<T>*> cores;
+    
+    public:
+      CorePool(size_t count) : core_count{count}
+      {
+        first_core = new Core<T>;
+        Core<T>* t = first_core;
+        cores.emplace_back(t);
+       
+        while (true)
+        {
+          t->affinity = topology.get().get(count);
+          if (count > 1) 
+          {
+            t->next = new Core<T>;
+            t = t->next;
+            count--;
+            cores.emplace_back(t);
+          }
+          else
+          {
+            t->next = first_core;
+            break;
+          }
+        }
+      }
+
+      ~CorePool()
+      {
+        core_count = 0;
+        first_core = nullptr;
+        for (auto c: cores)
+        {
+          delete c;
+        }
+        cores.clear();
+      }
+  };
+}

--- a/src/rt/sched/corepool.h
+++ b/src/rt/sched/corepool.h
@@ -29,7 +29,7 @@ namespace verona::rt
     std::vector<Core<T>*> cores;
 
   public:
-    CorePool(size_t count) : core_count{count}
+    constexpr CorePool(size_t count) : core_count{count}
     {
       first_core = new Core<T>;
       Core<T>* t = first_core;

--- a/src/rt/sched/corepool.h
+++ b/src/rt/sched/corepool.h
@@ -4,7 +4,7 @@
 #include "pal/threading.h"
 
 #ifdef USE_SYSTEM_MONITOR
-#include "sysmonitor.h"
+#  include "sysmonitor.h"
 #endif
 
 #include <vector>
@@ -14,52 +14,52 @@ namespace verona::rt
   template<class P, class T>
   class CorePool
   {
-    private:
-      friend P;
+  private:
+    friend P;
 
 #ifdef USE_SYSTEM_MONITOR
-      friend SysMonitor<P>;
+    friend SysMonitor<P>;
 #endif
 
-      inline static Singleton<Topology, &Topology::init> topology;
-      Core<T>* first_core = nullptr;
-      size_t core_count = 0;
-      std::vector<Core<T>*> cores;
-    
-    public:
-      CorePool(size_t count) : core_count{count}
-      {
-        first_core = new Core<T>;
-        Core<T>* t = first_core;
-        cores.emplace_back(t);
-       
-        while (true)
-        {
-          t->affinity = topology.get().get(count);
-          if (count > 1) 
-          {
-            t->next = new Core<T>;
-            t = t->next;
-            count--;
-            cores.emplace_back(t);
-          }
-          else
-          {
-            t->next = first_core;
-            break;
-          }
-        }
-      }
+    inline static Singleton<Topology, &Topology::init> topology;
+    Core<T>* first_core = nullptr;
+    size_t core_count = 0;
+    std::vector<Core<T>*> cores;
 
-      ~CorePool()
+  public:
+    CorePool(size_t count) : core_count{count}
+    {
+      first_core = new Core<T>;
+      Core<T>* t = first_core;
+      cores.emplace_back(t);
+
+      while (true)
       {
-        core_count = 0;
-        first_core = nullptr;
-        for (auto c: cores)
+        t->affinity = topology.get().get(count);
+        if (count > 1)
         {
-          delete c;
+          t->next = new Core<T>;
+          t = t->next;
+          count--;
+          cores.emplace_back(t);
         }
-        cores.clear();
+        else
+        {
+          t->next = first_core;
+          break;
+        }
       }
+    }
+
+    ~CorePool()
+    {
+      core_count = 0;
+      first_core = nullptr;
+      for (auto c : cores)
+      {
+        delete c;
+      }
+      cores.clear();
+    }
   };
 }

--- a/src/rt/sched/corepool.h
+++ b/src/rt/sched/corepool.h
@@ -1,3 +1,5 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "core.h"

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -91,8 +91,7 @@ namespace verona::rt
           if (local->core == nullptr)
             abort();
           set_owning_core(local->core);
-          next = local->list;
-          local->list = this;
+          local->core->add_cown(this);
           local->core->total_cowns++;
         }
         else

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -8,9 +8,9 @@
 #include "../test/logging.h"
 #include "../test/systematic.h"
 #include "base_noticeboard.h"
+#include "core.h"
 #include "multimessage.h"
 #include "schedulerthread.h"
-#include "core.h"
 
 #include <algorithm>
 
@@ -88,7 +88,7 @@ namespace verona::rt
 
         if (local != nullptr)
         {
-          if (local->core == nullptr) 
+          if (local->core == nullptr)
             abort();
           set_owning_core(local->core);
           next = local->list;
@@ -174,8 +174,8 @@ namespace verona::rt
 
     Core<Cown>* owning_core()
     {
-      return
-        (Core<Cown>*)(core_status.load(std::memory_order_relaxed) & thread_mask);
+      return (
+        Core<Cown>*)(core_status.load(std::memory_order_relaxed) & thread_mask);
     }
 
   public:

--- a/src/rt/sched/schedulerlist.h
+++ b/src/rt/sched/schedulerlist.h
@@ -1,0 +1,122 @@
+#pragma once
+
+#include "ds/dllist.h"
+#include "threadsync.h"
+
+//#include <mutex>
+
+namespace verona::rt
+{
+  // SchedulerList implements two lists, active and free, both protected by the same lock.
+  // Implementing this here rather than inside the ThreadPool decouples its logic
+  // from the rest of the runtime implementation and should allow to easily change this class.
+  template<class T>
+  class SchedulerList
+  {
+    public:
+      //std::mutex m;
+      SchedulerLock m;
+
+      DLList<T> active;
+      DLList<T> free;
+
+    public:
+      SchedulerList() {}
+      ~SchedulerList()
+      {
+        m.lock();
+        if (!active.is_empty() || !free.is_empty())
+        {
+          //TODO should we abort or delete here?
+          abort();
+        }
+        m.unlock();
+      }
+
+      void addActive(T* thread)
+      {
+        add(true, thread);
+      }
+
+      void addFree(T* thread)
+      {
+        add(false, thread); 
+      }
+
+      T* popActive()
+      {
+        return pop_or_null(true);
+      }
+
+      T* popFree()
+      {
+        return pop_or_null(false);
+      }
+
+      void moveActiveToFree(T* thread)
+      {
+        m.lock();
+        active.remove(thread);
+        free.insert_back(thread);
+        m.unlock();
+      }
+
+
+      // WARNING: do not call other methods on the list or we end up with deadlock.
+      void forall(void (*f)(T* elem))
+      {
+        m.lock();
+        T* t = active.get_head();
+        while (t != nullptr)
+        {
+          f(t);
+          t = t->next;
+        }
+        t = free.get_head();
+        while (t != nullptr)
+        {
+          f(t);
+          t = t->next;
+        }
+        m.unlock();
+      }
+
+    private:
+      void add(bool is_active, T* elem)
+      {
+        if (elem == nullptr)
+          abort();
+        m.lock();
+        if (is_active)
+          active.insert_back(elem);
+        else
+          free.insert_back(elem);
+        m.unlock();
+      }
+
+      T* pop_or_null(bool is_active)
+      {
+        m.lock();
+        if (is_active)
+        {
+          if (active.is_empty())
+          {
+            m.unlock();
+            return nullptr;
+          }
+          T* res = active.pop();
+          m.unlock();
+          return res;
+        }
+
+        if (free.is_empty())
+        {
+          m.unlock();
+          return nullptr;
+        }
+        T* res = free.pop();
+        m.unlock();
+        return res;
+      }
+  };
+}

--- a/src/rt/sched/schedulerlist.h
+++ b/src/rt/sched/schedulerlist.h
@@ -24,7 +24,7 @@ namespace verona::rt
     DLList<T> free;
 
   public:
-    SchedulerList() {}
+    constexpr SchedulerList() = default;
     ~SchedulerList()
     {
       snmalloc::FlagLock lock(m);

--- a/src/rt/sched/schedulerlist.h
+++ b/src/rt/sched/schedulerlist.h
@@ -7,116 +7,117 @@
 
 namespace verona::rt
 {
-  // SchedulerList implements two lists, active and free, both protected by the same lock.
-  // Implementing this here rather than inside the ThreadPool decouples its logic
-  // from the rest of the runtime implementation and should allow to easily change this class.
+  // SchedulerList implements two lists, active and free, both protected by the
+  // same lock. Implementing this here rather than inside the ThreadPool
+  // decouples its logic from the rest of the runtime implementation and should
+  // allow to easily change this class.
   template<class T>
   class SchedulerList
   {
-    public:
-      //std::mutex m;
-      SchedulerLock m;
+  public:
+    // std::mutex m;
+    SchedulerLock m;
 
-      DLList<T> active;
-      DLList<T> free;
+    DLList<T> active;
+    DLList<T> free;
 
-    public:
-      SchedulerList() {}
-      ~SchedulerList()
+  public:
+    SchedulerList() {}
+    ~SchedulerList()
+    {
+      m.lock();
+      if (!active.is_empty() || !free.is_empty())
       {
-        m.lock();
-        if (!active.is_empty() || !free.is_empty())
-        {
-          //TODO should we abort or delete here?
-          abort();
-        }
-        m.unlock();
+        // TODO should we abort or delete here?
+        abort();
       }
+      m.unlock();
+    }
 
-      void addActive(T* thread)
+    void addActive(T* thread)
+    {
+      add(true, thread);
+    }
+
+    void addFree(T* thread)
+    {
+      add(false, thread);
+    }
+
+    T* popActive()
+    {
+      return pop_or_null(true);
+    }
+
+    T* popFree()
+    {
+      return pop_or_null(false);
+    }
+
+    void moveActiveToFree(T* thread)
+    {
+      m.lock();
+      active.remove(thread);
+      free.insert_back(thread);
+      m.unlock();
+    }
+
+    // WARNING: do not call other methods on the list or we end up with
+    // deadlock.
+    void forall(void (*f)(T* elem))
+    {
+      m.lock();
+      T* t = active.get_head();
+      while (t != nullptr)
       {
-        add(true, thread);
+        f(t);
+        t = t->next;
       }
-
-      void addFree(T* thread)
+      t = free.get_head();
+      while (t != nullptr)
       {
-        add(false, thread); 
+        f(t);
+        t = t->next;
       }
+      m.unlock();
+    }
 
-      T* popActive()
+  private:
+    void add(bool is_active, T* elem)
+    {
+      if (elem == nullptr)
+        abort();
+      m.lock();
+      if (is_active)
+        active.insert_back(elem);
+      else
+        free.insert_back(elem);
+      m.unlock();
+    }
+
+    T* pop_or_null(bool is_active)
+    {
+      m.lock();
+      if (is_active)
       {
-        return pop_or_null(true);
-      }
-
-      T* popFree()
-      {
-        return pop_or_null(false);
-      }
-
-      void moveActiveToFree(T* thread)
-      {
-        m.lock();
-        active.remove(thread);
-        free.insert_back(thread);
-        m.unlock();
-      }
-
-
-      // WARNING: do not call other methods on the list or we end up with deadlock.
-      void forall(void (*f)(T* elem))
-      {
-        m.lock();
-        T* t = active.get_head();
-        while (t != nullptr)
-        {
-          f(t);
-          t = t->next;
-        }
-        t = free.get_head();
-        while (t != nullptr)
-        {
-          f(t);
-          t = t->next;
-        }
-        m.unlock();
-      }
-
-    private:
-      void add(bool is_active, T* elem)
-      {
-        if (elem == nullptr)
-          abort();
-        m.lock();
-        if (is_active)
-          active.insert_back(elem);
-        else
-          free.insert_back(elem);
-        m.unlock();
-      }
-
-      T* pop_or_null(bool is_active)
-      {
-        m.lock();
-        if (is_active)
-        {
-          if (active.is_empty())
-          {
-            m.unlock();
-            return nullptr;
-          }
-          T* res = active.pop();
-          m.unlock();
-          return res;
-        }
-
-        if (free.is_empty())
+        if (active.is_empty())
         {
           m.unlock();
           return nullptr;
         }
-        T* res = free.pop();
+        T* res = active.pop();
         m.unlock();
         return res;
       }
+
+      if (free.is_empty())
+      {
+        m.unlock();
+        return nullptr;
+      }
+      T* res = free.pop();
+      m.unlock();
+      return res;
+    }
   };
 }

--- a/src/rt/sched/schedulerlist.h
+++ b/src/rt/sched/schedulerlist.h
@@ -1,3 +1,5 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
 #pragma once
 
 #include "ds/dllist.h"

--- a/src/rt/sched/schedulerlist.h
+++ b/src/rt/sched/schedulerlist.h
@@ -30,7 +30,6 @@ namespace verona::rt
       snmalloc::FlagLock lock(m);
       if (!active.is_empty() || !free.is_empty())
       {
-        // TODO should we abort or delete here?
         abort();
       }
     }

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -702,7 +702,6 @@ namespace verona::rt
       }
 
       assert(core != nullptr);
-      // TODO not sure about the logic here.
       T* _list = core->drain();
       T** list = &_list;
       T** p = &_list;

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -485,8 +485,8 @@ namespace verona::rt
         }
         else
         {
-          Logging::cout() << "Reached token: stolen from " << owning_core->affinity
-                          << Logging::endl;
+          Logging::cout() << "Reached token: stolen from "
+                          << owning_core->affinity << Logging::endl;
         }
 
         // Put back the token

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -9,6 +9,10 @@
 #include "schedulerstats.h"
 #include "threadpool.h"
 
+#include "core.h"
+#include "ds/dllist.h"
+#include "schedulerlist.h"
+
 #include <snmalloc/snmalloc.h>
 
 namespace verona::rt
@@ -34,17 +38,18 @@ namespace verona::rt
     size_t systematic_id = 0;
 
   private:
-    using Scheduler = ThreadPool<SchedulerThread<T>>;
+    using Scheduler = ThreadPool<SchedulerThread<T>, T>;
     friend Scheduler;
     friend T;
+    friend DLList<SchedulerThread<T>>;
+    friend SchedulerList<SchedulerThread<T>>;
 
     template<typename Owner>
     friend class Noticeboard;
 
     static constexpr uint64_t TSC_QUIESCENCE_TIMEOUT = 1'000'000;
 
-    T* token_cown = nullptr;
-
+    Core<T>* core = nullptr;
 #ifdef USE_SYSTEMATIC_TESTING
     friend class ThreadSyncSystematic<SchedulerThread>;
     Systematic::Local* local_systematic{nullptr};
@@ -53,10 +58,8 @@ namespace verona::rt
     LocalSync local_sync{};
 #endif
 
-    MPMCQ<T> q;
     Alloc* alloc = nullptr;
-    SchedulerThread<T>* next = nullptr;
-    SchedulerThread<T>* victim = nullptr;
+    Core<T>* victim = nullptr;
 
     bool running = true;
 
@@ -72,35 +75,35 @@ namespace verona::rt
     EpochMark prev_epoch = EpochMark::EPOCH_B;
 
     ThreadState::State state = ThreadState::State::NotInLD;
-    SchedulerStats stats;
 
     T* list = nullptr;
-
-    // The number of cowns in the per-thread list `list`.
-    size_t total_cowns = 0;
-
-    // The number of cowns that have been collected in the per-thread list
-    // `list`. This is atomic as other threads can collect the body of the
-    // cown managed from this thread.  They cannot collect the actual cown
-    // allocation.  The ratio of free_cowns to total_cowns is used to
-    // determine when to walk the `list` to collect the stubs.
-    std::atomic<size_t> free_cowns = 0;
-
+		
     /// The MessageBody of a running behaviour.
     typename T::MessageBody* message_body = nullptr;
 
+    /// SchedulerList pointers.
+    SchedulerThread<T>* prev = nullptr;
+    SchedulerThread<T>* next = nullptr;
+
     T* get_token_cown()
     {
-      assert(token_cown);
-      return token_cown;
+      assert(core != nullptr);
+      assert(core ->token_cown);
+      return core->token_cown;
     }
 
-    SchedulerThread() : token_cown{T::create_token_cown()}, q{token_cown}
+    SchedulerThread() 
     {
-      token_cown->set_owning_thread(this);
+      Logging::cout() << "Scheduler Thread created" << Logging::endl;
     }
 
     ~SchedulerThread() {}
+
+    void setCore(Core<T>* core)
+    {
+      this->core = core;
+      core->token_cown->set_owning_core(core);
+    }
 
     inline void stop()
     {
@@ -119,26 +122,26 @@ namespace verona::rt
         scheduled_unscanned_cown = true;
       }
       assert(!a->queue.is_sleeping());
-      q.enqueue(*alloc, a);
+      core->q.enqueue(*alloc, a);
 
       if (Scheduler::get().unpause())
-        stats.unpause();
+        core->stats.unpause();
     }
 
-    inline void schedule_lifo(T* a)
+    static inline void schedule_lifo(Core<T>* c, T* a)
     {
       // A lifo scheduled cown is coming from an external source, such as
       // asynchronous I/O.
       Logging::cout() << "LIFO scheduling cown " << a << " onto "
-                      << systematic_id << Logging::endl;
-      q.enqueue_front(ThreadAlloc::get(), a);
+                      << c->affinity << Logging::endl;
+      c->q.enqueue_front(ThreadAlloc::get(), a);
       Logging::cout() << "LIFO scheduled cown " << a << " onto "
-                      << systematic_id << Logging::endl;
+                      << c->affinity << Logging::endl;
 
-      stats.lifo();
+      c->stats.lifo();
 
       if (Scheduler::get().unpause())
-        stats.unpause();
+        c->stats.unpause();
     }
 
     template<typename... Args>
@@ -160,8 +163,10 @@ namespace verona::rt
 
       Scheduler::local() = this;
       alloc = &ThreadAlloc::get();
-      victim = next;
+      assert(this->core != nullptr);
+      victim = core->next;
       T* cown = nullptr;
+      this->core->servicing_threads++;
 
 #ifdef USE_SYSTEMATIC_TESTING
       Systematic::attach_systematic_thread(this->local_systematic);
@@ -170,7 +175,7 @@ namespace verona::rt
       while (true)
       {
         if (
-          (total_cowns < (free_cowns << 1))
+          (this->core->total_cowns < (this->core->free_cowns << 1))
 #ifdef USE_SYSTEMATIC_TESTING
           || Systematic::coin()
 #endif
@@ -188,7 +193,7 @@ namespace verona::rt
 
         if (cown == nullptr)
         {
-          cown = q.dequeue(*alloc);
+          cown = core->q.dequeue(*alloc);
           if (cown != nullptr)
             Logging::cout()
               << "Pop cown " << clear_thread_bit(cown) << Logging::endl;
@@ -230,6 +235,18 @@ namespace verona::rt
 
         Logging::cout() << "Running cown " << cown << Logging::endl;
 
+        // Update progress counter on that core.
+        Core<T>* cown_core = cown->owning_core();
+        assert(this->core != nullptr);
+
+        // If the cown comes from another core, both core counts are incremented.
+        // This reflects both CPU utilization and queue progress.
+        if (cown_core != nullptr)
+          cown_core->progress_counter++;
+        if (cown_core != this->core)
+          core->progress_counter++;
+        core->last_worker = this->systematic_id;
+
         bool reschedule = cown->run(*alloc, state);
 
         if (reschedule)
@@ -246,7 +263,7 @@ namespace verona::rt
             // otherwise run this cown again. Don't push to the queue
             // immediately to avoid another thread stealing our only cown.
 
-            T* n = q.dequeue(*alloc);
+            T* n = core->q.dequeue(*alloc);
 
             if (n != nullptr)
             {
@@ -255,7 +272,7 @@ namespace verona::rt
             }
             else
             {
-              if (q.nothing_old())
+              if (core->q.nothing_old())
               {
                 Logging::cout() << "Queue empty" << Logging::endl;
                 // We have effectively reached token cown.
@@ -310,8 +327,15 @@ namespace verona::rt
 
       Logging::cout() << "End teardown (phase 2)" << Logging::endl;
 
-      q.destroy(*alloc);
-
+      if (core != nullptr)
+      {
+        auto val = core->servicing_threads.fetch_sub(1);
+        if (val == 1)
+        {
+          Logging::cout() << "Destroying core " << core->affinity << Logging::endl;
+          core->q.destroy(*alloc);
+        }
+      }
       Systematic::finished_thread();
 
       // Reset the local thread pointer as this physical thread could be reused
@@ -325,7 +349,7 @@ namespace verona::rt
       T* cown;
 
       // Try to steal from the victim thread.
-      if (victim != this)
+      if (victim != this->core)
       {
         cown = victim->q.dequeue(*alloc);
 
@@ -333,7 +357,7 @@ namespace verona::rt
         {
           // stats.steal();
           Logging::cout() << "Fast-steal cown " << clear_thread_bit(cown)
-                          << " from " << victim->systematic_id << Logging::endl;
+                          << " from " << victim->affinity << Logging::endl;
           result = cown;
           return true;
         }
@@ -361,7 +385,7 @@ namespace verona::rt
       {
         yield();
 
-        if (q.nothing_old())
+        if (core->q.nothing_old())
         {
           n_ld_tokens = 0;
         }
@@ -370,22 +394,22 @@ namespace verona::rt
         ld_protocol();
 
         // Check if some other thread has pushed work on our queue.
-        cown = q.dequeue(*alloc);
+        cown = core->q.dequeue(*alloc);
 
         if (cown != nullptr)
           return cown;
 
         // Try to steal from the victim thread.
-        if (victim != this)
+        if (victim != this->core)
         {
           cown = victim->q.dequeue(*alloc);
 
           if (cown != nullptr)
           {
-            stats.steal();
+            core->stats.steal();
             Logging::cout()
               << "Stole cown " << clear_thread_bit(cown) << " from "
-              << victim->systematic_id << Logging::endl;
+              << victim->affinity << Logging::endl;
             return cown;
           }
         }
@@ -417,7 +441,7 @@ namespace verona::rt
           // We've been spinning looking for work for some time. While paused,
           // our running flag may be set to false, in which case we terminate.
           if (Scheduler::get().pause())
-            stats.pause();
+            core->stats.pause();
         }
       }
 
@@ -449,9 +473,9 @@ namespace verona::rt
       if (has_thread_bit(cown))
       {
         auto unmasked = clear_thread_bit(cown);
-        SchedulerThread* sched = unmasked->owning_thread();
+        Core<T>* core = unmasked->owning_core();
 
-        if (sched == this)
+        if (core == this->core)
         {
           if (Scheduler::get().fair)
           {
@@ -469,24 +493,25 @@ namespace verona::rt
         else
         {
           Logging::cout() << "Reached token: stolen from "
-                          << sched->systematic_id << Logging::endl;
+                          << core->affinity << Logging::endl;
         }
 
         // Put back the token
-        sched->q.enqueue(*alloc, cown);
+        core->q.enqueue(*alloc, cown);
         return false;
       }
 
       // Register this cown with the scheduler thread if it is not currently
       // registered with a scheduler thread.
-      if (cown->owning_thread() == nullptr)
+      if (cown->owning_core() == nullptr)
       {
         Logging::cout() << "Bind cown to scheduler thread: " << this
                         << Logging::endl;
-        cown->set_owning_thread(this);
+        assert(this->core != nullptr);
+        cown->set_owning_core(this->core);
         cown->next = list;
         list = cown;
-        total_cowns++;
+        this->core->total_cowns++;
       }
 
       return true;
@@ -553,7 +578,7 @@ namespace verona::rt
           sprev == ThreadState::PreScan && snext == ThreadState::PreScan &&
           Scheduler::get().unpause())
         {
-          stats.unpause();
+          core->stats.unpause();
         }
 
         if (snext == sprev)
@@ -574,7 +599,7 @@ namespace verona::rt
           case ThreadState::PreScan:
           {
             if (Scheduler::get().unpause())
-              stats.unpause();
+              core->stats.unpause();
 
             enter_prescan();
             return;
@@ -740,13 +765,14 @@ namespace verona::rt
         }
         p = &(c->next);
       }
-      assert(total_cowns == count);
-      free_cowns -= removed_count;
-      total_cowns -= removed_count;
+      assert(this->core != nullptr);
+      assert(this->core->total_cowns == count);
+      this->core->free_cowns -= removed_count;
+			this->core->total_cowns -= removed_count;
 
       Logging::cout() << "Stub collected " << removed_count << " cowns"
-                      << " Free cowns " << free_cowns << " Total cowns "
-                      << total_cowns << Logging::endl;
+                      << " Free cowns " << this->core->free_cowns << " Total cowns "
+                      << this->core->total_cowns << Logging::endl;
     }
   };
 } // namespace verona::rt

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -164,16 +164,16 @@ namespace verona::rt
       assert(core != nullptr);
       victim = core->next;
       T* cown = nullptr;
-      this->core->servicing_threads++;
+      core->servicing_threads++;
 
 #ifdef USE_SYSTEMATIC_TESTING
-      Systematic::attach_systematic_thread(this->local_systematic);
+      Systematic::attach_systematic_thread(local_systematic);
 #endif
 
       while (true)
       {
         if (
-          (this->core->total_cowns < (this->core->free_cowns << 1))
+          (core->total_cowns < (core->free_cowns << 1))
 #ifdef USE_SYSTEMATIC_TESTING
           || Systematic::coin()
 #endif
@@ -235,15 +235,15 @@ namespace verona::rt
 
         // Update progress counter on that core.
         Core<T>* cown_core = cown->owning_core();
-        assert(this->core != nullptr);
+        assert(core != nullptr);
 
         // If the cown comes from another core, both core counts are
         // incremented. This reflects both CPU utilization and queue progress.
         if (cown_core != nullptr)
           cown_core->progress_counter++;
-        if (cown_core != this->core)
+        if (cown_core != core)
           core->progress_counter++;
-        core->last_worker = this->systematic_id;
+        core->last_worker = systematic_id;
 
         bool reschedule = cown->run(*alloc, state);
 
@@ -348,7 +348,7 @@ namespace verona::rt
       T* cown;
 
       // Try to steal from the victim thread.
-      if (victim != this->core)
+      if (victim != core)
       {
         cown = victim->q.dequeue(*alloc);
 
@@ -399,7 +399,7 @@ namespace verona::rt
           return cown;
 
         // Try to steal from the victim thread.
-        if (victim != this->core)
+        if (victim != core)
         {
           cown = victim->q.dequeue(*alloc);
 
@@ -473,7 +473,7 @@ namespace verona::rt
         auto unmasked = clear_thread_bit(cown);
         Core<T>* core = unmasked->owning_core();
 
-        if (core == this->core)
+        if (core == core)
         {
           if (Scheduler::get().fair)
           {
@@ -505,11 +505,11 @@ namespace verona::rt
       {
         Logging::cout() << "Bind cown to scheduler thread: " << this
                         << Logging::endl;
-        assert(this->core != nullptr);
-        cown->set_owning_core(this->core);
+        assert(core != nullptr);
+        cown->set_owning_core(core);
         cown->next = list;
         list = cown;
-        this->core->total_cowns++;
+        core->total_cowns++;
       }
 
       return true;

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -2,16 +2,15 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include "core.h"
+#include "ds/dllist.h"
 #include "ds/hashmap.h"
 #include "ds/mpscq.h"
 #include "mpmcq.h"
 #include "object/object.h"
+#include "schedulerlist.h"
 #include "schedulerstats.h"
 #include "threadpool.h"
-
-#include "core.h"
-#include "ds/dllist.h"
-#include "schedulerlist.h"
 
 #include <snmalloc/snmalloc.h>
 
@@ -77,7 +76,7 @@ namespace verona::rt
     ThreadState::State state = ThreadState::State::NotInLD;
 
     T* list = nullptr;
-		
+
     /// The MessageBody of a running behaviour.
     typename T::MessageBody* message_body = nullptr;
 
@@ -88,11 +87,11 @@ namespace verona::rt
     T* get_token_cown()
     {
       assert(core != nullptr);
-      assert(core ->token_cown);
+      assert(core->token_cown);
       return core->token_cown;
     }
 
-    SchedulerThread() 
+    SchedulerThread()
     {
       Logging::cout() << "Scheduler Thread created" << Logging::endl;
     }
@@ -132,11 +131,11 @@ namespace verona::rt
     {
       // A lifo scheduled cown is coming from an external source, such as
       // asynchronous I/O.
-      Logging::cout() << "LIFO scheduling cown " << a << " onto "
-                      << c->affinity << Logging::endl;
+      Logging::cout() << "LIFO scheduling cown " << a << " onto " << c->affinity
+                      << Logging::endl;
       c->q.enqueue_front(ThreadAlloc::get(), a);
-      Logging::cout() << "LIFO scheduled cown " << a << " onto "
-                      << c->affinity << Logging::endl;
+      Logging::cout() << "LIFO scheduled cown " << a << " onto " << c->affinity
+                      << Logging::endl;
 
       c->stats.lifo();
 
@@ -239,8 +238,8 @@ namespace verona::rt
         Core<T>* cown_core = cown->owning_core();
         assert(this->core != nullptr);
 
-        // If the cown comes from another core, both core counts are incremented.
-        // This reflects both CPU utilization and queue progress.
+        // If the cown comes from another core, both core counts are
+        // incremented. This reflects both CPU utilization and queue progress.
         if (cown_core != nullptr)
           cown_core->progress_counter++;
         if (cown_core != this->core)
@@ -332,7 +331,8 @@ namespace verona::rt
         auto val = core->servicing_threads.fetch_sub(1);
         if (val == 1)
         {
-          Logging::cout() << "Destroying core " << core->affinity << Logging::endl;
+          Logging::cout() << "Destroying core " << core->affinity
+                          << Logging::endl;
           core->q.destroy(*alloc);
         }
       }
@@ -407,9 +407,8 @@ namespace verona::rt
           if (cown != nullptr)
           {
             core->stats.steal();
-            Logging::cout()
-              << "Stole cown " << clear_thread_bit(cown) << " from "
-              << victim->affinity << Logging::endl;
+            Logging::cout() << "Stole cown " << clear_thread_bit(cown)
+                            << " from " << victim->affinity << Logging::endl;
             return cown;
           }
         }
@@ -492,8 +491,8 @@ namespace verona::rt
         }
         else
         {
-          Logging::cout() << "Reached token: stolen from "
-                          << core->affinity << Logging::endl;
+          Logging::cout() << "Reached token: stolen from " << core->affinity
+                          << Logging::endl;
         }
 
         // Put back the token
@@ -768,11 +767,12 @@ namespace verona::rt
       assert(this->core != nullptr);
       assert(this->core->total_cowns == count);
       this->core->free_cowns -= removed_count;
-			this->core->total_cowns -= removed_count;
+      this->core->total_cowns -= removed_count;
 
       Logging::cout() << "Stub collected " << removed_count << " cowns"
-                      << " Free cowns " << this->core->free_cowns << " Total cowns "
-                      << this->core->total_cowns << Logging::endl;
+                      << " Free cowns " << this->core->free_cowns
+                      << " Total cowns " << this->core->total_cowns
+                      << Logging::endl;
     }
   };
 } // namespace verona::rt

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -98,10 +98,9 @@ namespace verona::rt
 
     ~SchedulerThread() {}
 
-    void setCore(Core<T>* core)
+    void set_core(Core<T>* core)
     {
       this->core = core;
-      core->token_cown->set_owning_core(core);
     }
 
     inline void stop()
@@ -162,7 +161,7 @@ namespace verona::rt
 
       Scheduler::local() = this;
       alloc = &ThreadAlloc::get();
-      assert(this->core != nullptr);
+      assert(core != nullptr);
       victim = core->next;
       T* cown = nullptr;
       this->core->servicing_threads++;

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -466,9 +466,9 @@ namespace verona::rt
       if (has_thread_bit(cown))
       {
         auto unmasked = clear_thread_bit(cown);
-        Core<T>* core = unmasked->owning_core();
+        Core<T>* owning_core = unmasked->owning_core();
 
-        if (core == core)
+        if (owning_core == core)
         {
           if (Scheduler::get().fair)
           {
@@ -485,12 +485,12 @@ namespace verona::rt
         }
         else
         {
-          Logging::cout() << "Reached token: stolen from " << core->affinity
+          Logging::cout() << "Reached token: stolen from " << owning_core->affinity
                           << Logging::endl;
         }
 
         // Put back the token
-        core->q.enqueue(*alloc, cown);
+        owning_core->q.enqueue(*alloc, cown);
         return false;
       }
 

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -706,6 +706,7 @@ namespace verona::rt
       T* _list = core->drain();
       T** list = &_list;
       T** p = &_list;
+      T* tail = nullptr;
       assert(p != nullptr);
       size_t removed_count = 0;
       size_t count = 0;
@@ -746,18 +747,14 @@ namespace verona::rt
                 << "Cown " << c << " not outdated." << Logging::endl;
           }
         }
+        tail = c;
         p = &(c->next);
       }
 
       // Put the list back
       if (*list != nullptr)
       {
-        // TODO this is slow, find a better way to keep track of the tail.
-        T* tail = *list;
-        while (tail->next != nullptr)
-        {
-          tail = tail->next;
-        }
+        assert(tail != nullptr);
         core->add_cowns(*list, tail);
       }
 

--- a/src/rt/sched/threadpool.h
+++ b/src/rt/sched/threadpool.h
@@ -313,8 +313,9 @@ namespace verona::rt
 
       // For future ids.
       systematic_ids = count + 1;
-      
-      for (; count > 0; count--) {
+
+      for (; count > 0; count--)
+      {
         T* t = new T;
         t->systematic_id = count;
 #ifdef USE_SYSTEMATIC_TESTING
@@ -339,7 +340,7 @@ namespace verona::rt
         ThreadPoolBuilder builder(thread_count);
 
         Logging::cout() << "Starting all threads" << Logging::endl;
-        for (size_t i = 0; i < thread_count; i++) 
+        for (size_t i = 0; i < thread_count; i++)
         {
           T* t = threads->popFree();
           if (t == nullptr)
@@ -352,12 +353,12 @@ namespace verona::rt
       Logging::cout() << "All threads stopped" << Logging::endl;
 
       T* t = threads->popActive();
-      while(t != nullptr)
+      while (t != nullptr)
       {
         T* prev = t;
         t = threads->popActive();
         delete prev;
-      } 
+      }
       t = threads->popFree();
       while (t != nullptr)
       {
@@ -397,8 +398,8 @@ namespace verona::rt
       Core<E>* c = first_core();
       do
       {
-        Logging::cout() << "Checking for pending work on thread "
-                        << c->affinity << Logging::endl;
+        Logging::cout() << "Checking for pending work on thread " << c->affinity
+                        << Logging::endl;
         if (!c->q.nothing_old())
         {
           Logging::cout() << "Found pending work!" << Logging::endl;
@@ -471,7 +472,7 @@ namespace verona::rt
         teardown_in_progress = true;
 
         // Tell all threads to stop looking for work.
-        threads->forall([](T* thread){thread->stop();}); 
+        threads->forall([](T* thread) { thread->stop(); });
         Logging::cout() << "Teardown: all threads stopped" << Logging::endl;
 
         h.unpause_all();

--- a/src/rt/sched/threadstate.h
+++ b/src/rt/sched/threadstate.h
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include <snmalloc/snmalloc.h>
-
 #include <atomic>
+#include <snmalloc/snmalloc.h>
 
 namespace verona::rt
 {
@@ -110,7 +109,8 @@ namespace verona::rt
     };
 
     // ThreadState counters.
-    struct StateCounters {
+    struct StateCounters
+    {
       size_t active_threads = 0;
       std::atomic<size_t> barrier_count = 0;
     };
@@ -306,7 +306,7 @@ namespace verona::rt
     /// @warn Should be holding the threadpool lock.
     size_t exit_thread()
     {
-      return internal_state.barrier_count.fetch_sub(1) -1;
+      return internal_state.barrier_count.fetch_sub(1) - 1;
     }
 
     size_t get_active_threads()

--- a/src/rt/test/perf/smallbank/smallbank.cc
+++ b/src/rt/test/perf/smallbank/smallbank.cc
@@ -164,7 +164,7 @@ public:
     // Business logic
     for (uint32_t i = 0; i < TX_BATCH; i++)
     {
-      uint8_t txn_type = rand() % TX_COUNT;
+      uint8_t txn_type = (uint8_t) rand() % TX_COUNT;
       uint64_t acc1 =
         static_cast<uint64_t>(rand()) % (ACCOUNTS_COUNT + ACCOUNT_EXTRA);
 

--- a/src/rt/test/perf/smallbank/smallbank.cc
+++ b/src/rt/test/perf/smallbank/smallbank.cc
@@ -164,7 +164,7 @@ public:
     // Business logic
     for (uint32_t i = 0; i < TX_BATCH; i++)
     {
-      uint8_t txn_type = (uint8_t) rand() % TX_COUNT;
+      uint8_t txn_type = (uint8_t)rand() % TX_COUNT;
       uint64_t acc1 =
         static_cast<uint64_t>(rand()) % (ACCOUNTS_COUNT + ACCOUNT_EXTRA);
 


### PR DESCRIPTION
Introducing the `Core` layer in the Verona Runtime scheduler.
Cores hold the cown queues while SchedulerThreads are assigned to a core.
This refactoring enables to add new scheduler threads as needed during the execution of the runtime.