### PR TITLE
Some refactoring of reference count manipulation

### DIFF
--- a/src/rt/ds/dllist.h
+++ b/src/rt/ds/dllist.h
@@ -24,10 +24,12 @@ namespace verona::rt
     T* tail = Terminator();
 
   public:
+#ifndef NDEBUG
     ~DLList()
     {
-      clear();
+      assert(is_empty());
     }
+#endif
 
     constexpr DLList() = default;
 

--- a/src/rt/sched/corepool.h
+++ b/src/rt/sched/corepool.h
@@ -26,6 +26,8 @@ namespace verona::rt
     size_t core_count = 0;
 
   public:
+    constexpr CorePool() = default;
+
     void init(size_t count)
     {
       core_count = count;
@@ -69,9 +71,11 @@ namespace verona::rt
       core_count = 0;
     }
 
+#ifndef NDEBUG
     ~CorePool()
     {
-      clear();
+      assert(first_core == nullptr);
     }
+#endif
   };
 }

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -261,7 +261,6 @@ namespace verona::rt
       o->incref();
     }
 
-    
     static void release(Alloc& alloc, Cown* o)
     {
       Logging::cout() << "Cown " << o << " release" << Logging::endl;
@@ -903,7 +902,7 @@ namespace verona::rt
         }
         else
         {
-        Cown::release(alloc, senders[s].cown());
+          Cown::release(alloc, senders[s].cown());
         }
 
         senders[s] = Request();

--- a/src/rt/sched/cown.h
+++ b/src/rt/sched/cown.h
@@ -261,6 +261,7 @@ namespace verona::rt
       o->incref();
     }
 
+    
     static void release(Alloc& alloc, Cown* o)
     {
       Logging::cout() << "Cown " << o << " release" << Logging::endl;

--- a/src/rt/sched/schedulerlist.h
+++ b/src/rt/sched/schedulerlist.h
@@ -25,6 +25,8 @@ namespace verona::rt
 
   public:
     constexpr SchedulerList() = default;
+
+#ifndef NDEBUG
     ~SchedulerList()
     {
       snmalloc::FlagLock lock(m);
@@ -33,6 +35,7 @@ namespace verona::rt
         abort();
       }
     }
+#endif
 
     void add_active(T* thread)
     {

--- a/src/rt/sched/schedulerthread.h
+++ b/src/rt/sched/schedulerthread.h
@@ -62,10 +62,6 @@ namespace verona::rt
 
     bool running = true;
 
-    // `n_ld_tokens` indicates the times of token cown a scheduler has to
-    // process before reaching its LD checkpoint (`n_ld_tokens == 0`).
-    uint8_t n_ld_tokens = 0;
-
     bool should_steal_for_fairness = false;
 
     std::atomic<bool> scheduled_unscanned_cown = false;
@@ -218,7 +214,6 @@ namespace verona::rt
               {
                 Logging::cout() << "Queue empty" << Logging::endl;
                 // We have effectively reached token cown.
-                n_ld_tokens = 0;
 
                 T* stolen;
                 if (Scheduler::get().fair && fast_steal(stolen))
@@ -296,11 +291,6 @@ namespace verona::rt
       while (running)
       {
         yield();
-
-        if (core->q.nothing_old())
-        {
-          n_ld_tokens = 0;
-        }
 
         // Check if some other thread has pushed work on our queue.
         cown = core->q.dequeue(*alloc);

--- a/src/rt/sched/threadpool.h
+++ b/src/rt/sched/threadpool.h
@@ -37,8 +37,8 @@ namespace verona::rt
     static constexpr uint64_t TSC_PAUSE_SLOP = 1'000'000;
     static constexpr uint64_t TSC_UNPAUSE_SLOP = TSC_PAUSE_SLOP / 2;
 
-    bool detect_leaks = true;
-    size_t incarnation = 1;
+    bool detect_leaks{true};
+    size_t incarnation{1};
 
     /**
      * Used to represent the current pause_epoch.

--- a/src/rt/sched/threadstate.h
+++ b/src/rt/sched/threadstate.h
@@ -13,8 +13,10 @@ namespace verona::rt
     // ThreadState counters.
     struct StateCounters
     {
-      size_t active_threads = 0;
-      std::atomic<size_t> barrier_count = 0;
+      size_t active_threads{0};
+      std::atomic<size_t> barrier_count{0};
+
+      constexpr StateCounters() = default;
     };
 
   private:

--- a/src/rt/sched/threadsync.h
+++ b/src/rt/sched/threadsync.h
@@ -39,6 +39,8 @@ namespace verona::rt
     std::atomic<State> state{Unlocked};
 
   public:
+    constexpr SchedulerLock() = default;
+
     /**
      * Acquires the lock. Spins waiting for it to be available.
      */
@@ -100,7 +102,7 @@ namespace verona::rt
   class ThreadSync
   {
     SchedulerLock lock;
-    LocalSync* waiters = nullptr;
+    LocalSync* waiters{nullptr};
 
     void unlock()
     {
@@ -127,6 +129,8 @@ namespace verona::rt
     }
 
   public:
+    constexpr ThreadSync() = default;
+
     void unpause_all(T*)
     {
       Logging::cout() << "Unpause all" << Logging::endl;

--- a/src/rt/test/func/simp1/simp1.cc
+++ b/src/rt/test/func/simp1/simp1.cc
@@ -1,0 +1,34 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include <cpp/when.h>
+#include <test/harness.h>
+
+class Body
+{
+public:
+  ~Body()
+  {
+    Logging::cout() << "Body destroyed" << Logging::endl;
+  }
+};
+
+using namespace verona::cpp;
+
+void test_body()
+{
+  Logging::cout() << "test_body()" << Logging::endl;
+
+  auto log = make_cown<Body>();
+
+  when(log) << [=](auto) { Logging::cout() << "log" << Logging::endl; };
+}
+
+int main(int argc, char** argv)
+{
+  SystematicTestHarness harness(argc, argv);
+
+  harness.run(test_body);
+
+  return 0;
+}

--- a/src/rt/test/func/simp2/simp2.cc
+++ b/src/rt/test/func/simp2/simp2.cc
@@ -22,7 +22,8 @@ void test_body()
   auto log1 = make_cown<Body>();
   auto log2 = make_cown<Body>();
 
-  when(log1, log2) << [=](auto, auto) { Logging::cout() << "log" << Logging::endl; };
+  when(log1, log2) <<
+    [=](auto, auto) { Logging::cout() << "log" << Logging::endl; };
 }
 
 int main(int argc, char** argv)

--- a/src/rt/test/func/simp2/simp2.cc
+++ b/src/rt/test/func/simp2/simp2.cc
@@ -1,0 +1,35 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include <cpp/when.h>
+#include <test/harness.h>
+
+class Body
+{
+public:
+  ~Body()
+  {
+    Logging::cout() << "Body destroyed" << Logging::endl;
+  }
+};
+
+using namespace verona::cpp;
+
+void test_body()
+{
+  Logging::cout() << "test_body()" << Logging::endl;
+
+  auto log1 = make_cown<Body>();
+  auto log2 = make_cown<Body>();
+
+  when(log1, log2) << [=](auto, auto) { Logging::cout() << "log" << Logging::endl; };
+}
+
+int main(int argc, char** argv)
+{
+  SystematicTestHarness harness(argc, argv);
+
+  harness.run(test_body);
+
+  return 0;
+}

--- a/src/rt/test/func/simp3/simp3.cc
+++ b/src/rt/test/func/simp3/simp3.cc
@@ -1,0 +1,35 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include <cpp/when.h>
+#include <test/harness.h>
+
+class Body
+{
+public:
+  ~Body()
+  {
+    Logging::cout() << "Body destroyed" << Logging::endl;
+  }
+};
+
+using namespace verona::cpp;
+
+void test_body()
+{
+  Logging::cout() << "test_body()" << Logging::endl;
+
+  auto log1 = make_cown<Body>();
+
+  when(log1) << [](auto) { Logging::cout() << "log" << Logging::endl; };
+  when(log1) << [](auto) { Logging::cout() << "log" << Logging::endl; };
+}
+
+int main(int argc, char** argv)
+{
+  SystematicTestHarness harness(argc, argv);
+
+  harness.run(test_body);
+
+  return 0;
+}

--- a/src/rt/test/func/simp4/simp4.cc
+++ b/src/rt/test/func/simp4/simp4.cc
@@ -1,0 +1,36 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include <cpp/when.h>
+#include <test/harness.h>
+
+class Body
+{
+public:
+  ~Body()
+  {
+    Logging::cout() << "Body destroyed" << Logging::endl;
+  }
+};
+
+using namespace verona::cpp;
+
+void test_body()
+{
+  Logging::cout() << "test_body()" << Logging::endl;
+
+  auto log1 = make_cown<Body>();
+
+  when(log1) << [](auto l) { Logging::cout() << "log" << Logging::endl; 
+    when(l.cown()) << [](auto) { Logging::cout() << "log" << Logging::endl; };
+  };
+}
+
+int main(int argc, char** argv)
+{
+  SystematicTestHarness harness(argc, argv);
+
+  harness.run(test_body);
+
+  return 0;
+}

--- a/src/rt/test/func/simp4/simp4.cc
+++ b/src/rt/test/func/simp4/simp4.cc
@@ -21,7 +21,8 @@ void test_body()
 
   auto log1 = make_cown<Body>();
 
-  when(log1) << [](auto l) { Logging::cout() << "log" << Logging::endl; 
+  when(log1) << [](auto l) {
+    Logging::cout() << "log" << Logging::endl;
     when(l.cown()) << [](auto) { Logging::cout() << "log" << Logging::endl; };
   };
 }

--- a/src/rt/test/func/simp5/simp5.cc
+++ b/src/rt/test/func/simp5/simp5.cc
@@ -1,0 +1,38 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include <cpp/when.h>
+#include <test/harness.h>
+
+class Body
+{
+public:
+  ~Body()
+  {
+    Logging::cout() << "Body destroyed" << Logging::endl;
+  }
+};
+
+using namespace verona::cpp;
+
+void test_body()
+{
+  Logging::cout() << "test_body()" << Logging::endl;
+
+  auto log1 = make_cown<Body>();
+  auto log2 = make_cown<Body>();
+  auto log3 = make_cown<Body>();
+
+  when(log1, log2) << [=](auto, auto) { Logging::cout() << "log1" << Logging::endl; };
+  when(log2, log3) << [=](auto, auto) { Logging::cout() << "log2" << Logging::endl; };
+  when(log1, log3) << [=](auto, auto) { Logging::cout() << "log3" << Logging::endl; };
+}
+
+int main(int argc, char** argv)
+{
+  SystematicTestHarness harness(argc, argv);
+
+  harness.run(test_body);
+
+  return 0;
+}

--- a/src/rt/test/func/simp5/simp5.cc
+++ b/src/rt/test/func/simp5/simp5.cc
@@ -23,9 +23,12 @@ void test_body()
   auto log2 = make_cown<Body>();
   auto log3 = make_cown<Body>();
 
-  when(log1, log2) << [=](auto, auto) { Logging::cout() << "log1" << Logging::endl; };
-  when(log2, log3) << [=](auto, auto) { Logging::cout() << "log2" << Logging::endl; };
-  when(log1, log3) << [=](auto, auto) { Logging::cout() << "log3" << Logging::endl; };
+  when(log1, log2) <<
+    [=](auto, auto) { Logging::cout() << "log1" << Logging::endl; };
+  when(log2, log3) <<
+    [=](auto, auto) { Logging::cout() << "log2" << Logging::endl; };
+  when(log1, log3) <<
+    [=](auto, auto) { Logging::cout() << "log3" << Logging::endl; };
 }
 
 int main(int argc, char** argv)

--- a/src/rt/test/func/simp6/simp6.cc
+++ b/src/rt/test/func/simp6/simp6.cc
@@ -1,0 +1,40 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include <cpp/when.h>
+#include <test/harness.h>
+
+class Body
+{
+public:
+  ~Body()
+  {
+    Logging::cout() << "Body destroyed" << Logging::endl;
+  }
+};
+
+using namespace verona::cpp;
+
+void test_body()
+{
+  Logging::cout() << "test_body()" << Logging::endl;
+
+  auto log1 = make_cown<Body>();
+  auto log2 = make_cown<Body>();
+  auto log3 = make_cown<Body>();
+  auto log4 = make_cown<Body>();
+
+  when(log1, log2) << [=](auto, auto) { Logging::cout() << "log1" << Logging::endl; };
+  when(log3, log4) << [=](auto, auto) { Logging::cout() << "log2" << Logging::endl; };
+  when(log2, log3) << [=](auto, auto) { Logging::cout() << "log3" << Logging::endl; };
+  when(log4, log1) << [=](auto, auto) { Logging::cout() << "log3" << Logging::endl; };
+}
+
+int main(int argc, char** argv)
+{
+  SystematicTestHarness harness(argc, argv);
+
+  harness.run(test_body);
+
+  return 0;
+}

--- a/src/rt/test/func/simp6/simp6.cc
+++ b/src/rt/test/func/simp6/simp6.cc
@@ -24,10 +24,14 @@ void test_body()
   auto log3 = make_cown<Body>();
   auto log4 = make_cown<Body>();
 
-  when(log1, log2) << [=](auto, auto) { Logging::cout() << "log1" << Logging::endl; };
-  when(log3, log4) << [=](auto, auto) { Logging::cout() << "log2" << Logging::endl; };
-  when(log2, log3) << [=](auto, auto) { Logging::cout() << "log3" << Logging::endl; };
-  when(log4, log1) << [=](auto, auto) { Logging::cout() << "log3" << Logging::endl; };
+  when(log1, log2) <<
+    [=](auto, auto) { Logging::cout() << "log1" << Logging::endl; };
+  when(log3, log4) <<
+    [=](auto, auto) { Logging::cout() << "log2" << Logging::endl; };
+  when(log2, log3) <<
+    [=](auto, auto) { Logging::cout() << "log3" << Logging::endl; };
+  when(log4, log1) <<
+    [=](auto, auto) { Logging::cout() << "log3" << Logging::endl; };
 }
 
 int main(int argc, char** argv)

--- a/src/rt/test/harness.h
+++ b/src/rt/test/harness.h
@@ -173,6 +173,8 @@ public:
 
       Logging::cout() << "External threads joined" << std::endl;
 
+      LocalEpochPool::sort();
+
       if (detect_leaks)
         snmalloc::debug_check_empty<snmalloc::Alloc::Config>();
       high_resolution_clock::time_point t1 = high_resolution_clock::now();


### PR DESCRIPTION
Overall, reduces the amount of reference count required on a cown from one per message to one per scheduler queue. 