### PR TITLE
Pass through additional ADO env vars to AnyBuild

### DIFF
--- a/devops/steps/linux/anybuild.yml
+++ b/devops/steps/linux/anybuild.yml
@@ -37,10 +37,15 @@ steps:
     # why cache miss key must not contain commas
     cacheDataStoreKey="$(echo "${{ parameters.BuildName }}" | tr ',' '_' )"
 
+    # Pass through SYSTEM_, BUILD_ env vars for AnyBuild telemetry to join to ADO pipeline telemetry.
+
     env -i                                                           \
       SECRET=$(LLVMPrincipalPassword)                                \
       HOME="$HOME"                                                   \
       PATH="$PATH"                                                   \
+      SYSTEM_DEFINITIONNAME="$SYSTEM_DEFINITIONNAME"                 \
+      SYSTEM_DEFINITIONID="$SYSTEM_DEFINITIONID"                     \
+      BUILD_BUILDID="$BUILD_BUILDID"                                 \
     "$abClientExe"                                                   \
       --RemoteExecServiceUri $(AnyBuildEnvironmentUri)               \
       --NoCheckForUpdates                                            \


### PR DESCRIPTION
To improve joins of AnyBuild telemetry with ADO telemetry.