### PR TITLE
Mark implicit functions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,10 +36,6 @@ add_executable(verona
   passes/validtypeargs.cc
 )
 
-target_include_directories(verona
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-)
-
 target_link_libraries(verona
   Threads::Threads
   fmt::fmt

--- a/src/lang.cc
+++ b/src/lang.cc
@@ -233,6 +233,12 @@ namespace verona
                           << (Block << (Expr << (RefLet << (Ident ^ id))))));
   }
 
+  bool is_implicit(Node n)
+  {
+    auto f = n->parent(Function);
+    return f && ((f / Implicit)->type() == Implicit);
+  }
+
   Options& options()
   {
     static Options opts;

--- a/src/lang.h
+++ b/src/lang.h
@@ -134,7 +134,8 @@ namespace verona
   inline const auto Default = TokenDef("default");
 
   // Rewrite identifiers.
-  inline const auto Id = TokenDef("Id");
+  inline const auto Implicit = TokenDef("implicit");
+  inline const auto Explicit = TokenDef("explicit");
   inline const auto Lhs = TokenDef("Lhs");
   inline const auto Rhs = TokenDef("Rhs");
   inline const auto Op = TokenDef("Op");
@@ -149,6 +150,8 @@ namespace verona
   inline const auto create = Location("create");
 
   // Helper patterns.
+  inline const auto IsImplicit = T(Implicit) / T(Explicit);
+  inline const auto Hand = T(Lhs) / T(Rhs);
   inline const auto TypeStruct = In(Type) / In(TypeList) / In(TypeTuple) /
     In(TypeView) / In(TypeUnion) / In(TypeIsect) / In(TypeSubtype);
   inline const auto TypeCaps = T(Iso) / T(Mut) / T(Imm);

--- a/src/lang.h
+++ b/src/lang.h
@@ -192,6 +192,7 @@ namespace verona
   Node call(Node op, Node lhs = {}, Node rhs = {});
   Node load(Node arg);
   Node nlrexpand(Match& _, Node call, bool unwrap);
+  bool is_implicit(Node n);
 
   // Pass definitions.
   Parse parser();

--- a/src/passes/anf.cc
+++ b/src/passes/anf.cc
@@ -1,6 +1,6 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
-#include "lang.h"
+#include "../lang.h"
 
 namespace verona
 {
@@ -16,10 +16,10 @@ namespace verona
         [](Match& _) { return _(Lift); },
 
       // Lift `let x` bindings, leaving a RefLet behind.
-      T(Expr) << (T(Bind)[Bind] << (T(Ident)[Id] * T(Type) * T(Expr))) >>
+      T(Expr) << (T(Bind)[Bind] << (T(Ident)[Ident] * T(Type) * T(Expr))) >>
         [](Match& _) {
           return Seq << (Lift << Block << _(Bind))
-                     << (RefLet << (Ident ^ _(Id)));
+                     << (RefLet << clone(_(Ident)));
         },
 
       // Lift RefLet and Return.

--- a/src/passes/application.cc
+++ b/src/passes/application.cc
@@ -1,6 +1,6 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
-#include "lang.h"
+#include "../lang.h"
 
 namespace verona
 {

--- a/src/passes/assignlhs.cc
+++ b/src/passes/assignlhs.cc
@@ -1,6 +1,6 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
-#include "lang.h"
+#include "../lang.h"
 
 namespace verona
 {

--- a/src/passes/assignment.cc
+++ b/src/passes/assignment.cc
@@ -1,6 +1,6 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
-#include "lang.h"
+#include "../lang.h"
 
 namespace verona
 {
@@ -12,12 +12,12 @@ namespace verona
       // Let binding.
       In(Assign) *
           (T(Expr)
-           << ((T(Let) << T(Ident)[Id]) /
-               (T(TypeAssert) << (T(Let) << T(Ident)[Id]) * T(Type)[Type]))) *
+           << ((T(Let) << T(Ident)[Ident]) /
+               (T(TypeAssert)
+                << (T(Let) << T(Ident)[Ident]) * T(Type)[Type]))) *
           T(Expr)[Rhs] * End >>
         [](Match& _) {
-          return Expr
-            << (Bind << (Ident ^ _(Id)) << typevar(_, Type) << _(Rhs));
+          return Expr << (Bind << _(Ident) << typevar(_, Type) << _(Rhs));
         },
 
       // Destructuring assignment.

--- a/src/passes/autocreate.cc
+++ b/src/passes/autocreate.cc
@@ -1,6 +1,6 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
-#include "lang.h"
+#include "../lang.h"
 
 namespace verona
 {
@@ -35,7 +35,7 @@ namespace verona
           // TODO: return Self & K?
           auto body = ClassBody
             << *_[ClassBody]
-            << (Function << DontCare << (Ident ^ new_) << TypeParams
+            << (Function << Implicit << Rhs << (Ident ^ new_) << TypeParams
                          << new_params << typevar(_) << DontCare << typepred()
                          << (Block << (Expr << unit())));
 
@@ -43,7 +43,7 @@ namespace verona
           {
             // Create the `create` function.
             body
-              << (Function << DontCare << (Ident ^ create) << TypeParams
+              << (Function << Implicit << Rhs << (Ident ^ create) << TypeParams
                            << clone(new_params) << typevar(_) << DontCare
                            << typepred()
                            << (Block << (Expr << (Call << New << new_args))));
@@ -53,11 +53,11 @@ namespace verona
         }),
 
         // Strip the default field values.
-        T(FieldLet) << (T(Ident)[Id] * T(Type)[Type] * Any) >>
-          [](Match& _) { return FieldLet << _(Id) << _(Type); },
+        T(FieldLet) << (T(Ident)[Ident] * T(Type)[Type] * Any) >>
+          [](Match& _) { return FieldLet << _(Ident) << _(Type); },
 
-        T(FieldVar) << (T(Ident)[Id] * T(Type)[Type] * Any) >>
-          [](Match& _) { return FieldVar << _(Id) << _(Type); },
+        T(FieldVar) << (T(Ident)[Ident] * T(Type)[Type] * Any) >>
+          [](Match& _) { return FieldVar << _(Ident) << _(Type); },
       }};
   }
 }

--- a/src/passes/autofields.cc
+++ b/src/passes/autofields.cc
@@ -1,6 +1,6 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
-#include "lang.h"
+#include "../lang.h"
 
 namespace verona
 {
@@ -9,22 +9,22 @@ namespace verona
     return {
       dir::topdown | dir::once,
       {
-        (T(FieldVar) / T(FieldLet))[Op] << (T(Ident)[Id] * T(Type)[Type]) >>
+        (T(FieldVar) / T(FieldLet))[Op] << (T(Ident)[Ident] * T(Type)[Type]) >>
           ([](Match& _) -> Node {
             // If it's a FieldLet, generate only an RHS function. If it's a
             // FieldVar, generate an LHS function, which will autogenerate an
             // RHS function.
             auto field = _(Op);
-            auto id = _(Id);
+            auto id = _(Ident);
             auto self_id = _.fresh(l_self);
-            Token is_ref = (field->type() == FieldVar) ? Ref : DontCare;
+            Token hand = (field->type() == FieldVar) ? Lhs : Rhs;
             auto expr = FieldRef << (RefLet << (Ident ^ self_id)) << clone(id);
 
-            if (is_ref == DontCare)
+            if (hand == Rhs)
               expr = load(expr);
 
             // TODO: capability for Self, return type is self.T
-            auto f = Function << is_ref << clone(id) << TypeParams
+            auto f = Function << Implicit << hand << clone(id) << TypeParams
                               << (Params
                                   << (Param << (Ident ^ self_id)
                                             << (Type << Self) << DontCare))

--- a/src/passes/autorhs.cc
+++ b/src/passes/autorhs.cc
@@ -1,6 +1,6 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
-#include "lang.h"
+#include "../lang.h"
 
 namespace verona
 {
@@ -10,12 +10,12 @@ namespace verona
       dir::topdown | dir::once,
       {
         T(Function)[Function]
-            << (T(Ref) * Name[Id] * T(TypeParams)[TypeParams] *
+            << (IsImplicit * T(Lhs) * Name[Ident] * T(TypeParams)[TypeParams] *
                 T(Params)[Params] * T(Type)[Type] * T(DontCare) *
                 T(TypePred)[TypePred] * (T(Block) / T(DontCare))) >>
           ([](Match& _) -> Node {
             auto f = _(Function);
-            auto id = _(Id);
+            auto id = _(Ident);
             auto params = _(Params);
             auto parent = f->parent()->parent()->shared_from_this();
             Token ptype =
@@ -29,7 +29,7 @@ namespace verona
             {
               if (
                 (def != f) && (def->type() == Function) &&
-                ((def / Ref)->type() != Ref) &&
+                ((def / Ref)->type() != Rhs) &&
                 ((def / Ident)->location() == id->location()) &&
                 ((def / Params)->size() == params->size()))
               {
@@ -48,7 +48,7 @@ namespace verona
               args << (Expr << (RefLet << clone(param / Ident)));
 
             auto rhs_f =
-              Function << DontCare << clone(id) << clone(_(TypeParams))
+              Function << Implicit << Rhs << clone(id) << clone(_(TypeParams))
                        << clone(params) << clone(_(Type)) << DontCare
                        << clone(_(TypePred))
                        << (Block

--- a/src/passes/codereuse.cc
+++ b/src/passes/codereuse.cc
@@ -1,6 +1,6 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
-#include "lang.h"
+#include "../lang.h"
 
 namespace verona
 {

--- a/src/passes/conditionals.cc
+++ b/src/passes/conditionals.cc
@@ -1,6 +1,6 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
-#include "lang.h"
+#include "../lang.h"
 
 namespace verona
 {

--- a/src/passes/defbeforeuse.cc
+++ b/src/passes/defbeforeuse.cc
@@ -1,6 +1,6 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
-#include "lang.h"
+#include "../lang.h"
 
 namespace verona
 {
@@ -9,8 +9,8 @@ namespace verona
     return {
       dir::topdown | dir::once,
       {
-        T(RefLet) << T(Ident)[Id] >> ([](Match& _) -> Node {
-          auto id = _(Id);
+        T(RefLet) << T(Ident)[Ident] >> ([](Match& _) -> Node {
+          auto id = _(Ident);
           auto defs = id->lookup();
 
           if (
@@ -18,7 +18,7 @@ namespace verona
             ((defs.front()->type() == Param) || defs.front()->precedes(id)))
             return NoChange;
 
-          return err(_[Id], "use of uninitialized identifier");
+          return err(_[Ident], "use of uninitialized identifier");
         }),
       }};
   }

--- a/src/passes/defbeforeuse.cc
+++ b/src/passes/defbeforeuse.cc
@@ -1,6 +1,7 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
 #include "../lang.h"
+#include "../lookup.h"
 
 namespace verona
 {
@@ -10,15 +11,10 @@ namespace verona
       dir::topdown | dir::once,
       {
         T(RefLet) << T(Ident)[Ident] >> ([](Match& _) -> Node {
-          auto id = _(Ident);
-          auto defs = id->lookup();
+          if (!is_implicit(_(Ident)) && !lookup(_[Ident], {Bind, Param}))
+            return err(_[Ident], "use of uninitialized identifier");
 
-          if (
-            (defs.size() == 1) &&
-            ((defs.front()->type() == Param) || defs.front()->precedes(id)))
-            return NoChange;
-
-          return err(_[Ident], "use of uninitialized identifier");
+          return NoChange;
         }),
       }};
   }

--- a/src/passes/drop.cc
+++ b/src/passes/drop.cc
@@ -1,6 +1,6 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
-#include "lang.h"
+#include "../lang.h"
 
 namespace verona
 {
@@ -225,13 +225,14 @@ namespace verona
     PassDef drop = {
       dir::topdown | dir::once,
       {
-        (T(Param) / T(Bind)) << T(Ident)[Id] >> ([drop_map](Match& _) -> Node {
-          drop_map->back().gen(_(Id)->location());
-          return NoChange;
-        }),
+        (T(Param) / T(Bind)) << T(Ident)[Ident] >>
+          ([drop_map](Match& _) -> Node {
+            drop_map->back().gen(_(Ident)->location());
+            return NoChange;
+          }),
 
-        T(RefLet)[RefLet] << T(Ident)[Id] >> ([drop_map](Match& _) -> Node {
-          drop_map->back().ref(_(Id)->location(), _(RefLet));
+        T(RefLet)[RefLet] << T(Ident)[Ident] >> ([drop_map](Match& _) -> Node {
+          drop_map->back().ref(_(Ident)->location(), _(RefLet));
           return NoChange;
         }),
 

--- a/src/passes/lambda.cc
+++ b/src/passes/lambda.cc
@@ -1,6 +1,6 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
-#include "lang.h"
+#include "../lang.h"
 
 namespace verona
 {
@@ -11,12 +11,12 @@ namespace verona
     PassDef lambda = {
       dir::bottomup,
       {
-        T(RefLet) << T(Ident)[Id] >> ([freevars](Match& _) -> Node {
+        T(RefLet) << T(Ident)[Ident] >> ([freevars](Match& _) -> Node {
           if (!freevars->empty())
           {
             // If we don't have a definition within the scope of the lambda,
             // then it's a free variable.
-            auto id = _(Id);
+            auto id = _(Ident);
 
             if (id->lookup(id->parent(Lambda)).empty())
               freevars->back().insert(id->location());
@@ -39,8 +39,8 @@ namespace verona
             Node create_params = Params;
             Node new_args = Args;
             auto create_func = Function
-              << DontCare << (Ident ^ create) << TypeParams << create_params
-              << typevar(_) << DontCare << typepred()
+              << Implicit << Rhs << (Ident ^ create) << TypeParams
+              << create_params << typevar(_) << DontCare << typepred()
               << (Block << (Expr << (Call << New << new_args)));
 
             // The create call will instantiate the anonymous type.
@@ -92,7 +92,7 @@ namespace verona
             // parameter with a fresh name to the lambda parameters.
             // TODO: capability for Self
             auto apply_func = Function
-              << DontCare << apply_id() << _(TypeParams)
+              << Implicit << Rhs << apply_id() << _(TypeParams)
               << (Params << (Param << (Ident ^ self_id) << (Type << Self)
                                    << DontCare)
                          << *_[Params])

--- a/src/passes/localvar.cc
+++ b/src/passes/localvar.cc
@@ -1,15 +1,15 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
-#include "lang.h"
+#include "../lang.h"
 
 namespace verona
 {
   PassDef localvar()
   {
     return {
-      T(Var) << T(Ident)[Id] >>
+      T(Var) << T(Ident)[Ident] >>
         [](Match& _) {
-          return Assign << (Expr << (Let << _(Id))) << (Expr << cell());
+          return Assign << (Expr << (Let << _(Ident))) << (Expr << cell());
         },
 
       T(RefVar)[RefVar] >> [](Match& _) { return load(RefLet << *_[RefVar]); },

--- a/src/passes/modules.cc
+++ b/src/passes/modules.cc
@@ -1,6 +1,6 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
-#include "lang.h"
+#include "../lang.h"
 
 namespace verona
 {

--- a/src/passes/namearity.cc
+++ b/src/passes/namearity.cc
@@ -1,6 +1,6 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
-#include "lang.h"
+#include "../lang.h"
 
 namespace verona
 {
@@ -10,32 +10,32 @@ namespace verona
       dir::bottomup | dir::once,
       {
         T(Function)
-            << ((T(Ref) / T(DontCare))[Ref] * Name[Id] *
+            << (IsImplicit[Implicit] * Hand[Ref] * Name[Ident] *
                 T(TypeParams)[TypeParams] * T(Params)[Params] * T(Type)[Type] *
                 (T(LLVMFuncType) / T(DontCare))[LLVMFuncType] *
                 T(TypePred)[TypePred] * (T(Block) / T(DontCare))[Block]) >>
           [](Match& _) {
-            auto id = _(Id);
+            auto id = _(Ident);
             auto arity = _(Params)->size();
             auto name =
               std::string(id->location().view()) + "." + std::to_string(arity);
 
-            if (_(Ref)->type() == Ref)
-              name += ".ref";
+            if (_(Ref)->type() == Lhs)
+              name += ".lhs";
 
-            return Function << (Ident ^ name) << _(TypeParams) << _(Params)
-                            << _(Type) << _(LLVMFuncType) << _(TypePred)
-                            << _(Block);
+            return Function << _(Implicit) << (Ident ^ name) << _(TypeParams)
+                            << _(Params) << _(Type) << _(LLVMFuncType)
+                            << _(TypePred) << _(Block);
           },
 
         (T(Call) / T(CallLHS))[Call]
             << ((T(FunctionName)
-                 << ((TypeName / T(DontCare))[Lhs] * Name[Id] *
+                 << ((TypeName / T(DontCare))[Lhs] * Name[Ident] *
                      T(TypeArgs)[TypeArgs])) *
                 T(Args)[Args]) >>
           [](Match& _) {
             auto arity = _(Args)->size();
-            auto name = std::string(_(Id)->location().view()) + "." +
+            auto name = std::string(_(Ident)->location().view()) + "." +
               std::to_string(arity);
 
             if (_(Call)->type() == CallLHS)
@@ -47,15 +47,15 @@ namespace verona
           },
 
         (T(Call) / T(CallLHS))[Call]
-            << ((T(Selector) << (Name[Id] * T(TypeArgs)[TypeArgs])) *
+            << ((T(Selector) << (Name[Ident] * T(TypeArgs)[TypeArgs])) *
                 T(Args)[Args]) >>
           [](Match& _) {
             auto arity = _(Args)->size();
-            auto name = std::string(_(Id)->location().view()) + "." +
+            auto name = std::string(_(Ident)->location().view()) + "." +
               std::to_string(arity);
 
             if (_(Call)->type() == CallLHS)
-              name += ".ref";
+              name += ".lhs";
 
             return Call << (Selector << (Ident ^ name) << _(TypeArgs))
                         << _(Args);

--- a/src/passes/namearity.cc
+++ b/src/passes/namearity.cc
@@ -70,8 +70,12 @@ namespace verona
                         << _(Args);
           },
 
-        T(CallLHS)[Call] << T(New) >>
-          [](Match& _) { return err(_[Call], "can't assign to new"); },
+        T(CallLHS)[Call] << T(New) >> ([](Match& _) -> Node {
+          if (!is_implicit(_(Call)))
+            return err(_[Call], "can't assign to new");
+
+          return NoChange;
+        }),
       }};
   }
 }

--- a/src/passes/nlrcheck.cc
+++ b/src/passes/nlrcheck.cc
@@ -1,6 +1,6 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
-#include "lang.h"
+#include "../lang.h"
 
 namespace verona
 {

--- a/src/passes/reverseapp.cc
+++ b/src/passes/reverseapp.cc
@@ -1,6 +1,6 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
-#include "lang.h"
+#include "../lang.h"
 
 namespace verona
 {

--- a/src/passes/traitisect.cc
+++ b/src/passes/traitisect.cc
@@ -1,6 +1,6 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
-#include "lang.h"
+#include "../lang.h"
 
 namespace verona
 {
@@ -12,7 +12,7 @@ namespace verona
     return {
       dir::once | dir::topdown,
       {
-        T(TypeTrait)[TypeTrait] << (T(Ident)[Id] * T(ClassBody)[ClassBody]) >>
+        T(TypeTrait)[TypeTrait] << (T(Ident)[Ident] * T(ClassBody)[ClassBody]) >>
           [](Match& _) {
             // If we're inside a TypeIsect, put the new traits inside it.
             // Otherwise, create a new TypeIsect.
@@ -20,7 +20,7 @@ namespace verona
               (_(TypeTrait)->parent()->type() == TypeIsect) ? Seq : TypeIsect;
 
             Node base = ClassBody;
-            r << (TypeTrait << _(Id) << base);
+            r << (TypeTrait << _(Ident) << base);
 
             for (auto& member : *_(ClassBody))
             {

--- a/src/passes/typealg.cc
+++ b/src/passes/typealg.cc
@@ -1,6 +1,6 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
-#include "lang.h"
+#include "../lang.h"
 
 namespace verona
 {

--- a/src/passes/typeflat.cc
+++ b/src/passes/typeflat.cc
@@ -1,6 +1,6 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
-#include "lang.h"
+#include "../lang.h"
 
 namespace verona
 {

--- a/src/passes/typefunc.cc
+++ b/src/passes/typefunc.cc
@@ -1,6 +1,6 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
-#include "lang.h"
+#include "../lang.h"
 
 namespace verona
 {
@@ -44,7 +44,7 @@ namespace verona
                           << (TypeTrait
                               << (Ident ^ _.fresh(l_trait))
                               << (ClassBody
-                                  << (Function << DontCare << apply_id()
+                                  << (Function << Explicit << Rhs << apply_id()
                                                << TypeParams << params
                                                << (Type << clone(_(Rhs)))
                                                << DontCare << typepred()

--- a/src/passes/typenames.cc
+++ b/src/passes/typenames.cc
@@ -1,8 +1,7 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
-#include "lang.h"
-
-#include "lookup.h"
+#include "../lang.h"
+#include "../lookup.h"
 
 namespace verona
 {
@@ -13,16 +12,16 @@ namespace verona
         [](Match& _) { return TypeVar ^ _.fresh(l_typevar); },
 
       // Names on their own must be types.
-      TypeStruct * T(Ident)[Id] * ~T(TypeArgs)[TypeArgs] >>
+      TypeStruct * T(Ident)[Ident] * ~T(TypeArgs)[TypeArgs] >>
         [](Match& _) {
-          return makename(DontCare, _(Id), (_(TypeArgs) || TypeArgs));
+          return makename(DontCare, _(Ident), (_(TypeArgs) || TypeArgs));
         },
 
       // Scoping binds most tightly.
-      TypeStruct * TypeName[Lhs] * T(DoubleColon) * T(Ident)[Id] *
+      TypeStruct * TypeName[Lhs] * T(DoubleColon) * T(Ident)[Ident] *
           ~T(TypeArgs)[TypeArgs] >>
         [](Match& _) {
-          return makename(_(Lhs), _(Id), (_(TypeArgs) || TypeArgs));
+          return makename(_(Lhs), _(Ident), (_(TypeArgs) || TypeArgs));
         },
     };
   }

--- a/src/passes/typevalid.cc
+++ b/src/passes/typevalid.cc
@@ -1,8 +1,8 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
-#include "btype.h"
-#include "lang.h"
-#include "lookup.h"
+#include "../btype.h"
+#include "../lang.h"
+#include "../lookup.h"
 
 namespace verona
 {

--- a/src/passes/typeview.cc
+++ b/src/passes/typeview.cc
@@ -1,6 +1,6 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
-#include "lang.h"
+#include "../lang.h"
 
 namespace verona
 {

--- a/src/passes/validtypeargs.cc
+++ b/src/passes/validtypeargs.cc
@@ -12,7 +12,9 @@ namespace verona
       {
         (TypeName[Op] << ((TypeName / T(DontCare)) * T(Ident) * T(TypeArgs))) >>
           ([](Match& _) -> Node {
-            if (!valid_typeargs(_(Op)))
+            auto tn = _(Op);
+
+            if (!is_implicit(tn) && !valid_typeargs(tn))
               return err(_[Op], "invalid type arguments");
 
             return NoChange;

--- a/src/passes/validtypeargs.cc
+++ b/src/passes/validtypeargs.cc
@@ -1,7 +1,7 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
-#include "lang.h"
-#include "subtype.h"
+#include "../lang.h"
+#include "../subtype.h"
 
 namespace verona
 {

--- a/src/readme.md
+++ b/src/readme.md
@@ -1,11 +1,8 @@
 # TODO
 
-Error messages:
-- Too many repetitions from implicit methods.
-  - `defaultargs`, `partialapp`, `autocreate`, `autofields`, etc.
+`assignlhs` isn't catching LHS calls inside `NLRCheck`.
 
 Code reuse:
-- Code reuse must be intersections of classes and traits only, recursively through type aliases.
 - Logical order: (1) defaultargs, (2) inheritance, (3) partialapp.
   - Can actually do inheritance first, treating defaultargs as blocking multiple arities.
 - Do textual inclusion of any member or method that isn't already defined.

--- a/src/subtype.cc
+++ b/src/subtype.cc
@@ -321,7 +321,7 @@ namespace verona
       if (r->type() == Package)
       {
         return (l->type() == Package) &&
-          ((l->node / Id)->location() == (r->node / Id)->location());
+          ((l->node / Ident)->location() == (r->node / Ident)->location());
       }
 
       // Check predicate subtyping.

--- a/src/wf.h
+++ b/src/wf.h
@@ -8,7 +8,8 @@ namespace verona
 {
   using namespace wf::ops;
 
-  inline const auto wfRef = Ref >>= Ref | DontCare;
+  inline const auto wfRef = Ref >>= Lhs | Rhs;
+  inline const auto wfImplicit = Implicit >>= Implicit | Explicit;
   inline const auto wfName = Ident >>= Ident | Symbol;
   inline const auto wfDefault = Default >>= Lambda | DontCare;
 
@@ -70,7 +71,7 @@ namespace verona
     | (FieldLet <<= Ident * Type * wfDefault)[Ident]
     | (FieldVar <<= Ident * Type * wfDefault)[Ident]
     | (Function <<=
-        wfRef * wfName * TypeParams * Params * Type *
+        wfImplicit * wfRef * wfName * TypeParams * Params * Type *
         (LLVMFuncType >>= LLVMFuncType | DontCare) * TypePred *
         (Block >>= Block | DontCare))[Ident]
     | (TypeParams <<= TypeParam++)
@@ -88,7 +89,7 @@ namespace verona
     | (Let <<= Ident)[Ident]
     | (Var <<= Ident)[Ident]
     | (TypeAssert <<= Expr * Type)
-    | (Package <<= (Id >>= String | Escaped))
+    | (Package <<= (Ident >>= String | Escaped))
     | (LLVMFuncType <<= (Args >>= LLVMList) * (Return >>= LLVM | Ident))
     | (LLVMList <<= (LLVM | Ident)++)
     | (TypePred <<= Type)
@@ -398,9 +399,9 @@ namespace verona
     | (TupleFlatten <<= Copy | Move)
     | (Args <<= (Copy | Move)++)
     | (Conditional <<= (If >>= Copy | Move) * Block * Block)
-    | (TypeTest <<= (Id >>= Copy | Move) * Type)
-    | (Cast <<= (Id >>= Copy | Move) * Type)
-    | (FieldRef <<= (Id >>= Copy | Move) * Ident)
+    | (TypeTest <<= (Ref >>= (Copy | Move)) * Type)
+    | (Cast <<= (Ref >>= (Copy | Move)) * Type)
+    | (FieldRef <<= (Ref >>= (Copy | Move)) * Ident)
     | (Bind <<= Ident * Type *
         (Rhs >>=
           Tuple | Call | Conditional | TypeTest | Cast | CallLHS | FieldRef |
@@ -418,7 +419,7 @@ namespace verona
 
     // Remove LHS/RHS function distinction.
     | (Function <<=
-        Ident * TypeParams * Params * Type *
+        wfImplicit * Ident * TypeParams * Params * Type *
         (LLVMFuncType >>= LLVMFuncType | DontCare) * TypePred *
         (Block >>= Block | DontCare))[Ident]
 


### PR DESCRIPTION
Functions are marked as explicit (defined in the source code) or implicit (compiler generated). Errors from inside implicit functions aren't reported, as there will be explicit code that raises the error.