### PR TITLE
Update to latest trieste version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(TRIESTE_BUILD_SAMPLES OFF)
 FetchContent_Declare(
   trieste
   GIT_REPOSITORY https://github.com/microsoft/trieste
-  GIT_TAG main
+  GIT_TAG e8bf084a1f9275580db77624df031e500c910f10
   GIT_SHALLOW TRUE
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(TRIESTE_BUILD_SAMPLES OFF)
 FetchContent_Declare(
   trieste
   GIT_REPOSITORY https://github.com/microsoft/trieste
-  GIT_TAG e8bf084a1f9275580db77624df031e500c910f10
+  GIT_TAG 0b2ec3c5ea7bf52b0f6b2ed9e4f9d571aba47a8b
   GIT_SHALLOW TRUE
 )
 

--- a/src/lang.cc
+++ b/src/lang.cc
@@ -271,14 +271,14 @@ namespace verona
   std::vector<Pass> passes()
   {
     return {
-        modules(),       structure(),     reference(),     conditionals(),
-        lambda(),        autocreate(),    defaultargs(),   typenames(),
-        typeview(),      typefunc(),      typealg(),       typeflat(),
-        typevalid(),     typereference(), codereuse(),     memberconflict(),
-        resetimplicit(), reverseapp(),    application(),   assignlhs(),
-        localvar(),      assignment(),    autofields(),    autorhs(),
-        partialapp(),    traitisect(),    nlrcheck(),      anf(),
-        defbeforeuse(),  drop(),          validtypeargs(), // typeinfer(),
-      };
+      modules(),       structure(),     reference(),     conditionals(),
+      lambda(),        autocreate(),    defaultargs(),   typenames(),
+      typeview(),      typefunc(),      typealg(),       typeflat(),
+      typevalid(),     typereference(), codereuse(),     memberconflict(),
+      resetimplicit(), reverseapp(),    application(),   assignlhs(),
+      localvar(),      assignment(),    autofields(),    autorhs(),
+      partialapp(),    traitisect(),    nlrcheck(),      anf(),
+      defbeforeuse(),  drop(),          validtypeargs(), // typeinfer(),
+    };
   }
 }

--- a/src/lang.cc
+++ b/src/lang.cc
@@ -268,13 +268,9 @@ namespace verona
     return opts;
   }
 
-  Driver& driver()
+  std::vector<Pass> passes()
   {
-    static Driver d(
-      "Verona",
-      &options(),
-      parser(),
-      {
+    return {
         modules(),       structure(),     reference(),     conditionals(),
         lambda(),        autocreate(),    defaultargs(),   typenames(),
         typeview(),      typefunc(),      typealg(),       typeflat(),
@@ -283,8 +279,6 @@ namespace verona
         localvar(),      assignment(),    autofields(),    autorhs(),
         partialapp(),    traitisect(),    nlrcheck(),      anf(),
         defbeforeuse(),  drop(),          validtypeargs(), // typeinfer(),
-      });
-
-    return d;
+      };
   }
 }

--- a/src/lang.h
+++ b/src/lang.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include <trieste/driver.h>
+#include <trieste/trieste.h>
 
 namespace verona
 {
@@ -271,12 +271,9 @@ namespace verona
   {
     bool no_std = false;
 
-    void configure(CLI::App& cli) override
-    {
-      cli.add_flag("--no-std", no_std, "Don't import the standard library.");
-    }
+    void configure(CLI::App& cli) override;
   };
 
   Options& options();
-  Driver& driver();
+  std::vector<Pass> passes();
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -14,10 +14,7 @@ namespace verona
 int main(int argc, char** argv)
 {
   trieste::Driver d(
-      "Verona",
-      &verona::options(),
-      verona::parser(),
-      verona::passes());
+    "Verona", &verona::options(), verona::parser(), verona::passes());
 
   return d.run(argc, argv);
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,8 +1,23 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
 #include "lang.h"
+#include "trieste/driver.h"
+
+namespace verona
+{
+  void Options::configure(CLI::App& cli)
+  {
+    cli.add_flag("--no-std", no_std, "Don't import the standard library.");
+  }
+}
 
 int main(int argc, char** argv)
 {
-  return verona::driver().run(argc, argv);
+  trieste::Driver d(
+      "Verona",
+      &verona::options(),
+      verona::parser(),
+      verona::passes());
+
+  return d.run(argc, argv);
 }


### PR DESCRIPTION
This reduces the compile time by around 20% as the latest Trieste does not include CPP::CLI in the main header.