### PR TITLE
Epoch fix

### DIFF
--- a/src/rt/ds/asymlock.h
+++ b/src/rt/ds/asymlock.h
@@ -99,5 +99,15 @@ namespace verona::rt
     {
       return internal_lock.load(std::memory_order_relaxed) != 0;
     }
+
+    bool debug_external_held()
+    {
+      return external_lock.load(std::memory_order_relaxed);
+    }
+
+    bool debug_held()
+    {
+      return debug_internal_held() || debug_external_held();
+    }
   };
 } // namespace verona::rt

--- a/src/rt/ds/barrier.h
+++ b/src/rt/ds/barrier.h
@@ -148,7 +148,13 @@ namespace verona::rt
   public:
     static inline void memory()
     {
+#ifdef USE_SYSTEMATIC_TESTING
+      // Systematic testing does not need memory barriers, as
+      // the code is being executed through interleavings.
+      compiler();
+#else
       FlushProcessWriteBuffers();
+#endif
     }
 
     static inline void compiler()

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -298,8 +298,12 @@ namespace verona::rt
         auto epoch = epoch_when_popped;
         auto outdated =
           epoch == NO_EPOCH_SET || GlobalEpoch::is_outdated(epoch);
-        if (outdated)
+        if (outdated || Scheduler::is_teardown_in_progress())
         {
+          // If teardown is in progress, then there are no ABA issues, so
+          // directly deallocate.
+          // TODO: Investigate if we could eject global epoch to avoid the
+          // additional test.
           Logging::cout() << "Cown " << this << " dealloc" << Logging::endl;
           dealloc(alloc);
         }

--- a/src/rt/sched/epoch.h
+++ b/src/rt/sched/epoch.h
@@ -322,8 +322,8 @@ namespace verona::rt
       //   || new_epoch + 1 == GlobalEpoch::get()
       //   || (old_epoch == new_epoch + 1)   (A)
       // If old_epoch != new_epoch+1, then the global epoch can be advanced at
-      // most once from this point. However, in the highly unlikely case they are
-      // equal, then we need to retry the whole process.
+      // most once from this point. However, in the highly unlikely case they
+      // are equal, then we need to retry the whole process.
 
       // Assuming we are not in case (A), we will retry if we hit this case
       // Publish we are in the latest epoch

--- a/src/rt/sched/epoch.h
+++ b/src/rt/sched/epoch.h
@@ -310,7 +310,9 @@ namespace verona::rt
 
       // Remove the ejected bit, this will prevent other threads from advancing
       // the epoch continualy.
-      epoch.store(old_epoch & ~EJECTED_BIT, std::memory_order_acq_rel);
+      // Need to prevent subsequent load of global epoch occuring before this
+      // store.
+      epoch.store(old_epoch & ~EJECTED_BIT, std::memory_order_seq_cst);
 
       // Re-read the global epoch
       auto new_epoch = GlobalEpoch::get();

--- a/src/rt/sched/epoch.h
+++ b/src/rt/sched/epoch.h
@@ -341,7 +341,6 @@ namespace verona::rt
      */
     void eject()
     {
-      assert(lock.debug_held());
       epoch.store(get_epoch() | EJECTED_BIT, std::memory_order_release);
     }
 

--- a/src/rt/sched/epoch.h
+++ b/src/rt/sched/epoch.h
@@ -2,6 +2,29 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+/**
+ * This file provides an Epoch based memory reclamation mechanism.
+ *
+ * There is a global epoch, and each thread has its own view of the local
+ * epoch. The local epoch can be in one of four states
+ *   1. Equal to the global epoch
+ *   2. One less that the global epoch
+ *   3. Ejected
+ *   4. Rejoining
+ * The global epoch can be advanced as long as there is no thread in state 2.
+ * When a thread is in a state 2, any other thread that wishes to advance
+ * the epoch must eject that thread. If a thread is using an Epoch it cannot be
+ * ejected, but if it is not using an Epoch then it may be ejected.
+ *
+ * The ejection mechanism is built on top of the Asymetric lock.  Holding the
+ * epoch, holds the `internal` side of a lock.  To eject a thread, the ejectee
+ * must hold the `external` side of the lock.
+ *
+ * To rejoin a thread must observe itself to be in state 1. That is set its
+ * local epoch to the global one, and then observe the global one has not
+ * changed. A rejoining thread may prevent a thread from advancing the epoch.
+ */
+
 #include "../ds/asymlock.h"
 #include "../ds/queue.h"
 #include "../test/logging.h"
@@ -11,6 +34,10 @@
 
 namespace verona::rt
 {
+  /**
+   * The representation of an epoch is a 63 bit counter.  If the top bit is
+   * set, then the epoch is considered ejected.
+   */
   static constexpr uint64_t EJECTED_BIT = 0x8000000000000000;
 
   static uint64_t inc_epoch_by(uint64_t epoch, uint64_t i)
@@ -19,6 +46,10 @@ namespace verona::rt
     return (epoch + i) & ~EJECTED_BIT;
   }
 
+  /**
+   * Represents the global state of the current epoch.
+   *
+   */
   class GlobalEpoch
   {
   private:
@@ -32,6 +63,7 @@ namespace verona::rt
 
     static void set(uint64_t e)
     {
+      Logging::cout() << "Global epoch set to " << e << std::endl;
       global_epoch().store(e, std::memory_order_release);
     }
 
@@ -54,23 +86,35 @@ namespace verona::rt
       }
       return true;
     }
-
-    static void advance()
-    {
-      auto global_e = get();
-      global_e = inc_epoch_by(global_e, 3);
-      set(global_e);
-    }
   };
 
+  /**
+   * Represents the thread local state of the thread's current epoch.
+   *
+   * This also stores the delayed operations that need to wait until the epoch
+   * has advanced sufficiently.
+   *
+   * There are two types of delayed operations:
+   *   1. Decrementing the reference count of an object
+   *   2. Deallocating an object.
+   */
   class LocalEpoch : public Pooled<LocalEpoch>
   {
   private:
+    /**
+     * Used to represent objects that are being delayed deallocations.
+     * The object itself is used to represent this. The object to be deallocated
+     * is used itself by casting to an InnerNode.
+     */
     struct InnerNode
     {
       InnerNode* next;
     };
 
+    /**
+     * Represents the node in the queue for objects that need an incref
+     * applying.
+     */
     struct DecNode
     {
       DecNode* next;
@@ -80,20 +124,38 @@ namespace verona::rt
     friend class ThreadLocalEpoch;
     friend class Epoch;
 
+    /// Ranges from 0 to 3 to represent the current epoch on
+    /// more finite structures.
+    uint8_t index = 0;
+
+    /// The queue of objects to be deallocated.
     Queue<InnerNode> delete_list;
-    Queue<InnerNode> dec_list;
+
+    /// Represents how many objects in each epoch of delete_list
+    size_t unusable[4] = {0, 0, 0, 0};
+
+    /// The queue of objects to be decremeneted.
+    Queue<DecNode> dec_list;
+
+    /// Represents how many objects in each epoch of dec_list
+    size_t to_dec[4] = {0, 0, 0, 0};
+
     // Providing heuristic for advancing the epoch. Currently, we only look at
     // one slot to determine if we should advance the epoch (see
     // advance_is_sensible()), but we keep the history here so that better
     // heuristic could be applied later.
     size_t pressure[4] = {0, 0, 0, 0};
-    size_t unusable[4] = {0, 0, 0, 0};
-    size_t to_dec[4] = {0, 0, 0, 0};
-    uint8_t index = 0;
 
+    /// The current epoch for this structure.  Initially set to EJECTED_BIT
+    /// so we hit a slow path initially.
     std::atomic<uint64_t> epoch = EJECTED_BIT;
+
+    /// Used to allow ejection from other threads.
     AsymmetricLock lock;
 
+    /// Used to check that all threads are in a particular state.
+    /// Forward reference due to requiring the LocalEpochPool to
+    /// find all LocalEpochs.
     template<typename T, bool predicate(LocalEpoch* p, T t)>
     static bool forall(T t);
 
@@ -109,32 +171,27 @@ namespace verona::rt
     {
       auto node = (DecNode*)alloc.alloc<sizeof(DecNode)>();
       node->o = p;
-      dec_list.enqueue((InnerNode*)node);
+      dec_list.enqueue(node);
       (*get_to_dec(2))++;
       debug_check_count();
     }
 
     inline void use_epoch(Alloc& a)
     {
-      lock.internal_acquire();
-
-      auto new_epoch = GlobalEpoch::get();
-      auto old_epoch = get_epoch();
-
-      if (old_epoch != new_epoch)
+      if (lock.internal_acquire())
       {
-        if (lock.internal_count() == 1)
-          use_epoch_rare(a, old_epoch, new_epoch);
+        auto new_epoch = GlobalEpoch::get();
+        auto old_epoch = get_epoch();
+
+        if (old_epoch != new_epoch)
+          use_epoch_rare(a, old_epoch);
       }
     }
 
     inline void release_epoch(Alloc& a)
     {
-      if (advance_is_sensible())
-      {
-        if (lock.internal_count() == 1)
-          release_epoch_rare(a);
-      }
+      if ((lock.internal_count() == 1) && (advance_is_sensible()))
+        release_epoch_rare(a);
 
       lock.internal_release();
     }
@@ -154,7 +211,10 @@ namespace verona::rt
       return &to_dec[(index + i) & 3];
     }
 
-    void advance_epoch(Alloc& alloc)
+    /**
+     * Deals with the olded epoches worth of delayed operations for this thread.
+     */
+    void flush_old_epoch(Alloc& alloc)
     {
       debug_check_count();
 
@@ -194,11 +254,6 @@ namespace verona::rt
       debug_check_count();
     }
 
-    void add_pressure()
-    {
-      (*get_pressure(2))++;
-    }
-
     // TODO: Add a proper heuristic here
     bool advance_is_sensible()
     {
@@ -209,6 +264,7 @@ namespace verona::rt
 #endif
     }
 
+    // TODO: Add a proper heuristic here
     bool advance_is_urgent()
     {
 #ifdef USE_SYSTEMATIC_TESTING
@@ -223,53 +279,77 @@ namespace verona::rt
       return epoch.load(std::memory_order_acquire);
     }
 
-    NOINLINE
-    void refresh_rare(Alloc& a, uint64_t old_epoch, uint64_t new_epoch)
-    {
-      advance_epoch(a);
-
-      if (inc_epoch_by(old_epoch, 1) != new_epoch)
-      {
-        advance_epoch(a);
-
-        if (inc_epoch_by(old_epoch, 1) != new_epoch)
-        {
-          advance_epoch(a);
-        }
-      }
-
-      epoch.store(new_epoch, std::memory_order_release);
-    }
-
+    /**
+     * Used to advance the epoch to the current global epoch.
+     * Should only be called when the thread has not been ejected.
+     */
     inline void refresh(Alloc& a)
     {
       assert(lock.debug_internal_held());
 
       auto new_epoch = GlobalEpoch::get();
       auto old_epoch = get_epoch();
+      assert(!(old_epoch & EJECTED_BIT));
 
       if (old_epoch != new_epoch)
       {
-        refresh_rare(a, old_epoch, new_epoch);
+        assert(inc_epoch_by(old_epoch, 1) == new_epoch);
+        flush_old_epoch(a);
+        epoch.store(new_epoch, std::memory_order_release);
       }
     }
 
     NOINLINE void rejoin_epoch(Alloc& a, uint64_t old_epoch)
     {
-      epoch.store(old_epoch & ~EJECTED_BIT, std::memory_order_release);
+      Logging::cout() << "Rejoining epoch " << old_epoch << Logging::endl;
+      assert(old_epoch & EJECTED_BIT);
+      assert(lock.debug_internal_held());
 
+      // Clear the ejected bit
+      old_epoch = old_epoch & ~EJECTED_BIT;
+
+      // Remove the ejected bit, this will prevent other threads from advancing
+      // the epoch continualy.
+      epoch.store(old_epoch & ~EJECTED_BIT, std::memory_order_acq_rel);
+
+      // Re-read the global epoch
+      auto new_epoch = GlobalEpoch::get();
+
+      // At this point, we know that the
+      //   new_epoch == GlobalEpoch::get()
+      //   || new_epoch + 1 == GlobalEpoch::get()
+      // as the global epoch can be advanced at most once from this point.
+
+      // Publish we are in the latest epoch
+      // Hence we are now in state 1 or 2 from the comment at the top of the
+      // file.
+      epoch.store(new_epoch, std::memory_order_release);
+
+      // Flush all the old epochs, we might have been ejected for a while, so
+      // there could be more than one.
+      size_t max_steps = 4;
       do
       {
-        refresh(a);
-        // TODO FENCE?
-      } while (epoch.load(std::memory_order_relaxed) != GlobalEpoch::get());
+        flush_old_epoch(a);
+        old_epoch = inc_epoch_by(old_epoch, 1);
+      } while ((old_epoch != new_epoch) && (--max_steps > 0));
     }
 
+    /**
+     * Ejects the current thread from the epoch system.
+     * Must hold the lock (internal or external).
+     */
     void eject()
     {
+      assert(lock.debug_held());
       epoch.store(get_epoch() | EJECTED_BIT, std::memory_order_release);
     }
 
+    /**
+     * Returns true if o is in the epoch e
+     * or if o has been ejected.
+     * otherwise returns false.
+     */
     static bool in_epoch(LocalEpoch* o, uint64_t e)
     {
       assert((e & EJECTED_BIT) == 0);
@@ -277,6 +357,12 @@ namespace verona::rt
       return (e == oe) || ((oe & EJECTED_BIT) == EJECTED_BIT);
     }
 
+    /**
+     * Returns true if o is in the epoch e
+     * or if o has been ejected.
+     *
+     * It will also attempt to eject o if it is not in the epoch e.
+     */
     static bool in_epoch_try_eject(LocalEpoch* o, uint64_t e)
     {
       if (in_epoch(o, e))
@@ -299,7 +385,13 @@ namespace verona::rt
       return false;
     }
 
-    void try_advance_global_epoch(bool try_eject)
+    /**
+     * Try to advance the global epoch.
+     * If try_eject is true, then we will attempt to eject threads that are not
+     * in the latest epoch.
+     * Returns true if the global epoch was advanced.
+     */
+    bool try_advance_global_epoch(bool try_eject)
     {
       // Client must have already locked the epoch
       assert(lock.debug_internal_held());
@@ -310,24 +402,28 @@ namespace verona::rt
       if (try_eject)
       {
         if (!forall<uint64_t, in_epoch_try_eject>(e))
-          return;
+          return false;
       }
       else
       {
         if (!forall<uint64_t, in_epoch>(e))
-          return;
+          return false;
       }
 
+      // Advance the global epoch
+      // Note multiple threads could be attempting this write at the same time.
+      // But they will all be attempting to write the same value.
       auto next_epoch = inc_epoch_by(e, 1);
       assert((GlobalEpoch::get() == e) || GlobalEpoch::get() == e + 1);
       GlobalEpoch::set(next_epoch);
+      return true;
     }
 
-    void use_epoch_rare(Alloc& a, uint64_t old_epoch, uint64_t new_epoch)
+    void use_epoch_rare(Alloc& a, uint64_t old_epoch)
     {
       if ((old_epoch & EJECTED_BIT) == 0)
       {
-        refresh_rare(a, old_epoch, new_epoch);
+        refresh(a);
       }
       else
       {
@@ -341,8 +437,8 @@ namespace verona::rt
 
       if (advance_is_sensible())
       {
-        try_advance_global_epoch(advance_is_urgent());
-        refresh(a);
+        if (try_advance_global_epoch(advance_is_urgent()))
+          refresh(a);
       }
     }
 
@@ -398,6 +494,9 @@ namespace verona::rt
     return true;
   }
 
+  /**
+   * Handles lifetime management of the LocalEpoch structure.
+   */
   class ThreadLocalEpoch
   {
   private:
@@ -416,6 +515,9 @@ namespace verona::rt
     }
   };
 
+  /**
+   * RAII wrapper for an epoch.
+   */
   class Epoch
   {
   private:
@@ -444,11 +546,6 @@ namespace verona::rt
       yield();
     }
 
-    void add_pressure()
-    {
-      local_epoch->add_pressure();
-    }
-
     uint64_t get_local_epoch_epoch()
     {
       return local_epoch->epoch;
@@ -464,25 +561,15 @@ namespace verona::rt
       local_epoch->add_to_dec_list(alloc, object);
     }
 
+    /**
+     * Empties all the delayed operations. This does not wait until the epoch
+     * has been advanced, and should only be called when this is safe due to
+     * other synchronization, such as during teardown.
+     */
     void flush_local()
     {
       for (int i = 0; i < 4; i++)
-        local_epoch->advance_epoch(alloc);
-    }
-
-    static void flush(Alloc& a)
-    {
-      // This should only be called when no threads are using the epoch, for
-      // example when cleaning up before process termination.
-      auto curr = LocalEpochPool::iterate();
-
-      while (curr != nullptr)
-      {
-        for (int i = 0; i < 4; i++)
-          curr->advance_epoch(a);
-
-        curr = LocalEpochPool::iterate(curr);
-      }
+        local_epoch->flush_old_epoch(alloc);
     }
   };
 } // namespace verona::rt

--- a/src/rt/sched/epoch.h
+++ b/src/rt/sched/epoch.h
@@ -585,9 +585,7 @@ namespace verona::rt
       while (curr != nullptr)
       {
         // There are four epoch that can be cleared.
-        // A second pass is required because delayed decrefs can cause delayed
-        // deallocations to be inserted. So we clear each epoch twice.
-        for (int i = 0; i < 8; i++)
+        for (int i = 0; i < 4; i++)
           curr->flush_old_epoch(a);
 
         curr->eject();

--- a/src/rt/sched/epoch.h
+++ b/src/rt/sched/epoch.h
@@ -258,7 +258,7 @@ namespace verona::rt
     bool advance_is_sensible()
     {
 #ifdef USE_SYSTEMATIC_TESTING
-      return Systematic::coin(4);
+      return Systematic::coin(2);
 #else
       return *get_pressure(2) > 128;
 #endif
@@ -268,7 +268,7 @@ namespace verona::rt
     bool advance_is_urgent()
     {
 #ifdef USE_SYSTEMATIC_TESTING
-      return Systematic::coin(7);
+      return Systematic::coin(2);
 #else
       return *get_pressure(2) > 1024;
 #endif

--- a/src/rt/sched/epoch.h
+++ b/src/rt/sched/epoch.h
@@ -583,8 +583,8 @@ namespace verona::rt
       auto curr = LocalEpochPool::iterate();
 
       while (curr != nullptr)
-    {
-      for (int i = 0; i < 4; i++)
+      {
+        for (int i = 0; i < 4; i++)
           curr->flush_old_epoch(a);
 
         curr = LocalEpochPool::iterate(curr);

--- a/src/rt/sched/noticeboard.h
+++ b/src/rt/sched/noticeboard.h
@@ -56,19 +56,24 @@ namespace verona::rt
 #else
       if constexpr (!std::is_fundamental_v<T>)
       {
-        Epoch e(alloc);
         auto local_content = get<T>();
         Logging::cout() << "Updating noticeboard " << this << " old value "
                         << local_content << " new value " << new_o
                         << Logging::endl;
-        e.dec_in_epoch(local_content);
+
         put(new_o);
+        yield();
+        Epoch e(alloc);
+        e.dec_in_epoch(local_content);
+        Logging::cout() << "Dec ref from noticeboard update" << local_content
+                        << Logging::endl;
       }
       else
       {
         UNUSED(alloc);
         put(new_o);
       }
+      yield();
 #endif
     }
 
@@ -86,6 +91,7 @@ namespace verona::rt
           // only protect incref with epoch
           Epoch e(alloc);
           local_content = get<T>();
+          yield();
           Logging::cout() << "Inc ref from noticeboard peek" << local_content
                           << Logging::endl;
           local_content->incref();

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -244,19 +244,6 @@ namespace verona::rt
         yield();
       }
 
-      Logging::cout() << "Begin teardown (phase 1)" << Logging::endl;
-
-      // Flush any cowns that weren't collected due to potential
-      // ABA issues on the queue.  The runtime is in a consistent
-      // state so no ABAs can exist anymore.
-      Epoch(ThreadAlloc::get()).flush_local();
-      // Second flush required for noticeboards.
-      Epoch(ThreadAlloc::get()).flush_local();
-
-      Scheduler::get().enter_barrier();
-
-      Logging::cout() << "End teardown (phase 1)" << Logging::endl;
-
       if (core != nullptr)
       {
         auto val = core->servicing_threads.fetch_sub(1);

--- a/src/rt/sched/threadpool.h
+++ b/src/rt/sched/threadpool.h
@@ -249,7 +249,12 @@ namespace verona::rt
       Object::reset_ids();
 #endif
       thread_count = 0;
-
+      // Flush any cowns that weren't collected due to potential
+      // ABA issues on the queue.  The runtime is in a consistent
+      // state so no ABAs can exist anymore.
+      Epoch::flush(ThreadAlloc::get());
+      // Second flush required for noticeboards.  The delayed decref could
+      // cause a delayed deallocation to be created.
       Epoch::flush(ThreadAlloc::get());
       core_pool.clear();
     }

--- a/src/rt/sched/threadpool.h
+++ b/src/rt/sched/threadpool.h
@@ -253,9 +253,7 @@ namespace verona::rt
       // ABA issues on the queue.  The runtime is in a consistent
       // state so no ABAs can exist anymore.
       Epoch::flush(ThreadAlloc::get());
-      // Second flush required for noticeboards.  The delayed decref could
-      // cause a delayed deallocation to be created.
-      Epoch::flush(ThreadAlloc::get());
+
       core_pool.clear();
     }
 

--- a/src/rt/sched/threadpool.h
+++ b/src/rt/sched/threadpool.h
@@ -250,7 +250,6 @@ namespace verona::rt
 #endif
       thread_count = 0;
 
-      Epoch::flush(ThreadAlloc::get());
       core_pool.clear();
     }
 

--- a/src/rt/sched/threadpool.h
+++ b/src/rt/sched/threadpool.h
@@ -250,6 +250,7 @@ namespace verona::rt
 #endif
       thread_count = 0;
 
+      Epoch::flush(ThreadAlloc::get());
       core_pool.clear();
     }
 

--- a/src/rt/test/func/noticeboard/noticeboard_basic.h
+++ b/src/rt/test/func/noticeboard/noticeboard_basic.h
@@ -10,7 +10,7 @@
  *    2. Incref the value read
  * An interleaving between 1 and 2 that deallocates the read value
  * would be problematic.
- * 
+ *
  * This test should fail if the Epoch protection is removed from
  *   Noticeboard::peek
  * This is true for the commit that adds this comment.
@@ -34,8 +34,7 @@ namespace noticeboard_basic
 
     void f()
     {
-      Logging::cout() << "Ping on " << target
-                      << std::endl;
+      Logging::cout() << "Ping on " << target << std::endl;
     }
   };
 
@@ -114,8 +113,7 @@ namespace noticeboard_basic
 
       C* new_c = new (RegionType::Trace) C(1);
 
-      Logging::cout() << "Update DB Create C " << new_c
-                      << std::endl;
+      Logging::cout() << "Update DB Create C " << new_c << std::endl;
 
       freeze(new_c);
       db->box.update(alloc, new_c);
@@ -143,11 +141,9 @@ namespace noticeboard_basic
     {
       auto& alloc = ThreadAlloc::get();
 
-      Logging::cout() << "Peek"
-                      << std::endl;
+      Logging::cout() << "Peek" << std::endl;
       auto o = (C*)peeker->box->peek(alloc);
-      Logging::cout() << "Peeked " << o
-                      << std::endl;
+      Logging::cout() << "Peeked " << o << std::endl;
       // o goes out of scope
       Immutable::release(alloc, o);
     }


### PR DESCRIPTION
While working through the tests after removing the leak detector I found a problem with the epoch mechanism for handling memory management of cowns.  

This PR 

* reworks the Epoch code to be clearer (and hopefully correct),
* adds much more documentation,
* provides testing for noticeboard usage of Epoch. 

Further test coverage of this code would be beneficial, but it is difficult to test due to the heuristics.